### PR TITLE
feat(monsters): added missing bosses

### DIFF
--- a/data/monsters/bosses/boreth.lua
+++ b/data/monsters/bosses/boreth.lua
@@ -1,0 +1,118 @@
+local mType = Game.createMonsterType("Boreth")
+local monster = {}
+
+monster.description = "Boreth"
+monster.experience = 1800
+monster.outfit = {
+	lookType = 287,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 2,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 479,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 1400
+monster.maxHealth = 1400
+monster.race = "undead"
+monster.corpse = 8109
+monster.speed = 140
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 20,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 80,
+	targetDistance = 1,
+	runHealth = 600,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I'll water my plants with your blood!", yell = false },
+}
+
+monster.loot = {
+    { name = "Gold Coin", chance = 100000, maxCount = 100 },
+    { name = "Blood Preservation", chance = 86379, maxCount = 1 },
+    { name = "Strong Health Potion", chance = 21050, maxCount = 1 },
+    { id = 3098, chance = 10990, maxCount = 1 },
+    { name = "Platinum Coin", chance = 9750, maxCount = 5 },
+    { name = "Black Pearl", chance = 2009, maxCount = 1 },
+    { name = "Vampire Shield", chance = 1080, maxCount = 1 },
+    { name = "Dreaded Cleaver", chance = 620, maxCount = 1 },
+    { name = "Hibiscus Dress", chance = 150, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -535 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -400, range = 5, shootEffect = CONST_ANI_SNIPERARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -200, range = 1, target = true },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = 320, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
+}
+
+monster.defenses = {
+	defense = 54,
+	armor = 59,
+	mitigation = 3.7,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 300, maxDamage = 400, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 2000, chance = 50, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/bosses/chopper.lua
+++ b/data/monsters/bosses/chopper.lua
@@ -1,0 +1,128 @@
+local mType = Game.createMonsterType("Chopper")
+local monster = {}
+
+monster.description = "Chopper"
+monster.experience = 5400
+monster.outfit = {
+	lookType = 462,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {}
+
+monster.bosstiary = {
+	bossRaceId = 852,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 7200
+monster.maxHealth = 7200
+monster.race = "venom"
+monster.corpse = 13983
+monster.speed = 155
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Bzzzzzzzrrrrzzzzzzrrrrr!", yell = false },
+	{ text = "Peeex!", yell = false },
+}
+
+monster.loot = {
+    { name = "Gold Coin", chance = 100000, maxCount = 207 },
+    { name = "Waspoid Claw", chance = 100000, maxCount = 1 },
+    { name = "Platinum Coin", chance = 96300, maxCount = 4 },
+    { name = "Compound Eye", chance = 79010, maxCount = 1 },
+    { name = "Waspoid Wing", chance = 77780, maxCount = 1 },
+    { name = "Small Topaz", chance = 58020, maxCount = 2 },
+    { id = 14225, chance = 56789, maxCount = 2 },
+    { name = "Great Health Potion", chance = 46909, maxCount = 2 },
+    { name = "Great Mana Potion", chance = 32100, maxCount = 2 },
+    { name = "Black Pearl", chance = 28399, maxCount = 1 },
+    { name = "Yellow Gem", chance = 13580, maxCount = 1 },
+    { name = "Emerald Bangle", chance = 7410, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -252, condition = { type = CONDITION_POISON, totalDamage = 400, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -110, maxDamage = -180, radius = 3, effect = CONST_ME_POISONAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -40, maxDamage = -80, range = 7, shootEffect = CONST_ANI_POISON, target = false },
+}
+
+monster.defenses = {
+	defense = 25,
+	armor = 36,
+	mitigation = 1.54,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -2 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 25 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -7 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 5 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType.onThink = function(monster, interval) end
+
+mType.onAppear = function(monster, creature) end
+
+mType.onDisappear = function(monster, creature) end
+
+mType.onMove = function(monster, creature, fromPosition, toPosition) end
+
+mType.onSay = function(monster, creature, type, message) end
+
+mType:register(monster)

--- a/data/monsters/bosses/kusuma.lua
+++ b/data/monsters/bosses/kusuma.lua
@@ -1,0 +1,131 @@
+local mType = Game.createMonsterType("Kusuma")
+local monster = {}
+
+monster.description = "Kusuma"
+monster.experience = 9380
+monster.outfit = {
+	lookType = 1068,
+	lookHead = 0,
+	lookBody = 42,
+	lookLegs = 71,
+	lookFeet = 3,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 7650
+monster.maxHealth = 7650
+monster.race = "blood"
+monster.corpse = 28664
+monster.speed = 180
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2287,
+	bossRace = RARITY_ARCHFOE,
+}
+monster.strategiesTarget = {
+	nearest = 80,
+	health = 10,
+	damage = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 800,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {}
+
+monster.loot = {
+	{ name = "gold coin", chance = 100000, maxCount = 197 },
+	{ name = "platinum coin", chance = 100000, maxCount = 5 },
+	{ name = "amulet of loss", chance = 120 },
+	{ name = "gold ring", chance = 1870 },
+	{ name = "hailstorm rod", chance = 10000 },
+	{ name = "garlic necklace", chance = 2050 },
+	{ name = "blank rune", chance = 26250, maxCount = 2 },
+	{ name = "golden sickle", chance = 350 },
+	{ name = "skull staff", chance = 1520 },
+	{ name = "scythe", chance = 3000 },
+	{ name = "bunch of wheat", chance = 50000 },
+	{ name = "soul orb", chance = 23720 },
+	{ id = 6299, chance = 1410 },
+	{ id = 43916, chance = 4000 },
+	{ id = 43729, chance = 22000, maxCount = 3 },
+	{ id = 43738, chance = 9000 },
+	{ id = 43849, chance = 10000 },
+	{ id = 43857, chance = 7000 },
+	{ name = "demonic essence", chance = 28000 },
+	{ name = "assassin star", chance = 5900, maxCount = 10 },
+	{ name = "great mana potion", chance = 31360, maxCount = 3 },
+	{ id = 281, chance = 4450 },
+	{ id = 282, chance = 4450 },
+	{ name = "seeds", chance = 4300 },
+	{ name = "terra mantle", chance = 1050 },
+	{ name = "terra legs", chance = 2500 },
+	{ name = "ultimate health potion", chance = 14720, maxCount = 2 },
+	{ name = "gold ingot", chance = 5270 },
+	{ name = "bundle of cursed straw", chance = 15000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 75, attack = 100 },
+	{ name = "combat", interval = 1000, chance = 8, type = COMBAT_DEATHDAMAGE, minDamage = -300, maxDamage = -500, radius = 9, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "speed", interval = 1000, chance = 12, speedChange = -250, radius = 6, effect = CONST_ME_POISONAREA, target = false, duration = 60000 },
+	{ name = "strength", interval = 1000, chance = 10, minDamage = -300, maxDamage = -750, radius = 5, effect = CONST_ME_HITAREA, target = false },
+	{ name = "combat", interval = 3000, chance = 13, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -500, range = 7, radius = 7, shootEffect = CONST_ANI_FIRE, effect = 244, target = true },
+	{ name = "combat", interval = 3000, chance = 8, type = COMBAT_HOLYDAMAGE, minDamage = -300, maxDamage = -450, radius = 10, effect = 246, target = false },
+}
+
+monster.defenses = {
+	defense = 110,
+	armor = 110,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 90 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -10 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 90 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 90 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/bosses/lersatio.lua
+++ b/data/monsters/bosses/lersatio.lua
@@ -1,0 +1,135 @@
+local mType = Game.createMonsterType("Lersatio")
+local monster = {}
+
+monster.description = "Lersatio"
+monster.experience = 2500
+monster.outfit = {
+	lookType = 287,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {}
+
+monster.bosstiary = {
+	bossRaceId = 482,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 1645
+monster.maxHealth = 1645
+monster.race = "undead"
+monster.corpse = 8109
+monster.speed = 210
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 1,
+	summons = {
+		{ name = "vampire", chance = 10, interval = 2000, count = 3 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "The monsters in the mirrors will come eat your dreams.", yell = false },
+	{ text = "Your pitiful life has come to an end.", yell = false },
+	{ text = "One day I will see my pretty face in a mirror again.", yell = false },
+}
+
+monster.loot = {
+    { name = "Gold Coin", chance = 100000, maxCount = 100 },
+    { name = "Blood Preservation", chance = 89580, maxCount = 1 },
+    { name = "Strong Health Potion", chance = 23660, maxCount = 1 },
+    { id = 3098, chance = 11000, maxCount = 1 },
+    { name = "Platinum Coin", chance = 9740, maxCount = 5 },
+    { name = "Black Pearl", chance = 1850, maxCount = 1 },
+    { name = "Vampire Shield", chance = 580, maxCount = 1 },
+    { name = "Dreaded Cleaver", chance = 490, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -535 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -400, range = 5, shootEffect = CONST_ANI_SNIPERARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -200, range = 1, target = true },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = 320, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
+}
+
+monster.defenses = {
+	defense = 54,
+	armor = 59,
+	mitigation = 3.7,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 300, maxDamage = 400, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 2000, chance = 50, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 20 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType.onThink = function(monster, interval) end
+
+mType.onAppear = function(monster, creature) end
+
+mType.onDisappear = function(monster, creature) end
+
+mType.onMove = function(monster, creature, fromPosition, toPosition) end
+
+mType.onSay = function(monster, creature, type, message) end
+
+mType:register(monster)

--- a/data/monsters/bosses/marziel.lua
+++ b/data/monsters/bosses/marziel.lua
@@ -1,0 +1,135 @@
+local mType = Game.createMonsterType("Marziel")
+local monster = {}
+
+monster.description = "Marziel"
+monster.experience = 3000
+monster.outfit = {
+	lookType = 287,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {}
+
+monster.bosstiary = {
+	bossRaceId = 481,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 1900
+monster.maxHealth = 1900
+monster.race = "undead"
+monster.corpse = 8109
+monster.speed = 210
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 1,
+	summons = {
+		{ name = "vampire", chance = 10, interval = 2000, count = 3 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "My brides will show you how to suffer beautifully.", yell = false },
+	{ text = "I smell warm blood.", yell = false },
+	{ text = "Why are you disturbing me and my brides?", yell = false },
+	{ text = "You shouldn't have come.", yell = false },
+	{ text = "You! You had no right to read my diary!", yell = false },
+	{ text = "I... want... your... blood!", yell = false },
+}
+
+monster.loot = {
+    { name = "Gold Coin", chance = 100000, maxCount = 88 },
+    { name = "Platinum Coin", chance = 22219, maxCount = 5 },
+    { name = "Strong Health Potion", chance = 22219, maxCount = 1 },
+    { id = 3098, chance = 5560, maxCount = 1 },
+    { name = "Vampire Shield", chance = 5560, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -535 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -400, range = 5, shootEffect = CONST_ANI_SNIPERARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -200, range = 1, target = true },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = 320, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
+}
+
+monster.defenses = {
+	defense = 54,
+	armor = 59,
+	mitigation = 3.7,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 300, maxDamage = 400, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 2000, chance = 50, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 20 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType.onThink = function(monster, interval) end
+
+mType.onAppear = function(monster, creature) end
+
+mType.onDisappear = function(monster, creature) end
+
+mType.onMove = function(monster, creature, fromPosition, toPosition) end
+
+mType.onSay = function(monster, creature, type, message) end
+
+mType:register(monster)

--- a/data/monsters/bosses/maw.lua
+++ b/data/monsters/bosses/maw.lua
@@ -1,0 +1,117 @@
+local mType = Game.createMonsterType("Maw")
+local monster = {}
+
+monster.description = "Maw"
+monster.experience = 6500
+monster.outfit = {
+	lookType = 458,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 857,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 8200
+monster.maxHealth = 8200
+monster.race = "venom"
+monster.corpse = 13937
+monster.speed = 115
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 95,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Kropp!", yell = false },
+}
+
+monster.loot = {
+    { name = "Compound Eye", chance = 100000, maxCount = 1 },
+    { name = "Gold Coin", chance = 100000, maxCount = 196 },
+    { name = "Kollos Shell", chance = 100000, maxCount = 1 },
+    { name = "Platinum Coin", chance = 83820, maxCount = 6 },
+    { name = "Great Mana Potion", chance = 66180, maxCount = 2 },
+    { id = 14225, chance = 55880, maxCount = 2 },
+    { name = "Ultimate Health Potion", chance = 33820, maxCount = 1 },
+    { name = "Small Ruby", chance = 32350, maxCount = 4 },
+    { name = "Black Pearl", chance = 29410, maxCount = 4 },
+    { id = 3039, chance = 22060, maxCount = 1 },
+    { name = "Gooey Mass", chance = 20590, maxCount = 2 },
+    { id = 282, chance = 8820, maxCount = 1 },
+    { name = "Gold Ingot", chance = 7350, maxCount = 1 },
+    { name = "Calopteryx Cape", chance = 4410, maxCount = 1 },
+    { name = "Hive Bow", chance = 1470, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -353 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -350, range = 7, radius = 3, shootEffect = CONST_ANI_EXPLOSION, effect = CONST_ME_EXPLOSIONHIT, target = true },
+}
+
+monster.defenses = {
+	defense = 35,
+	armor = 52,
+	mitigation = 1.71,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 30 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -7 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -5 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/bosses/mindmasher.lua
+++ b/data/monsters/bosses/mindmasher.lua
@@ -1,0 +1,117 @@
+local mType = Game.createMonsterType("Mindmasher")
+local monster = {}
+
+monster.description = "Mindmasher"
+monster.experience = 6000
+monster.outfit = {
+	lookType = 403,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 855,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 9500
+monster.maxHealth = 9500
+monster.race = "venom"
+monster.corpse = 12525
+monster.speed = 120
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+    { name = "Compound Eye", chance = 100000, maxCount = 2 },
+    { id = 14225, chance = 100000, maxCount = 3 },
+    { name = "Gold Coin", chance = 100000, maxCount = 233 },
+    { name = "Platinum Coin", chance = 77360, maxCount = 4 },
+    { name = "Great Mana Potion", chance = 50940, maxCount = 2 },
+    { name = "Great Health Potion", chance = 49060, maxCount = 2 },
+    { name = "Small Sapphire", chance = 43400, maxCount = 2 },
+    { name = "Small Emerald", chance = 37740, maxCount = 2 },
+    { name = "Ripper Lance", chance = 32079, maxCount = 1 },
+    { id = 3097, chance = 20750, maxCount = 1 },
+    { name = "Yellow Gem", chance = 16980, maxCount = 1 },
+    { name = "Twin Hooks", chance = 11320, maxCount = 1 },
+    { name = "Spike Sword", chance = 5660, maxCount = 1 },
+    { name = "Epee", chance = 3769, maxCount = 1 },
+    { name = "Carapace Shield", chance = 1890, maxCount = 1 },
+    { id = 282, chance = 1890, maxCount = 1 },
+    { name = "Grasshopper Legs", chance = 1890, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -110, condition = { type = CONDITION_POISON, totalDamage = 160, interval = 4000 } },
+}
+
+monster.defenses = {
+	defense = 15,
+	armor = 30,
+	mitigation = 0.91,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/bosses/owin.lua
+++ b/data/monsters/bosses/owin.lua
@@ -1,0 +1,147 @@
+local mType = Game.createMonsterType("Owin")
+local monster = {}
+
+monster.description = "Owin"
+monster.experience = 5000
+monster.outfit = {
+	lookType = 721,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {}
+
+monster.health = 9600
+monster.maxHealth = 9600
+monster.race = "blood"
+monster.corpse = 27718
+monster.speed = 125
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 1156,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 2,
+	summons = {
+		{ name = "Wereboar", chance = 20, interval = 2000, count = 2 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "You will DIE!", yell = false },
+}
+
+monster.loot = {
+    { name = "Gold Coin", chance = 100000, maxCount = 117 },
+    { name = "Moonlight Crystals", chance = 100000, maxCount = 1 },
+    { name = "Platinum Coin", chance = 100000, maxCount = 7 },
+    { name = "Wereboar Hooves", chance = 100000, maxCount = 1 },
+    { name = "Wereboar Tusks", chance = 100000, maxCount = 1 },
+    { name = "Brown Mushroom", chance = 76440, maxCount = 2 },
+    { name = "Strong Health Potion", chance = 76440, maxCount = 5 },
+    { name = "Furry Club", chance = 40230, maxCount = 1 },
+    { name = "Ultimate Health Potion", chance = 22990, maxCount = 2 },
+    { name = "Wereboar Loincloth", chance = 21260, maxCount = 1 },
+    { name = "Stone Skin Amulet", chance = 17240, maxCount = 1 },
+    { name = "Berserk Potion", chance = 5170, maxCount = 1 },
+    { name = "Fur Armor", chance = 4600, maxCount = 1 },
+    { id = 22102, chance = 2300, maxCount = 1 },
+    { name = "Werewolf Amulet", chance = 1720, maxCount = 1 },
+    { name = "Ultimate Health Potion", chance = 569, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -290 },
+	{ name = "combat", interval = 1000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -100, maxDamage = -420, range = 7, target = false },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = -600, range = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 20000 },
+	{ name = "combat", interval = 1000, chance = 14, type = COMBAT_DEATHDAMAGE, minDamage = -100, maxDamage = -200, length = 5, spread = 0, effect = CONST_ME_MORTAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 45,
+	armor = 40,
+	--	mitigation = ???,
+	{ name = "combat", interval = 4000, chance = 15, type = COMBAT_HEALING, minDamage = 150, maxDamage = 345, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 40 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 50 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType.onThink = function(monster, interval) end
+
+mType.onAppear = function(monster, creature)
+	if monster:getType():isRewardBoss() then
+		monster:setReward(true)
+	end
+end
+
+mType.onDisappear = function(monster, creature) end
+
+mType.onMove = function(monster, creature, fromPosition, toPosition) end
+
+mType.onSay = function(monster, creature, type, message) end
+
+mType:register(monster)

--- a/data/monsters/bosses/rotspit.lua
+++ b/data/monsters/bosses/rotspit.lua
@@ -1,0 +1,118 @@
+local mType = Game.createMonsterType("Rotspit")
+local monster = {}
+
+monster.description = "Rotspit"
+monster.experience = 4100
+monster.outfit = {
+	lookType = 461,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 854,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 6800
+monster.maxHealth = 6800
+monster.race = "venom"
+monster.corpse = 13979
+monster.speed = 135
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 95,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Kropp!", yell = false },
+}
+
+monster.loot = {
+    { name = "Gold Coin", chance = 100000, maxCount = 192 },
+    { name = "Spitter Nose", chance = 100000, maxCount = 1 },
+    { name = "Platinum Coin", chance = 83930, maxCount = 5 },
+    { name = "Compound Eye", chance = 80360, maxCount = 1 },
+    { id = 14225, chance = 55360, maxCount = 2 },
+    { name = "Great Mana Potion", chance = 53569, maxCount = 2 },
+    { name = "Small Amethyst", chance = 48210, maxCount = 2 },
+    { name = "Small Emerald", chance = 46430, maxCount = 2 },
+    { name = "Brown Mushroom", chance = 42860, maxCount = 3 },
+    { name = "Great Health Potion", chance = 41070, maxCount = 2 },
+    { name = "Crystal Sword", chance = 16070, maxCount = 1 },
+    { id = 3053, chance = 3569, maxCount = 1 },
+    { name = "Crusader Helmet", chance = 1790, maxCount = 1 },
+    { id = 282, chance = 1790, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -151, condition = { type = CONDITION_POISON, totalDamage = 240, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -100, maxDamage = -160, range = 7, radius = 3, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = -400, range = 7, shootEffect = CONST_ANI_POISON, target = true, duration = 15000 },
+}
+
+monster.defenses = {
+	defense = 20,
+	armor = 48,
+	mitigation = 1.60,
+	{ name = "speed", interval = 2000, chance = 15, speedChange = 400, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -11 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 5 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/bosses/shadowstalker.lua
+++ b/data/monsters/bosses/shadowstalker.lua
@@ -1,0 +1,115 @@
+local mType = Game.createMonsterType("Shadowstalker")
+local monster = {}
+
+monster.description = "Shadowstalker"
+monster.experience = 4000
+monster.outfit = {
+	lookType = 456,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 853,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 6100
+monster.maxHealth = 6100
+monster.race = "venom"
+monster.corpse = 13865
+monster.speed = 125
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	damage = 30,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 95,
+	targetDistance = 1,
+	runHealth = 40,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+    { name = "Crawler Head Plating", chance = 100000, maxCount = 1 },
+    { name = "Gold Coin", chance = 100000, maxCount = 214 },
+    { name = "Platinum Coin", chance = 88000, maxCount = 5 },
+    { name = "Compound Eye", chance = 76000, maxCount = 1 },
+    { name = "Great Health Potion", chance = 52000, maxCount = 2 },
+    { name = "Great Mana Potion", chance = 48000, maxCount = 2 },
+    { name = "Small Topaz", chance = 46670, maxCount = 2 },
+    { id = 14225, chance = 41330, maxCount = 2 },
+    { name = "Small Emerald", chance = 40000, maxCount = 2 },
+    { name = "Yellow Gem", chance = 13330, maxCount = 1 },
+    { name = "Springsprout Rod", chance = 2670, maxCount = 1 },
+    { name = "War Hammer", chance = 2670, maxCount = 1 }
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -228, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -100, maxDamage = -180, range = 7, shootEffect = CONST_ANI_EARTHARROW, effect = CONST_ME_SMALLPLANTS, target = true },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 38,
+	mitigation = 1.26,
+	{ name = "speed", interval = 2000, chance = 15, speedChange = 300, effect = CONST_ME_MAGIC_RED, target = false, duration = 3000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -8 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -7 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 5 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)


### PR DESCRIPTION


<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper TFS Downgrades code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** 

Only a few missing bosses were added to the server; using the same looktypes as Canary.

 - Boreth
 - Chopper
 - Kusuma
 - Lersatio
 - Marziel
 - Maw Mindmasher
 - Owin
 - Rotspit
 - Shadowstalker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Novos Recursos

- Adicionados 10 novos bosses ao jogo: Boreth, Chopper, Kusuma, Lersatio, Marziel, Maw, Mindmasher, Owin, Rotspit e Shadowstalker. Cada boss possui configurações únicas de combate, ataques especiais, defesas distintas, resistências elementais e tabelas de recompensas variadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->