### PR TITLE
hash

### DIFF
--- a/data/scripts/eventcallbacks/player/default_onLook.lua
+++ b/data/scripts/eventcallbacks/player/default_onLook.lua
@@ -53,6 +53,10 @@ event.onLook = function(self, thing, position, distance, description)
 				description = string.format("%s, Unique ID: %d", description, uniqueId)
 			end
 
+			if thing:hasItemUID() then
+				description = string.format("%s\nHASH: %s", description, thing:getItemUID())
+			end
+
 			local transformEquipId = itemType:getTransformEquipId()
 			local transformDeEquipId = itemType:getTransformDeEquipId()
 			if transformEquipId ~= 0 then

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5,6 +5,9 @@
 
 #include "item.h"
 
+#include <atomic>
+#include <chrono>
+
 #include "actions.h"
 #include "bed.h"
 #include "container.h"
@@ -31,6 +34,10 @@ Items Item::items;
 // Freed explicitly in clearGlobalRegistry(); null-checked after that.
 static std::unique_ptr<std::unordered_set<Item*>> g_validItems = std::make_unique<std::unordered_set<Item*>>();
 
+namespace {
+	std::atomic<uint64_t> g_uidCounter{1};
+} // namespace
+
 std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/)
 {
 	const ItemType& it = Item::items[type];
@@ -45,6 +52,14 @@ std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0
 	if (it.id == 0) {
 		return nullptr;
 	}
+
+	// Helper: assign UID to non-stackable items
+	const auto assignUID = [](const std::shared_ptr<Item>& item) {
+		if (item && !item->isStackable()) [[likely]] {
+			item->setItemUID(Item::generateItemUID());
+		}
+		return item;
+	};
 
 	if (it.isDepot()) {
 		return std::make_shared<DepotLocker>(type);
@@ -69,17 +84,17 @@ std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0
 	} else if (it.isBed()) {
 		return std::make_shared<BedItem>(type);
 	} else if (it.id >= 3094 && it.id <= 3096) { // magic rings
-		return std::make_shared<Item>(type - 3, count);
+		return assignUID(std::make_shared<Item>(type - 3, count));
 	} else if (it.id == 3099 || it.id == 3100) { // magic rings
-		return std::make_shared<Item>(type - 2, count);
+		return assignUID(std::make_shared<Item>(type - 2, count));
 	} else if (it.id >= 3086 && it.id <= 3090) { // magic rings
-		return std::make_shared<Item>(type - 37, count);
+		return assignUID(std::make_shared<Item>(type - 37, count));
 	} else if (it.id == 3549) { // soft boots
-		return std::make_shared<Item>(6529, count);
+		return assignUID(std::make_shared<Item>(6529, count));
 	} else if (it.id == 6299) { // death ring
-		return std::make_shared<Item>(6300, count);
+		return assignUID(std::make_shared<Item>(6300, count));
 	}
-	return std::make_shared<Item>(type, count);
+	return assignUID(std::make_shared<Item>(type, count));
 }
 
 std::shared_ptr<Container> Item::CreateItemAsContainer(const uint16_t type, uint16_t size)
@@ -186,6 +201,39 @@ bool isValidItemPointer(Item* item)
 void Item::clearGlobalRegistry()
 {
 	g_validItems.reset();
+}
+
+uint64_t Item::generateItemUID() noexcept
+{
+	const uint64_t ts = static_cast<uint64_t>(
+		std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()
+		).count()
+	);
+	const uint64_t cnt = g_uidCounter.fetch_add(1, std::memory_order_relaxed);
+	return (ts << 20) | (cnt & 0xFFFFF);
+}
+
+uint64_t Item::getItemUID() const noexcept
+{
+	if (!attributes) [[unlikely]] {
+		return 0;
+	}
+	const auto* attr = const_cast<Item*>(this)->getCustomAttribute("__uid");
+	if (!attr) [[unlikely]] {
+		return 0;
+	}
+	return static_cast<uint64_t>(boost::get<int64_t>(attr->value));
+}
+
+void Item::setItemUID(uint64_t uid) noexcept
+{
+	setCustomAttribute("__uid", static_cast<int64_t>(uid));
+}
+
+bool Item::hasItemUID() const noexcept
+{
+	return getItemUID() != 0;
 }
 
 std::shared_ptr<Item> Item::clone() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -223,7 +223,10 @@ uint64_t Item::getItemUID() const noexcept
 	if (!attr) [[unlikely]] {
 		return 0;
 	}
-	return static_cast<uint64_t>(boost::get<int64_t>(attr->value));
+	if (const auto* val = boost::get<int64_t>(&attr->value)) {
+		return static_cast<uint64_t>(*val);
+	}
+	return 0;
 }
 
 void Item::setItemUID(uint64_t uid) noexcept

--- a/src/item.h
+++ b/src/item.h
@@ -896,6 +896,12 @@ public:
 		}
 	}
 
+	// UID tracking system for non-stackable items (anti-dupe)
+	[[nodiscard]] uint64_t getItemUID() const noexcept;
+	void setItemUID(uint64_t uid) noexcept;
+	[[nodiscard]] bool hasItemUID() const noexcept;
+	[[nodiscard]] static uint64_t generateItemUID() noexcept;
+
 	std::string_view getName() const
 	{
 		if (hasAttribute(ITEM_ATTRIBUTE_NAME)) {

--- a/src/luaitem.cpp
+++ b/src/luaitem.cpp
@@ -938,6 +938,31 @@ int luaItemSetInstanceId(lua_State *L)
 	}
 	return 1;
 }
+
+int luaItemGetItemUID(lua_State* L)
+{
+	// item:getItemUID()
+	const Item* item = getItemUserdata<const Item>(L, 1);
+	if (!item) [[unlikely]] {
+		lua_pushnil(L);
+		return 1;
+	}
+	// Return as string to avoid Lua number precision loss on uint64
+	pushString(L, std::to_string(item->getItemUID()));
+	return 1;
+}
+
+int luaItemHasItemUID(lua_State* L)
+{
+	// item:hasItemUID()
+	const Item* item = getItemUserdata<const Item>(L, 1);
+	if (!item) [[unlikely]] {
+		pushBoolean(L, false);
+		return 1;
+	}
+	pushBoolean(L, item->hasItemUID());
+	return 1;
+}
 } // namespace
 
 // Forge Tier Lua bindings
@@ -1127,6 +1152,10 @@ void LuaScriptInterface::registerItem()
 
 	registerMethod("Item", "getInstanceId", luaItemGetInstanceId);
 	registerMethod("Item", "setInstanceId", luaItemSetInstanceId);
+
+	// UID tracking (anti-dupe)
+	registerMethod("Item", "getItemUID", luaItemGetItemUID);
+	registerMethod("Item", "hasItemUID", luaItemHasItemUID);
 
 	registerMethod("Item", "getImbuementSlots", LuaScriptInterface::luaItemGetImbuementSlots);
 	registerMethod("Item", "getFreeImbuementSlots", LuaScriptInterface::luaItemGetFreeImbuementSlots);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novas Funcionalidades**
  * Itens não-acumuláveis agora possuem um identificador único (hash) que é automaticamente atribuído e exibido nas descrições quando você visualiza detalhes do item. Esta mudança oferece melhor rastreamento e identificação individual de cada item no jogo, permitindo verificar propriedades específicas de itens com maior clareza durante exploração e interação com o ambiente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->