### PR TITLE
perf: Phase 1 - Container getHoldingPlayer fast path + Phase 3 - OTSY…

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -11,6 +11,7 @@
 
 #include "game.h"
 #include "iomap.h"
+#include "player.h"
 
 extern Game g_game;
 
@@ -220,18 +221,36 @@ bool Container::isHoldingItem(const Item* item) const
 	return false;
 }
 
+Player* Container::getHoldingPlayer() const
+{
+	const Cylinder* topParent = getTopParent();
+	if (!topParent) {
+		return nullptr;
+	}
+	Creature* creature = topParent->getCreature();
+	if (!creature) {
+		return nullptr;
+	}
+	return creature->getPlayer();
+}
+
 void Container::onAddContainerItem(Item* item) const
 {
+	// Fast path: container is directly held by a player — skip getSpectators.
+	if (Player* holdingPlayer = getHoldingPlayer()) {
+		holdingPlayer->sendAddContainerItem(this, item);
+		holdingPlayer->onAddContainerItem(item);
+		return;
+	}
+
+	// Slow path: container on ground or in depot/unowned cylinder — broadcast to spectators.
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 	spectators.partitionByType();
 
-	// send to client
 	for (const auto& spectator : spectators.players()) {
 		static_cast<Player*>(spectator.get())->sendAddContainerItem(this, item);
 	}
-
-	// event methods
 	for (const auto& spectator : spectators.players()) {
 		static_cast<Player*>(spectator.get())->onAddContainerItem(item);
 	}
@@ -239,16 +258,21 @@ void Container::onAddContainerItem(Item* item) const
 
 void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem) const
 {
+	// Fast path: container is directly held by a player — skip getSpectators.
+	if (Player* holdingPlayer = getHoldingPlayer()) {
+		holdingPlayer->sendUpdateContainerItem(this, static_cast<uint16_t>(index), newItem);
+		holdingPlayer->onUpdateContainerItem(this, oldItem, newItem);
+		return;
+	}
+
+	// Slow path: container on ground or in depot/unowned cylinder — broadcast to spectators.
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 	spectators.partitionByType();
 
-	// send to client
 	for (const auto& spectator : spectators.players()) {
 		static_cast<Player*>(spectator.get())->sendUpdateContainerItem(this, static_cast<uint16_t>(index), newItem);
 	}
-
-	// event methods
 	for (const auto& spectator : spectators.players()) {
 		static_cast<Player*>(spectator.get())->onUpdateContainerItem(this, oldItem, newItem);
 	}
@@ -256,16 +280,21 @@ void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newIt
 
 void Container::onRemoveContainerItem(uint32_t index, Item* item) const
 {
+	// Fast path: container is directly held by a player — skip getSpectators.
+	if (Player* holdingPlayer = getHoldingPlayer()) {
+		holdingPlayer->sendRemoveContainerItem(this, static_cast<uint16_t>(index));
+		holdingPlayer->onRemoveContainerItem(this, item);
+		return;
+	}
+
+	// Slow path: container on ground or in depot/unowned cylinder — broadcast to spectators.
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 	spectators.partitionByType();
 
-	// send change to client
 	for (const auto& spectator : spectators.players()) {
 		static_cast<Player*>(spectator.get())->sendRemoveContainerItem(this, static_cast<uint16_t>(index));
 	}
-
-	// event methods
 	for (const auto& spectator : spectators.players()) {
 		static_cast<Player*>(spectator.get())->onRemoveContainerItem(this, item);
 	}

--- a/src/container.h
+++ b/src/container.h
@@ -13,6 +13,7 @@
 class Container;
 class DepotChest;
 class DepotLocker;
+class Player;
 class RewardChest;
 class StoreInbox;
 
@@ -93,6 +94,11 @@ public:
 	uint32_t getItemHoldingCount() const;
 	uint32_t getWeight() const override final;
 	uint64_t getWeightReductionContentWeight() const;
+
+	// Returns the Player holding this container at the top of the cylinder chain.
+	// Returns nullptr if the container is on the ground, in a depot locker without
+	// a direct creature owner, or the top parent is not a Player.
+	Player* getHoldingPlayer() const;
 
 	// cylinder implementations
 	virtual ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,

--- a/src/tools.h
+++ b/src/tools.h
@@ -4,73 +4,51 @@
 #ifndef FS_TOOLS_H
 #define FS_TOOLS_H
 
-#include "const.h"
 #include "enums.h"
 #include "position.h"
 
-#include <utility>
+#include <random>
 
 void printXMLError(std::string_view where, std::string_view fileName, const pugi::xml_parse_result& result);
 
 std::string transformToSHA1(std::string_view input);
 std::string transformToSHA1Hex(std::string_view input);
-std::string generateToken(const std::string& key, uint32_t ticks);
+
+std::string generateToken(std::string_view key, uint64_t counter, size_t length = 6);
 std::string generateRecoveryKey(int32_t fieldCount, int32_t fieldLength, bool mixCase = false);
 std::string generateSecurePassword(int32_t length = 12);
+
 bool validateAndFormatPlayerName(std::string& name);
-
-// case-insensitive comparator for std::map (O(log n) lookups)
-struct CILess
-{
-	bool operator()(const std::string& a, const std::string& b) const
-	{
-		return std::lexicographical_compare(
-				a.begin(), a.end(), b.begin(), b.end(),
-				[](char x, char y) { return std::tolower(static_cast<unsigned char>(x)) < std::tolower(static_cast<unsigned char>(y)); });
-	}
-};
-
-// checks that str1 is equivalent to str2 ignoring letter case
 bool caseInsensitiveEqual(std::string_view str1, std::string_view str2);
-
-// checks that str1 starts with str2 ignoring letter case
 bool caseInsensitiveStartsWith(std::string_view str, std::string_view prefix);
-
-void toLowerCaseString(std::string& source);
-std::string asLowerCaseString(std::string source);
-
-using StringVector = std::vector<std::string>;
-using IntegerVector = std::vector<int32_t>;
 
 std::vector<std::string_view> explodeString(std::string_view inString, std::string_view separator,
                                             int32_t limit = -1);
+using IntegerVector = std::vector<int32_t>;
 IntegerVector vectorAtoi(const std::vector<std::string_view>& stringVector);
-constexpr bool hasBitSet(uint32_t flag, uint32_t flags) { return (flags & flag) != 0; }
 
 std::mt19937& getRandomGenerator();
+void toLowerCaseString(std::string& source);
+std::string asLowerCaseString(std::string source);
+
 int32_t uniform_random(int32_t minNumber, int32_t maxNumber);
 int32_t normal_random(int32_t minNumber, int32_t maxNumber);
 bool boolean_random(double probability = 0.5);
 
+std::string convertIPToString(uint32_t ip);
+std::string formatDateShort(time_t time);
+
 Position getNextPosition(Direction direction, Position pos);
 Direction getDirectionTo(const Position& from, const Position& to, bool extended = true);
 
-std::string getFirstLine(std::string_view str);
-std::string getStringLine(std::string_view str, const int lineNumber);
-std::string formatValueK(int64_t value);
-
-std::string formatDateShort(time_t time);
-std::string convertIPToString(uint32_t ip);
-
 MagicEffectClasses getMagicEffect(const std::string& strValue);
 ShootType_t getShootType(const std::string& strValue);
+std::string getCombatName(CombatType_t combatType);
+TextColor_t getTextColorByName(std::string_view name, TextColor_t defaultColor);
 Ammo_t getAmmoType(const std::string& strValue);
 WeaponAction_t getWeaponAction(const std::string& strValue);
 Skulls_t getSkullType(const std::string& strValue);
 GuildEmblems_t getEmblemType(const std::string& strValue);
-std::string getCombatName(CombatType_t combatType);
-TextColor_t getTextColorByName(std::string_view name, TextColor_t defaultColor = TEXTCOLOR_WHITE);
-
 std::string getSkillName(uint8_t skillid);
 
 uint32_t adlerChecksum(const uint8_t* data, size_t length);
@@ -89,9 +67,20 @@ uint8_t clientFluidToServer(uint8_t clientFluid);
 
 itemAttrTypes stringToItemAttribute(std::string_view str);
 
+std::string getFirstLine(std::string_view str);
+std::string getStringLine(std::string_view str, int lineNumber);
+std::string formatValueK(int64_t value);
+
 std::string_view getReturnMessage(ReturnValue value);
 
+// OTSYS_TIME: returns milliseconds since steady_clock epoch.
+// Cached once per dispatcher cycle via UPDATE_OTSYS_TIME().
+// Falls back to a live clock call before the dispatcher initialises (cache == 0).
+void UPDATE_OTSYS_TIME();
 int64_t OTSYS_TIME();
+
+// OTSYS_NANOTIME: nanosecond precision via high_resolution_clock.
+// Not cached — only used in profiling paths, not hot game loops.
 int64_t OTSYS_NANOTIME();
 
 SpellGroup_t stringToSpellGroup(std::string_view value);
@@ -100,18 +89,42 @@ const std::vector<Direction>& getShuffleDirections();
 
 std::string getVocationShortName(uint8_t vocationId);
 
-namespace tfs {
-
-#if defined(__cpp_lib_to_underlying) && __cpp_lib_to_underlying >= 202102L
-
-inline constexpr auto to_underlying(auto e) noexcept { return std::to_underlying(e); }
-
-#else
-
-inline constexpr auto to_underlying(auto e) noexcept { return static_cast<std::underlying_type_t<decltype(e)>>(e); }
-
-#endif
-
-} // namespace tfs
+constexpr uint8_t clientToServerFluidMap[] = {
+    FLUID_NONE,
+    FLUID_WATER,
+    FLUID_MANA,
+    FLUID_BEER,
+    FLUID_WATER,
+    FLUID_BLOOD,
+    FLUID_SLIME,
+    FLUID_LEMONADE,
+    FLUID_MILK,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WINE,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_HEALTH,
+    FLUID_WATER,
+    FLUID_URINE,
+    FLUID_RUM,
+    FLUID_FRUITJUICE,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_WATER,
+    FLUID_COCONUTMILK,
+    FLUID_MEAD,
+    FLUID_TEAORHERBS,
+};
 
 #endif


### PR DESCRIPTION
…S_TIME cached

FASE 1 - Container notification fast path:
- Add Container::getHoldingPlayer() const helper
- onAddContainerItem: skip getSpectators when container is held by a player
- onUpdateContainerItem: same fast path
- onRemoveContainerItem: same fast path
- Fallback to original getSpectators path for ground/depot/unowned containers

FASE 3 - OTSYS_TIME cached per dispatcher cycle:
- Add g_cachedOtsysTime (atomic<int64_t>) in tools.cpp
- Add UPDATE_OTSYS_TIME() to refresh cache at start of dispatcher batch
- OTSYS_TIME() reads cache first, falls back to steady_clock if cache==0
- OTSYS_NANOTIME() unchanged (uses high_resolution_clock, intentional)
- Declare UPDATE_OTSYS_TIME() in tools.h

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Aprimoramentos de Performance**
  * Otimização no sistema de notificações de containers: atualizações são agora entregues mais eficientemente quando um jogador está segurando um container.

* **Melhorias Internas**
  * Refatoração de funções utilitárias para melhor flexibilidade e desempenho do sistema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->