### PR TITLE
Optimize safe container, storage, and time hot paths

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -386,7 +386,7 @@ static void showUseHotkeyMessage(Player* player, const Item* item, uint32_t coun
 	}
 }
 
-bool Actions::useItem(Player* player, const Position& pos, uint8_t index, std::shared_ptr<Item> item, bool isHotkey)
+bool Actions::useItem(Player* player, const Position& pos, uint8_t index, const std::shared_ptr<Item>& item, bool isHotkey)
 {
 	if (!item) [[unlikely]] {
 		return false;
@@ -447,7 +447,7 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, std::s
 }
 
 bool Actions::useItemEx(Player* player, const Position& fromPos, const Position& toPos, uint8_t toStackPos,
-                        std::shared_ptr<Item> item, bool isHotkey, Creature* creature /* = nullptr*/)
+                        const std::shared_ptr<Item>& item, bool isHotkey, Creature* creature /* = nullptr*/)
 {
 	if (!item) [[unlikely]] {
 		return false;

--- a/src/actions.h
+++ b/src/actions.h
@@ -90,8 +90,8 @@ public:
 	Actions(const Actions&) = delete;
 	Actions& operator=(const Actions&) = delete;
 
-	bool useItem(Player*, const Position&, uint8_t, std::shared_ptr<Item>, bool);
-	bool useItemEx(Player*, const Position&, const Position&, uint8_t, std::shared_ptr<Item>, bool,
+	bool useItem(Player*, const Position&, uint8_t, const std::shared_ptr<Item>&, bool);
+	bool useItemEx(Player*, const Position&, const Position&, uint8_t, const std::shared_ptr<Item>&, bool,
 	               Creature* = nullptr);
 
 	ReturnValue canUse(const Player* player, const Position& pos);

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -220,8 +220,42 @@ bool Container::isHoldingItem(const Item* item) const
 	return false;
 }
 
+std::shared_ptr<Player> Container::getHoldingPlayerForNotification() const
+{
+	Cylinder* cylinder = getParent();
+	Cylinder* topParent = nullptr;
+	while (cylinder && cylinder->getParent() != nullptr) {
+		topParent = cylinder;
+		cylinder = cylinder->getParent();
+	}
+
+	if (!topParent) {
+		topParent = cylinder;
+	}
+
+	if (!topParent) {
+		return nullptr;
+	}
+
+	if (Creature* creature = topParent->getCreature()) {
+		Player* player = creature->getPlayer();
+		if (!player) {
+			return nullptr;
+		}
+
+		return std::static_pointer_cast<Player>(player->weak_from_this().lock());
+	}
+	return nullptr;
+}
+
 void Container::onAddContainerItem(Item* item) const
 {
+	if (auto player = getHoldingPlayerForNotification()) {
+		player->sendAddContainerItem(this, item);
+		player->onAddContainerItem(item);
+		return;
+	}
+
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 	spectators.partitionByType();
@@ -239,6 +273,12 @@ void Container::onAddContainerItem(Item* item) const
 
 void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem) const
 {
+	if (auto player = getHoldingPlayerForNotification()) {
+		player->sendUpdateContainerItem(this, static_cast<uint16_t>(index), newItem);
+		player->onUpdateContainerItem(this, oldItem, newItem);
+		return;
+	}
+
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 	spectators.partitionByType();
@@ -256,6 +296,12 @@ void Container::onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newIt
 
 void Container::onRemoveContainerItem(uint32_t index, Item* item) const
 {
+	if (auto player = getHoldingPlayerForNotification()) {
+		player->sendRemoveContainerItem(this, static_cast<uint16_t>(index));
+		player->onRemoveContainerItem(this, item);
+		return;
+	}
+
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), false, true, 1, 1, 1, 1);
 	spectators.partitionByType();

--- a/src/container.h
+++ b/src/container.h
@@ -15,6 +15,7 @@ class DepotChest;
 class DepotLocker;
 class RewardChest;
 class StoreInbox;
+class Player;
 
 using ContainerQueue = std::queue<const Container*>;
 
@@ -142,6 +143,7 @@ private:
 	void onAddContainerItem(Item* item) const;
 	void onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem) const;
 	void onRemoveContainerItem(uint32_t index, Item* item) const;
+	std::shared_ptr<Player> getHoldingPlayerForNotification() const;
 
 	void updateItemWeight(int32_t diff);
 	bool hasCapacityLimit() const;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -1256,20 +1256,49 @@ bool IOLoginData::savePlayer(Player* player)
 
 	{
 		AutoStat statStorage("savePlayer", "storage");
-		if (!db.executeQuery(fmt::format("DELETE FROM `player_storage` WHERE `player_id` = {:d}", player->getGUID()))) {
-			return false;
-		}
+		if (player->hasStorageDirty()) {
+			const uint32_t playerId = player->getGUID();
+			const auto& removedStorageKeys = player->getRemovedStorageKeys();
+			if (!removedStorageKeys.empty()) {
+				std::ostringstream deleteQuery;
+				deleteQuery << "DELETE FROM `player_storage` WHERE `player_id` = " << playerId << " AND `key` IN (";
 
-		DBInsert storageQuery("INSERT INTO `player_storage` (`player_id`, `key`, `value`) VALUES ");
+				bool first = true;
+				for (const uint32_t key : removedStorageKeys) {
+					if (!first) {
+						deleteQuery << ',';
+					}
+					first = false;
+					deleteQuery << key;
+				}
+				deleteQuery << ')';
 
-		for (const auto& [key, value] : player->getStorageMap()) {
-			if (!storageQuery.addRow(fmt::format("{:d}, {:d}, {:d}", player->getGUID(), key, value))) {
-				return false;
+				if (!db.executeQuery(deleteQuery.str())) {
+					return false;
+				}
 			}
-		}
 
-		if (!storageQuery.execute()) {
-			return false;
+			const auto& modifiedStorageKeys = player->getModifiedStorageKeys();
+			if (!modifiedStorageKeys.empty()) {
+				DBInsert storageQuery("INSERT INTO `player_storage` (`player_id`, `key`, `value`) VALUES ");
+				storageQuery.upsert(std::vector<std::string>{"value"});
+
+				const auto& storageMap = player->getStorageMap();
+				for (const uint32_t key : modifiedStorageKeys) {
+					const auto it = storageMap.find(key);
+					if (it == storageMap.end()) {
+						continue;
+					}
+
+					if (!storageQuery.addRow(fmt::format("{:d}, {:d}, {:d}", playerId, key, it->second))) {
+						return false;
+					}
+				}
+
+				if (!storageQuery.execute()) {
+					return false;
+				}
+			}
 		}
 	}
 
@@ -1315,7 +1344,12 @@ bool IOLoginData::savePlayer(Player* player)
 
 	// End the transaction
 	AutoStat statCommit("savePlayer", "commit");
-	return transaction.commit();
+	if (!transaction.commit()) {
+		return false;
+	}
+
+	player->clearStorageDirty();
+	return true;
 }
 
 bool IOLoginData::loadAutoLootConfig(Player* player)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1082,7 +1082,26 @@ uint16_t Player::getLookCorpse() const
 
 void Player::setStorageValue(const uint32_t key, const std::optional<int64_t> value, const bool isSpawn /* = false*/)
 {
+	const auto oldValue = getStorageValue(key);
 	Creature::setStorageValue(key, value, isSpawn);
+
+	if (isSpawn || oldValue == getStorageValue(key)) {
+		return;
+	}
+
+	if (value && value.value() != -1) {
+		removedStorageKeys.erase(key);
+		modifiedStorageKeys.insert(key);
+	} else {
+		modifiedStorageKeys.erase(key);
+		removedStorageKeys.insert(key);
+	}
+}
+
+void Player::clearStorageDirty()
+{
+	modifiedStorageKeys.clear();
+	removedStorageKeys.clear();
 }
 
 bool Player::canSee(const Position& pos) const
@@ -6123,7 +6142,7 @@ void Player::removeItemImbuements(Item* item, slots_t slot) {
 	sendStats();
 }
 
-void Player::removeImbuementEffect(std::shared_ptr<Imbuement> imbue) {
+void Player::removeImbuementEffect(const std::shared_ptr<Imbuement>& imbue) {
 
 
 	if (imbue->isSkill()) {
@@ -6196,7 +6215,7 @@ void Player::removeImbuementEffect(std::shared_ptr<Imbuement> imbue) {
 	sendStats();
 }
 
-void Player::addImbuementEffect(std::shared_ptr<Imbuement> imbue) {
+void Player::addImbuementEffect(const std::shared_ptr<Imbuement>& imbue) {
 
 
 	if (imbue->isSkill()) {

--- a/src/player.h
+++ b/src/player.h
@@ -386,6 +386,10 @@ public:
 	bool canOpenCorpse(uint32_t ownerId) const;
 
 	void setStorageValue(const uint32_t key, const std::optional<int64_t> value, const bool isSpawn = false) override;
+	const std::unordered_set<uint32_t>& getModifiedStorageKeys() const { return modifiedStorageKeys; }
+	const std::unordered_set<uint32_t>& getRemovedStorageKeys() const { return removedStorageKeys; }
+	bool hasStorageDirty() const { return !modifiedStorageKeys.empty() || !removedStorageKeys.empty(); }
+	void clearStorageDirty();
 
 	void setGroup(const std::shared_ptr<Group>& newGroup) { group = newGroup; }
 	Group* getGroup() const { return group.get(); }
@@ -1255,8 +1259,8 @@ public:
 	void updateRegeneration();
 	void addItemImbuements(Item* item, slots_t slot);
 	void removeItemImbuements(Item* item, slots_t slot);
-	void removeImbuementEffect(std::shared_ptr<Imbuement> imbue);
-	void addImbuementEffect(std::shared_ptr<Imbuement> imbue);
+	void removeImbuementEffect(const std::shared_ptr<Imbuement>& imbue);
+	void addImbuementEffect(const std::shared_ptr<Imbuement>& imbue);
 
 	const std::unordered_map<uint8_t, OpenContainer>& getOpenContainers() const { return openContainers; }
 
@@ -1403,6 +1407,8 @@ private:
 
 	std::unordered_set<uint32_t> attackedSet;
 	std::unordered_set<uint32_t> VIPList;
+	std::unordered_set<uint32_t> modifiedStorageKeys;
+	std::unordered_set<uint32_t> removedStorageKeys;
 	std::unordered_map<std::string, PreyCombatBonus> preyCombatBonuses;
 
 	std::unordered_map<uint8_t, OpenContainer> openContainers;

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -9,6 +9,7 @@
 #include "game.h"
 #include "logger.h"
 #include "configmanager.h"
+#include "tools.h"
 
 extern Game g_game;
 
@@ -32,6 +33,7 @@ void Dispatcher::threadMain()
 {
     // Capture thread ID for isDispatcherThread() checks
     threadId = std::this_thread::get_id();
+    UPDATE_OTSYS_TIME();
 
     std::vector<std::unique_ptr<Task>> tmpTaskList;
     tmpTaskList.reserve(128);
@@ -67,6 +69,8 @@ void Dispatcher::threadMain()
             // consume extra signals
         }
 
+        UPDATE_OTSYS_TIME();
+
         // Critical section: move tasks to the temporary list
         {
             std::scoped_lock lockGuard(taskLock);
@@ -77,6 +81,7 @@ void Dispatcher::threadMain()
 
         // Process all available tasks
         for (auto& task : tmpTaskList) {
+            UPDATE_OTSYS_TIME();
 #if defined(STATS_ENABLED) || defined(SLOW_TASK_DETECTION)
             auto taskStart = std::chrono::steady_clock::now();
 #endif

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1381,10 +1381,25 @@ std::string_view getReturnMessage(ReturnValue value)
 	}
 }
 
-int64_t OTSYS_TIME()
+namespace {
+int64_t currentSteadyMilliseconds()
 {
 	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
 	    .count();
+}
+
+std::atomic<int64_t> g_cachedOtsysTime{0};
+} // namespace
+
+void UPDATE_OTSYS_TIME()
+{
+	g_cachedOtsysTime.store(currentSteadyMilliseconds(), std::memory_order_relaxed);
+}
+
+int64_t OTSYS_TIME()
+{
+	const int64_t cachedTime = g_cachedOtsysTime.load(std::memory_order_relaxed);
+	return cachedTime != 0 ? cachedTime : currentSteadyMilliseconds();
 }
 
 int64_t OTSYS_NANOTIME()

--- a/src/tools.h
+++ b/src/tools.h
@@ -91,6 +91,7 @@ itemAttrTypes stringToItemAttribute(std::string_view str);
 
 std::string_view getReturnMessage(ReturnValue value);
 
+void UPDATE_OTSYS_TIME();
 int64_t OTSYS_TIME();
 int64_t OTSYS_NANOTIME();
 


### PR DESCRIPTION
## Summary
- Avoid `getSpectators` for container add/update/remove notifications when the container is directly held by a player, keeping the old spectator fallback for ground/depot/store/reward/unknown ownership cases.
- Track dirty player storage keys and persist only removed/modified keys with batched DELETE and INSERT ... ON DUPLICATE KEY UPDATE.
- Cache `OTSYS_TIME()` using steady_clock and refresh it from the dispatcher loop.
- Reduce unnecessary `shared_ptr` refcount churn in synchronous action/imbuement hot paths by passing read-only shared pointers by const reference.

## Notes
- `player_storage` already has `PRIMARY KEY (player_id, key)` in `schema.sql`, so no migration was needed for upsert.
- Scheduler audit found no `getNextActionTime() - OTSYS_TIME()` misuse in this pass.
- Build was not run per request; static diff check only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Otimizações internas de performance em salvamento de dados do jogador
  * Melhorias na sincronização e gerenciamento de tempo do sistema
  * Otimização de notificações de atualização de container
  * Ajustes nas assinaturas internas para melhor eficiência de memória

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->