### PR TITLE
Coalesce follow path updates

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -28,6 +28,11 @@ Creature::~Creature()
 {
 	liveCreatures.erase(this);
 
+	if (eventFollowPath != 0) {
+		g_scheduler.stopEvent(eventFollowPath);
+		eventFollowPath = 0;
+	}
+
 	attackedCreature.reset();
 	followCreature.reset();
 	removeMaster();
@@ -466,7 +471,7 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 	if (auto fc = followCreature.lock(); creature == fc.get() || (creature == this && fc)) {
 		if (hasFollowPath) {
 			isUpdatingPath = false;
-			g_dispatcher.addTask(createTask([id = getID()] { g_game.updateCreatureWalk(id); }));
+			updateFollowPath();
 		}
 
 		if (newPos.z != oldPos.z || !canSee(fc->getPosition())) {
@@ -934,15 +939,34 @@ void Creature::goToFollowCreature()
 	onFollowCreatureComplete(follow.get());
 }
 
+void Creature::updateFollowPath()
+{
+	if (eventFollowPath != 0 || followCreature.expired()) {
+		return;
+	}
+
+	eventFollowPath = g_scheduler.addEvent(createSchedulerTask(FOLLOW_EVENT_INTERVAL, [id = getID()]() {
+		g_game.updateCreatureWalk(id);
+	}));
+}
+
 bool Creature::setFollowCreature(Creature* creature)
 {
 	if (creature) {
 		if (auto follow = followCreature.lock(); follow.get() == creature) {
+			updateFollowPath();
 			return true;
 		}
 
 		const Position& creaturePos = creature->getPosition();
 		if (creaturePos.z != getPosition().z || !canSee(creaturePos)) {
+			if (eventFollowPath != 0) {
+				g_scheduler.stopEvent(eventFollowPath);
+				eventFollowPath = 0;
+			}
+
+			isUpdatingPath = false;
+			hasFollowPath = false;
 			followCreature.reset();
 			return false;
 		}
@@ -956,9 +980,16 @@ bool Creature::setFollowCreature(Creature* creature)
 		forceUpdateFollowPath = false;
 		followCreature = creature->shared_from_this();
 		isUpdatingPath = true;
+		updateFollowPath();
 	} else {
+		if (eventFollowPath != 0) {
+			g_scheduler.stopEvent(eventFollowPath);
+			eventFollowPath = 0;
+		}
+
 		isUpdatingPath = false;
 		followCreature.reset();
+		hasFollowPath = false;
 	}
 
 	onFollowCreature(creature);

--- a/src/creature.h
+++ b/src/creature.h
@@ -74,6 +74,7 @@ class Tile;
 inline constexpr int32_t EVENT_CREATURECOUNT = 10;
 inline constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 1000;
 inline constexpr int32_t EVENT_CHECK_CREATURE_INTERVAL = (EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT);
+inline constexpr uint32_t FOLLOW_EVENT_INTERVAL = 100;
 
 class FrozenPathingConditionCall
 {
@@ -225,6 +226,8 @@ public:
 	// follow functions
 	std::shared_ptr<Creature> getFollowCreatureShared() const { return followCreature.lock(); }
 	virtual bool setFollowCreature(Creature* creature);
+	void updateFollowPath();
+	void completeEventFollowWalk() { eventFollowPath = 0; }
 
 	// follow events
 	virtual void onFollowCreature(const Creature*) {}
@@ -415,6 +418,7 @@ protected:
 	uint32_t id = 0;
 	uint32_t scriptEventsBitField = 0;
 	uint32_t eventWalk = 0;
+	uint32_t eventFollowPath = 0;
 	uint32_t walkUpdateTicks = 0;
 	uint32_t blockCount = 0;
 	uint32_t blockTicks = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4487,8 +4487,12 @@ void Game::checkCreatureWalk(uint32_t creatureId)
 void Game::updateCreatureWalk(uint32_t creatureId)
 {
 	Creature* creature = getCreatureByID(creatureId);
-	if (creature && !creature->isRemoved() && !creature->isDead()) {
-		creature->completeEventFollowWalk();
+	if (!creature) {
+		return;
+	}
+
+	creature->completeEventFollowWalk();
+	if (!creature->isRemoved() && !creature->isDead()) {
 		creature->goToFollowCreature();
 	}
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3944,7 +3944,6 @@ void Game::playerSetAttackedCreature(uint32_t playerId, uint32_t creatureId)
 	}
 
 	player->setAttackedCreature(attackCreature);
-	g_dispatcher.addTask([this, id = player->getID()]() { updateCreatureWalk(id); });
 }
 
 void Game::playerFollowCreature(uint32_t playerId, uint32_t creatureId)
@@ -3963,7 +3962,6 @@ void Game::playerFollowCreature(uint32_t playerId, uint32_t creatureId)
 	}
 
 	player->setAttackedCreature(nullptr);
-	g_dispatcher.addTask([this, id = player->getID()]() { updateCreatureWalk(id); });
 	player->setFollowCreature(followCreature);
 }
 
@@ -4490,6 +4488,7 @@ void Game::updateCreatureWalk(uint32_t creatureId)
 {
 	Creature* creature = getCreatureByID(creatureId);
 	if (creature && !creature->isRemoved() && !creature->isDead()) {
+		creature->completeEventFollowWalk();
 		creature->goToFollowCreature();
 	}
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1940,7 +1940,7 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 	auto follow = followCreature.lock();
 	if (hasFollowPath && (creature == follow.get() || (creature == this && follow))) {
 		isUpdatingPath = false;
-		g_dispatcher.addTask([id = getID()]() { g_game.updateCreatureWalk(id); });
+		updateFollowPath();
 	}
 
 	if (creature != this) {


### PR DESCRIPTION
## Summary
- Adapt the Atlas follow-path coalescing idea to this TFS 1.8 8.60 codebase.
- Replace repeated direct dispatcher `updateCreatureWalk` scheduling with one pending scheduler event per creature.
- Keep follow ownership through the existing `weak_ptr` / `shared_from_this` flow and capture only creature ids in delayed tasks.
- Cancel pending follow-path events when follow is cleared or the creature is destroyed.
- Clear the pending follow-path event handle before checking removed/dead state when the scheduled callback runs.

Reference: https://github.com/atlas-kit/atlas/commit/de6532ea70d74a7fea63e21870200cf51cfa1f7d

## Validation
- `rg` confirmed the old direct `g_dispatcher.addTask(... updateCreatureWalk ...)` follow-path calls are gone from the touched hot paths.
- `git diff --check` passed; only the existing Windows CRLF conversion warning was printed.
- `wsl sh -lc "cmake --build build-release --target tfs -- -j2"` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Refactor**
  * Otimização do sistema de rastreamento de criaturas: melhorias na gerência de eventos de seguimento e atualização de caminhos para maior eficiência na execução de movimento.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->