### PR TITLE
Optimize spectator and autosend filtering

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1070,7 +1070,7 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 
 					SpectatorVec spectators;
 					g_game.map.getSpectators(spectators, player->getPosition(), false, true);
-					spectators = InstanceUtils::filterByInstance(spectators, player->getInstanceID());
+					InstanceUtils::filterByInstanceInPlace(spectators, player->getInstanceID());
 					g_game.addAnimatedText(spectators, fmt::format("{:+d}", realHealthGain), player->getPosition(),
 					                       static_cast<TextColor_t>(getInteger(ConfigManager::HEALTH_GAIN_COLOUR)));
 
@@ -1110,7 +1110,7 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 
 					SpectatorVec spectators;
 					g_game.map.getSpectators(spectators, player->getPosition(), false, true);
-					spectators = InstanceUtils::filterByInstance(spectators, player->getInstanceID());
+					InstanceUtils::filterByInstanceInPlace(spectators, player->getInstanceID());
 					g_game.addAnimatedText(spectators, fmt::format("{:+d}", realManaGain), player->getPosition(),
 					                       static_cast<TextColor_t>(getInteger(ConfigManager::MANA_GAIN_COLOUR)));
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1144,7 +1144,7 @@ void Creature::onGainExperience(uint64_t gainExp, const std::shared_ptr<Creature
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, false, true);
-	spectators = InstanceUtils::filterByInstance(spectators, getInstanceID());
+	InstanceUtils::filterByInstanceInPlace(spectators, getInstanceID());
 	if (spectators.empty()) {
 		return;
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5102,7 +5102,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			if (realHeal > 0) {
 				SpectatorVec spectators;
 				map.getSpectators(spectators, targetPos, false, true);
-				spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+				InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 
 				addAnimatedText(spectators, fmt::format("{:d}", realHeal), targetPos,
 				                static_cast<TextColor_t>(getInteger(ConfigManager::HEALTH_GAIN_COLOUR)));
@@ -5192,7 +5192,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 			SpectatorVec spectators;
 			map.getSpectators(spectators, targetPos, false, true);
-			spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+			InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 
 			addAnimatedText(spectators, fmt::format("{:d}", realHealthChange), targetPos,
                       		static_cast<TextColor_t>(getInteger(ConfigManager::HEALTH_GAIN_COLOUR)));
@@ -5307,7 +5307,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 				targetPlayer->drainMana(attackerRef, manaDamage);
 
 				map.getSpectators(spectators, targetPos, true, true);
-				spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+				InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 				addMagicEffect(spectators, targetPos, CONST_ME_LOSEENERGY);
 
 				std::string spectatorMessage;
@@ -5405,7 +5405,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 		if (spectators.empty()) {
 			map.getSpectators(spectators, targetPos, true, true);
-			spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+			InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 		}
 
 		message.primary.value = damage.primary.value;
@@ -5608,7 +5608,7 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, CombatDamage& 
 		if (realManaChange > 0) {
 			SpectatorVec spectators;
 			map.getSpectators(spectators, target->getPosition(), false, true);
-			spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+			InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 
 			addAnimatedText(spectators, fmt::format("{:d}", realManaChange), target->getPosition(),
 			                static_cast<TextColor_t>(getInteger(ConfigManager::MANA_GAIN_COLOUR)));
@@ -5680,7 +5680,7 @@ bool Game::combatChangeMana(Creature* attacker, Creature* target, CombatDamage& 
 
 		SpectatorVec spectators;
 		map.getSpectators(spectators, targetPos, false, true);
-		spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+		InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 
 		addAnimatedText(spectators, fmt::format("{:+d}", manaLoss), targetPos,
 				static_cast<TextColor_t>(getInteger(ConfigManager::MANA_LOSS_COLOUR)));
@@ -5730,7 +5730,7 @@ void Game::addCreatureHealth(const Creature* target)
 {
 	SpectatorVec spectators;
 	map.getSpectators(spectators, target->getPosition(), true, true);
-	spectators = InstanceUtils::filterByInstance(spectators, target->getInstanceID());
+	InstanceUtils::filterByInstanceInPlace(spectators, target->getInstanceID());
 	addCreatureHealth(spectators, target);
 }
 
@@ -5750,7 +5750,7 @@ void Game::addAnimatedText(std::string_view message, const Position& pos, TextCo
 	SpectatorVec spectators;
 	map.getSpectators(spectators, pos, true, true);
 	if (instanceId != 0) {
-		spectators = InstanceUtils::filterByInstance(spectators, instanceId);
+		InstanceUtils::filterByInstanceInPlace(spectators, instanceId);
 	}
 	addAnimatedText(spectators, message, pos, color);
 }
@@ -5768,7 +5768,7 @@ void Game::addMagicEffect(const Position& pos, uint16_t effect, uint32_t instanc
 	SpectatorVec spectators;
 	map.getSpectators(spectators, pos, true, true);
 	if (instanceId != 0) {
-		spectators = InstanceUtils::filterByInstance(spectators, instanceId);
+		InstanceUtils::filterByInstanceInPlace(spectators, instanceId);
 	}
 	addMagicEffect(spectators, pos, effect);
 }
@@ -5795,7 +5795,7 @@ void Game::addDistanceEffect(const Position& fromPos, const Position& toPos, uin
 	spectators.addSpectators(toPosSpectators);
 
 	if (instanceId != 0) {
-		spectators = InstanceUtils::filterByInstance(spectators, instanceId);
+		InstanceUtils::filterByInstanceInPlace(spectators, instanceId);
 	}
 	addDistanceEffect(spectators, fromPos, toPos, effect);
 }

--- a/src/instance_utils.h
+++ b/src/instance_utils.h
@@ -39,16 +39,16 @@ inline bool isPlayerInSameInstance(const Creature* player,
     return player && player->compareInstance(objectInstanceId);
 }
 
-inline SpectatorVec filterByInstance(const SpectatorVec &spectators,
-                                     uint32_t instanceId)
+inline void filterByInstanceInPlace(SpectatorVec &spectators,
+                                    uint32_t instanceId)
 {
-    SpectatorVec filtered;
-    for (const auto& spectator : spectators.players()) {
-        if (static_cast<const Player*>(spectator.get())->compareInstance(instanceId)) {
-            filtered.emplace_back(spectator);
-        }
+    if (instanceId == 0) {
+        return;
     }
-    return filtered;
+
+    spectators.filterPlayers([instanceId](const Player* player) {
+        return player && player->compareInstance(instanceId);
+    });
 }
 
 inline bool canInteract(const Creature *a, const Creature *b)

--- a/src/outputmessage.cpp
+++ b/src/outputmessage.cpp
@@ -41,6 +41,7 @@ void OutputMessagePool::sendAll() noexcept
 	protocols.swap(bufferedProtocols);
 
 	for (auto& protocol : protocols) {
+		protocol->inAutosend = false;
 		auto& msg = protocol->getCurrentBuffer();
 		if (msg) [[likely]] {
 			protocol->send(std::move(msg));
@@ -56,11 +57,12 @@ void OutputMessagePool::addProtocolToAutosend(Protocol_ptr protocol)
 {
 	// THREAD-SAFETY: Must be called from dispatcher thread only
 	// dispatcher thread
-	if (std::find(bufferedProtocols.begin(), bufferedProtocols.end(), protocol) != bufferedProtocols.end()) {
+	if (protocol->inAutosend) {
 		return;
 	}
 
-	bufferedProtocols.emplace_back(std::move(protocol));
+	auto& bufferedProtocol = bufferedProtocols.emplace_back(std::move(protocol));
+	bufferedProtocol->inAutosend = true;
 	if (!sendScheduled) [[unlikely]] {
 		scheduleSendAll(AUTOSEND_DELAY_DEFAULT);
 	}
@@ -73,6 +75,7 @@ void OutputMessagePool::removeProtocolFromAutosend(const Protocol_ptr& protocol)
 	auto it = std::find(bufferedProtocols.begin(), bufferedProtocols.end(), protocol);
 	if (it != bufferedProtocols.end()) [[likely]] {
 		// Swap-and-pop for O(1) removal - does not preserve order
+		(*it)->inAutosend = false;
 		std::swap(*it, bufferedProtocols.back());
 		bufferedProtocols.pop_back();
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2508,7 +2508,7 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 
 		SpectatorVec spectators;
 		g_game.map.getSpectators(spectators, position, false, true);
-		spectators = InstanceUtils::filterByInstance(spectators, getInstanceID());
+		InstanceUtils::filterByInstanceInPlace(spectators, getInstanceID());
 		g_game.addAnimatedText(spectators, std::to_string(lostExp), position, TEXTCOLOR_RED);
 		spectators.erase(this);
 		if (!spectators.empty()) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -65,11 +65,13 @@ protected:
 private:
 	friend class Connection;
 	friend class ConnectionManager;
+	friend class OutputMessagePool;
 
 	OutputMessage_ptr outputBuffer;
 
 	const ConnectionWeak_ptr connection;
 	xtea::round_keys key;
+	bool inAutosend = false;
 	bool encryptionEnabled = false;
 	bool checksumEnabled = true;
 	bool rawMessages = false;

--- a/src/spectators.cpp
+++ b/src/spectators.cpp
@@ -21,3 +21,33 @@ void SpectatorVec::partitionByType()
 	monsterEnd_ = static_cast<size_t>(monstersEnd - vec.begin());
 	partitioned_ = true;
 }
+
+void SpectatorVec::filterPlayers(std::function<bool(const Player*)> pred)
+{
+	if (!partitioned_) {
+		partitionByType();
+	}
+	assert(partitioned_);
+
+	size_t writeIndex = 0;
+	for (size_t readIndex = 0; readIndex < playerEnd_; ++readIndex) {
+		const Player* player = vec[readIndex]->getPlayer();
+		if (!pred(player)) {
+			continue;
+		}
+
+		if (writeIndex != readIndex) {
+			std::swap(vec[writeIndex], vec[readIndex]);
+		}
+		++writeIndex;
+	}
+
+	const size_t removedPlayers = playerEnd_ - writeIndex;
+	if (removedPlayers == 0) {
+		return;
+	}
+
+	vec.erase(vec.begin() + writeIndex, vec.begin() + playerEnd_);
+	playerEnd_ = writeIndex;
+	monsterEnd_ -= removedPlayers;
+}

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -4,10 +4,17 @@
 #ifndef FS_SPECTATORS_H
 #define FS_SPECTATORS_H
 
+#include <absl/container/flat_hash_set.h>
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
 #include <memory>
 #include <span>
+#include <vector>
 
 class Creature;
+class Player;
 
 class SpectatorVec
 {
@@ -20,11 +27,16 @@ public:
 
 	void addSpectators(const SpectatorVec& spectators)
 	{
+		absl::flat_hash_set<Creature*> existing;
+		existing.reserve(vec.size() + spectators.vec.size());
+		for (const auto& spectator : vec) {
+			existing.insert(spectator.get());
+		}
+
 		for (const auto& spectator : spectators.vec) {
-			if (std::find(vec.begin(), vec.end(), spectator) != vec.end()) {
-				continue;
+			if (existing.insert(spectator.get()).second) {
+				vec.emplace_back(spectator);
 			}
-			vec.emplace_back(spectator);
 		}
 		partitioned_ = false;
 	}
@@ -42,6 +54,7 @@ public:
 	}
 
 	void partitionByType();
+	void filterPlayers(std::function<bool(const Player*)> pred);
 
 	std::span<std::shared_ptr<Creature>> players() {
 		assert(partitioned_);


### PR DESCRIPTION
## Summary
- filter instance spectators in-place instead of returning copied SpectatorVec values
- track Protocol autosend membership with an O(1) flag
- use absl::flat_hash_set to merge SpectatorVec entries in O(n)

## Validation
- `cmake --build build-release -- -j$(nproc)`
- `ctest --test-dir build-release --output-on-failure` (no tests configured)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Otimizado o processamento de filtros de espectadores com operações "in-place" para melhor eficiência de memória
  * Melhorado o gerenciamento de autosend de protocolos com rastreamento de estado
  * Aprimorada a deduplicação de espectadores usando estruturas de dados mais eficientes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->