### PR TITLE
fix: crystal XML spawn path resolution and error logging

### DIFF
--- a/src/iomap.h
+++ b/src/iomap.h
@@ -102,7 +102,7 @@ public:
         }
 
         // Load traditional spawn file
-        map->spawns.loadFromXml(map->spawnfile.string());
+        bool spawnsLoaded = map->spawns.loadFromXml(map->spawnfile.string());
 
         // Also try Canary/Crystal-style monster+npc files
         std::string mapName(getString(ConfigManager::MAP_NAME));
@@ -110,10 +110,18 @@ public:
         if (worldPath.empty()) {
             worldPath = "data/world";
         }
-        map->spawns.loadFromMonsterNpcXml((worldPath / (mapName + "-monster.xml")).string());
-        map->spawns.loadFromMonsterNpcXml((worldPath / (mapName + "-npc.xml")).string());
 
-        return map->spawns.isStarted() || !map->spawns.getSpawnList().empty() || map->spawns.getNpcCount() > 0;
+        auto monsterPath = worldPath / (mapName + "-monster.xml");
+        if (std::filesystem::exists(monsterPath)) {
+            spawnsLoaded |= map->spawns.loadFromMonsterNpcXml(monsterPath.string());
+        }
+
+        auto npcPath = worldPath / (mapName + "-npc.xml");
+        if (std::filesystem::exists(npcPath)) {
+            spawnsLoaded |= map->spawns.loadFromMonsterNpcXml(npcPath.string());
+        }
+
+        return spawnsLoaded;
     }
 
     /* Load the houses (not house tile-data)

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -100,7 +100,16 @@ public:
             map->spawnfile = getString(ConfigManager::MAP_NAME);
             map->spawnfile += "-spawn.xml";
         }
-        return map->spawns.loadFromXml(map->spawnfile.string());
+
+        // Load traditional spawn file
+        map->spawns.loadFromXml(map->spawnfile.string());
+
+        // Also try Canary/Crystal-style monster+npc files
+        std::string mapName = getString(ConfigManager::MAP_NAME);
+        map->spawns.loadFromMonsterNpcXml(mapName + "-monster.xml");
+        map->spawns.loadFromMonsterNpcXml(mapName + "-npc.xml");
+
+        return map->spawns.isStarted() || !map->spawns.getSpawnList().empty() || map->spawns.getNpcCount() > 0;
     }
 
     /* Load the houses (not house tile-data)

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -106,8 +106,12 @@ public:
 
         // Also try Canary/Crystal-style monster+npc files
         std::string mapName(getString(ConfigManager::MAP_NAME));
-        map->spawns.loadFromMonsterNpcXml(mapName + "-monster.xml");
-        map->spawns.loadFromMonsterNpcXml(mapName + "-npc.xml");
+        auto worldPath = map->spawnfile.parent_path();
+        if (worldPath.empty()) {
+            worldPath = "data/world";
+        }
+        map->spawns.loadFromMonsterNpcXml((worldPath / (mapName + "-monster.xml")).string());
+        map->spawns.loadFromMonsterNpcXml((worldPath / (mapName + "-npc.xml")).string());
 
         return map->spawns.isStarted() || !map->spawns.getSpawnList().empty() || map->spawns.getNpcCount() > 0;
     }

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -105,7 +105,7 @@ public:
         map->spawns.loadFromXml(map->spawnfile.string());
 
         // Also try Canary/Crystal-style monster+npc files
-        std::string mapName = getString(ConfigManager::MAP_NAME);
+        std::string mapName(getString(ConfigManager::MAP_NAME));
         map->spawns.loadFromMonsterNpcXml(mapName + "-monster.xml");
         map->spawns.loadFromMonsterNpcXml(mapName + "-npc.xml");
 

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -204,6 +204,7 @@ bool Spawns::loadFromMonsterNpcXml(std::string_view filename)
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file(filename.data());
 	if (!result) {
+		printXMLError("Error - Spawns::loadFromMonsterNpcXml", filename, result);
 		return false;
 	}
 

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -199,6 +199,116 @@ bool Spawns::loadFromXml(std::string_view filename)
 	return true;
 }
 
+bool Spawns::loadFromMonsterNpcXml(std::string_view filename)
+{
+	pugi::xml_document doc;
+	pugi::xml_parse_result result = doc.load_file(filename.data());
+	if (!result) {
+		return false;
+	}
+
+	auto rootNode = doc.document_element();
+
+	auto processSpawnNode = [this](pugi::xml_node spawnNode) {
+		Position centerPos(pugi::cast<uint16_t>(spawnNode.attribute("centerx").value()),
+		                   pugi::cast<uint16_t>(spawnNode.attribute("centery").value()),
+		                   pugi::cast<uint16_t>(spawnNode.attribute("centerz").value()));
+
+		int32_t radius;
+		pugi::xml_attribute radiusAttribute = spawnNode.attribute("radius");
+		if (radiusAttribute) {
+			radius = pugi::cast<int32_t>(radiusAttribute.value());
+		} else {
+			radius = -1;
+		}
+
+		if (radius > 30) {
+			LOG_WARN(fmt::format("[Warning - Spawns::loadFromMonsterNpcXml] Radius size bigger than 30 at position: {}, consider lowering it.", centerPos));
+		}
+
+		if (!spawnNode.first_child()) {
+			LOG_WARN(fmt::format("[Warning - Spawns::loadFromMonsterNpcXml] Empty spawn at position: {} with radius: {}.", centerPos, radius));
+			return;
+		}
+
+		spawnList.push_front(std::make_shared<Spawn>(centerPos, radius));
+		Spawn& spawn = *spawnList.front();
+
+		for (auto& childNode : spawnNode.children()) {
+			int16_t childZ = centerPos.z;
+			pugi::xml_attribute zAttribute = childNode.attribute("z");
+			if (zAttribute) {
+				childZ = pugi::cast<int16_t>(zAttribute.value());
+			}
+
+			if (caseInsensitiveEqual(childNode.name(), "monster")) {
+				pugi::xml_attribute nameAttribute = childNode.attribute("name");
+				if (!nameAttribute) {
+					continue;
+				}
+
+				Direction dir = DIRECTION_NORTH;
+				pugi::xml_attribute directionAttribute = childNode.attribute("direction");
+				if (directionAttribute) {
+					dir = static_cast<Direction>(pugi::cast<uint16_t>(directionAttribute.value()));
+				}
+
+				Position pos(centerPos.x + pugi::cast<uint16_t>(childNode.attribute("x").value()),
+				             centerPos.y + pugi::cast<uint16_t>(childNode.attribute("y").value()), childZ);
+				int32_t interval = pugi::cast<int32_t>(childNode.attribute("spawntime").value()) * 1000;
+				if (interval >= MINSPAWN_INTERVAL && interval <= MAXSPAWN_INTERVAL) {
+					spawn.addMonster(nameAttribute.as_string(), pos, dir, static_cast<uint32_t>(interval));
+				} else {
+					if (interval < MINSPAWN_INTERVAL) {
+						LOG_WARN(fmt::format("[Warning - Spawns::loadFromMonsterNpcXml] {} {} spawntime can not be less than {} seconds.", nameAttribute.as_string(), pos, MINSPAWN_INTERVAL / 1000));
+					} else {
+						LOG_WARN(fmt::format("[Warning - Spawns::loadFromMonsterNpcXml] {} {} spawntime can not be more than {} seconds.", nameAttribute.as_string(), pos, MAXSPAWN_INTERVAL / 1000));
+					}
+				}
+			} else if (caseInsensitiveEqual(childNode.name(), "npc")) {
+				pugi::xml_attribute nameAttribute = childNode.attribute("name");
+				if (!nameAttribute) {
+					continue;
+				}
+
+				auto npc = Npc::createNpc(nameAttribute.as_string());
+				if (!npc) {
+					continue;
+				}
+
+				pugi::xml_attribute directionAttribute = childNode.attribute("direction");
+				if (directionAttribute) {
+					npc->setDirection(static_cast<Direction>(pugi::cast<uint16_t>(directionAttribute.value())));
+				}
+
+				pugi::xml_attribute instanceIdAttribute = childNode.attribute("instanceId");
+				if (instanceIdAttribute) {
+					npc->setInstanceID(pugi::cast<uint32_t>(instanceIdAttribute.value()));
+				}
+
+				npc->setMasterPos(
+				    Position(centerPos.x + pugi::cast<uint16_t>(childNode.attribute("x").value()),
+				             centerPos.y + pugi::cast<uint16_t>(childNode.attribute("y").value()), childZ),
+				    radius);
+				npcList.push_front(std::move(npc));
+			}
+		}
+	};
+
+	if (rootNode.attribute("centerx")) {
+		processSpawnNode(rootNode);
+	}
+
+	for (auto& spawnNode : rootNode.children()) {
+		if (spawnNode.attribute("centerx")) {
+			processSpawnNode(spawnNode);
+		}
+	}
+
+	loaded = true;
+	return true;
+}
+
 void Spawns::startup()
 {
 	if (!loaded || isStarted()) {

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -80,6 +80,7 @@ public:
 	static bool isInZone(const Position& centerPos, int32_t radius, const Position& pos);
 
 	bool loadFromXml(std::string_view filename);
+	bool loadFromMonsterNpcXml(std::string_view filename);
 	void startup();
 	void clear();
 


### PR DESCRIPTION
## Summary
- Fixed crystal-style (-monster.xml/-npc.xml) spawn file paths to use the same directory as the OTBM-defined spawnfile instead of relative CWD paths
- Added printXMLError to loadFromMonsterNpcXml so file-not-found/parse errors are visible in logs (previously silent)
- Fixed std::string_view to std::string copy-initialization for C++23 compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adicionado suporte ao carregamento de spawns em formatos alternativos para monstros e NPCs.
  * Implementado novo método de processamento de arquivos XML com suporte aprimorado para definição de coordenadas de spawn.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->