### PR TITLE
fix(imbuing): remove extra U32 from sendChoiceWindow - fixes EOF on O…

### DIFF
--- a/data/lib/core/imbuing.lua
+++ b/data/lib/core/imbuing.lua
@@ -4,6 +4,11 @@ local WINDOW_OPCODE = 0xEB
 local CLOSE_OPCODE = 0xEC
 local RESOURCE_BALANCE_OPCODE = 0xEE
 local USE_RANGE = 1
+local BLANK_IMBUEMENT_SCROLL_ID = 51442
+
+local IMBUEMENT_WINDOW_CHOICE = 0
+local IMBUEMENT_WINDOW_SELECT_ITEM = 1
+local IMBUEMENT_WINDOW_SCROLL = 2
 
 local SUCCESS_RATES = {
 	[1] = 90,
@@ -224,41 +229,43 @@ local function getItemName(itemId)
 	return name
 end
 
-local function writeImbuementInfo(msg, def)
+local function writeImbuementInfo(msg, def, includeBlankScroll)
 	msg:addU32(protocolId(def))
 	msg:addString(displayName(def))
 	msg:addString(def.description or "")
-	msg:addString(def.name or "")
+	msg:addByte(math.max(0, (tonumber(def.baseId) or 1) - 1))
 	msg:addU16(def.iconId or 0)
 	msg:addU32(def.duration or 0)
-	msg:addByte(def.premium and 1 or 0)
 
-	local items = def.items or {}
+	local items = {}
+	for _, req in ipairs(def.items or {}) do
+		items[#items + 1] = req
+	end
+	if includeBlankScroll then
+		items[#items + 1] = { itemId = BLANK_IMBUEMENT_SCROLL_ID, count = 1 }
+	end
+
 	msg:addByte(#items)
 	for _, req in ipairs(items) do
 		msg:addU16(req.itemId)
-		msg:addString(string.format("%dx %s", req.count, getItemName(req.itemId)))
+		msg:addString(getItemName(req.itemId))
 		msg:addU16(req.count)
 	end
 
 	msg:addU32(def.price or 0)
-	msg:addByte(getSuccessRate(def))
-	msg:addU32(getProtectionCost(def))
 end
 
 local function writeFallbackImbuementInfo(msg, imbuement)
 	msg:addU32(0)
-	local name, group = fallbackImbuementName(imbuement)
+	local name = fallbackImbuementName(imbuement)
+	local baseId = imbuement and tonumber(imbuement:getBaseId()) or 1
 	msg:addString(name)
 	msg:addString("")
-	msg:addString(group)
+	msg:addByte(math.max(0, baseId - 1))
 	msg:addU16(0)
 	msg:addU32(imbuement and imbuement:getDuration() or 0)
 	msg:addByte(0)
-	msg:addByte(0)
 	msg:addU32(0)
-	msg:addByte(getSuccessRate(imbuement))
-	msg:addU32(getProtectionCost(imbuement))
 end
 
 local function getActiveImbuements(item)
@@ -286,7 +293,23 @@ local function getApplicableDefinitions(item)
 	return list
 end
 
-local function writeNeededItems(msg, player, definitions)
+local function getScrollDefinitions()
+	ensureDefinitions()
+
+	local list = {}
+	for _, def in ipairs(cachedDefinitions) do
+		if tonumber(def.scrollId) and tonumber(def.scrollId) ~= 0 then
+			table.insert(list, def)
+		end
+	end
+	return list
+end
+
+local function getPlayerItemCount(player, itemId)
+	return math.min(player:getItemCount(itemId, -1, true), 0xFFFF)
+end
+
+local function writeNeededItems(msg, player, definitions, includeBlankScroll)
 	local itemIds = {}
 	local seen = {}
 
@@ -298,12 +321,16 @@ local function writeNeededItems(msg, player, definitions)
 			end
 		end
 	end
+	if includeBlankScroll and not seen[BLANK_IMBUEMENT_SCROLL_ID] then
+		seen[BLANK_IMBUEMENT_SCROLL_ID] = true
+		table.insert(itemIds, BLANK_IMBUEMENT_SCROLL_ID)
+	end
 
 	table.sort(itemIds)
 	msg:addU32(#itemIds)
 	for _, itemId in ipairs(itemIds) do
 		msg:addU16(itemId)
-		msg:addU16(math.min(player:getItemCount(itemId, -1, true), 0xFFFF))
+		msg:addU16(getPlayerItemCount(player, itemId))
 	end
 end
 
@@ -444,7 +471,13 @@ local function sendWindow(player, item)
 
 	local msg = NetworkMessage(player)
 	msg:addByte(WINDOW_OPCODE)
+	msg:addByte(IMBUEMENT_WINDOW_SELECT_ITEM)
+	msg:addByte(getPlayerItemCount(player, BLANK_IMBUEMENT_SCROLL_ID) > 0 and 1 or 0)
 	msg:addU16(item:getId())
+	local classification = item.getClassification and item:getClassification() or 0
+	if classification > 0 then
+		msg:addByte(item.getTier and item:getTier() or 0)
+	end
 	msg:addByte(math.min(slots, 3))
 
 	local activeImbuements = getActiveImbuements(item)
@@ -477,6 +510,93 @@ local function sendWindow(player, item)
 	return true
 end
 
+local function sendChoiceWindow(player)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
+	sendBalances(player)
+
+	local msg = NetworkMessage(player)
+	msg:addByte(WINDOW_OPCODE)
+	msg:addByte(IMBUEMENT_WINDOW_CHOICE)
+	msg:addByte(getPlayerItemCount(player, BLANK_IMBUEMENT_SCROLL_ID) > 0 and 1 or 0)
+	-- NOTE: client reads only U16 for CHOICE window (item id placeholder = 0)
+	msg:addU16(0)
+	msg:sendToPlayer(player)
+	return true
+end
+
+
+local function sendScrollWindow(player)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
+	local definitions = getScrollDefinitions()
+	sendBalances(player)
+
+	local msg = NetworkMessage(player)
+	msg:addByte(WINDOW_OPCODE)
+	msg:addByte(IMBUEMENT_WINDOW_SCROLL)
+	msg:addByte(getPlayerItemCount(player, BLANK_IMBUEMENT_SCROLL_ID) > 0 and 1 or 0)
+	msg:addByte(1)
+	msg:addByte(0)
+	msg:addU16(#definitions)
+	for _, def in ipairs(definitions) do
+		writeImbuementInfo(msg, def, true)
+	end
+
+	writeNeededItems(msg, player, definitions, true)
+	msg:sendToPlayer(player)
+	return true
+end
+
+function ImbuingWindow.openChoice(player, silent, sourcePosition, sourceThing)
+	if not supportsCustomNetwork(player) then
+		if not silent then
+			player:sendCancelMessage("The imbuing window is only available on OTClient.")
+		end
+		return false
+	end
+
+	if not isEnabled() then
+		if not silent then
+			player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		end
+		return false
+	end
+
+	local session = { mode = "choice" }
+	setAccessContext(session, player, sourceThing, sourcePosition)
+	sessions[player:getId()] = session
+	return sendChoiceWindow(player)
+end
+
+function ImbuingWindow.openScroll(player, silent, sourcePosition, sourceThing)
+	if not supportsCustomNetwork(player) then
+		if not silent then
+			player:sendCancelMessage("The imbuing window is only available on OTClient.")
+		end
+		return false
+	end
+
+	if not isEnabled() then
+		if not silent then
+			player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		end
+		return false
+	end
+
+	local session = sessions[player:getId()] or {}
+	session.mode = "scroll"
+	if sourcePosition or sourceThing or not session.sourcePosition then
+		setAccessContext(session, player, sourceThing, sourcePosition)
+	end
+	sessions[player:getId()] = session
+	return sendScrollWindow(player)
+end
+
 function ImbuingWindow.open(player, container, silent)
 	if not supportsCustomNetwork(player) then
 		if not silent then
@@ -506,7 +626,7 @@ function ImbuingWindow.open(player, container, silent)
 		return true
 	end
 
-	local session = {container = container, item = item}
+	local session = {mode = "item", container = container, item = item}
 	setAccessContext(session, player, container)
 	sessions[player:getId()] = session
 	return sendWindow(player, item)
@@ -547,8 +667,14 @@ function ImbuingWindow.openItem(player, item, silent, sourcePosition, sourceThin
 		return true
 	end
 
-	local session = {item = item, backpackOnly = true}
-	setAccessContext(session, player, sourceThing, sourcePosition)
+	local previousSession = sessions[player:getId()]
+	local session = {mode = "item", item = item, backpackOnly = true}
+	if previousSession and previousSession.sourcePosition and not sourcePosition and not sourceThing then
+		session.sourcePosition = previousSession.sourcePosition
+		session.sourceInstanceId = previousSession.sourceInstanceId
+	else
+		setAccessContext(session, player, sourceThing, sourcePosition)
+	end
 	sessions[player:getId()] = session
 	return sendWindow(player, item)
 end
@@ -574,6 +700,54 @@ function ImbuingWindow.sendClose(player)
 	return sent
 end
 
+local function applyScrollImbuement(player, def)
+	if not def or not def.scrollId or def.scrollId == 0 then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		sendScrollWindow(player)
+		return
+	end
+
+	for _, req in ipairs(def.items or {}) do
+		if player:getItemCount(req.itemId, -1, true) < req.count then
+			player:sendTextMessage(MESSAGE_STATUS_SMALL, "You do not have all required astral sources.")
+			sendScrollWindow(player)
+			return
+		end
+	end
+
+	if player:getItemCount(BLANK_IMBUEMENT_SCROLL_ID, -1, true) < 1 then
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You need a blank imbuement scroll.")
+		sendScrollWindow(player)
+		return
+	end
+
+	local cost = def.price or 0
+	if cost > 0 and player:getMoney() + player:getBankBalance() < cost then
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You do not have enough gold.")
+		sendScrollWindow(player)
+		return
+	end
+
+	for _, req in ipairs(def.items or {}) do
+		player:removeItem(req.itemId, req.count, -1, true)
+	end
+	player:removeItem(BLANK_IMBUEMENT_SCROLL_ID, 1, -1, true)
+
+	if cost > 0 then
+		player:removeTotalMoney(cost)
+	end
+
+	local created = player:addItem(def.scrollId, 1)
+	if not created then
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Failed to create imbuement scroll.")
+		sendScrollWindow(player)
+		return
+	end
+
+	player:sendTextMessage(MESSAGE_STATUS_SMALL, "Imbuement scroll created.")
+	sendScrollWindow(player)
+end
+
 function ImbuingWindow.apply(player, slot, imbuementId, protection)
 	if not isEnabled() then
 		return
@@ -583,17 +757,33 @@ function ImbuingWindow.apply(player, slot, imbuementId, protection)
 		return
 	end
 
-	local item = getSessionEquipment(player)
-	if not item then
-		ImbuingWindow.sendClose(player)
-		return
-	end
-
 	ensureDefinitions()
 	local def = definitionsById[imbuementId]
 	if not def then
 		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-		sendWindow(player, item)
+		local session = sessions[player:getId()]
+		if session and session.mode == "scroll" then
+			sendScrollWindow(player)
+		else
+			local item = getSessionEquipment(player)
+			if item then
+				sendWindow(player, item)
+			else
+				ImbuingWindow.sendClose(player)
+			end
+		end
+		return
+	end
+
+	local session = sessions[player:getId()]
+	if session and session.mode == "scroll" then
+		applyScrollImbuement(player, def)
+		return
+	end
+
+	local item = getSessionEquipment(player)
+	if not item then
+		ImbuingWindow.sendClose(player)
 		return
 	end
 

--- a/data/lib/core/imbuing.lua
+++ b/data/lib/core/imbuing.lua
@@ -12,18 +12,6 @@ local IMBUEMENT_WINDOW_CHOICE = 0
 local IMBUEMENT_WINDOW_SELECT_ITEM = 1
 local IMBUEMENT_WINDOW_SCROLL = 2
 
-local SUCCESS_RATES = {
-	[1] = 90,
-	[2] = 70,
-	[3] = 50,
-}
-
-local PROTECTION_COSTS = {
-	[1] = 10000,
-	[2] = 30000,
-	[3] = 50000,
-}
-
 local sessions = {}
 local cachedDefinitions = nil
 local definitionsById = {}
@@ -196,22 +184,6 @@ local function displayName(def)
 		return def.baseName .. " " .. def.name
 	end
 	return def.name
-end
-
-local function getSuccessRate(defOrImbuement)
-	local baseId = defOrImbuement and tonumber(defOrImbuement.baseId)
-	if not baseId and defOrImbuement and defOrImbuement.getBaseId then
-		baseId = tonumber(defOrImbuement:getBaseId())
-	end
-	return SUCCESS_RATES[baseId] or 90
-end
-
-local function getProtectionCost(defOrImbuement)
-	local baseId = defOrImbuement and tonumber(defOrImbuement.baseId)
-	if not baseId and defOrImbuement and defOrImbuement.getBaseId then
-		baseId = tonumber(defOrImbuement:getBaseId())
-	end
-	return PROTECTION_COSTS[baseId] or PROTECTION_COSTS[1]
 end
 
 local function fallbackImbuementName(imbuement)
@@ -401,6 +373,11 @@ local function containerHasItem(container, target)
 	for i = 0, container:getSize() - 1 do
 		local item = container:getItem(i)
 		if item == target then
+			return true
+		end
+
+		local childContainer = item:getContainer()
+		if childContainer and containerHasItem(childContainer, target) then
 			return true
 		end
 	end
@@ -714,11 +691,19 @@ function ImbuingWindow.openItem(player, item, silent, sourcePosition, sourceThin
 
 	local previousSession = sessions[player:getId()]
 	local session = {mode = "item", item = item, backpackOnly = true}
-	if previousSession and previousSession.sourcePosition and not sourcePosition and not sourceThing then
-		session.sourcePosition = previousSession.sourcePosition
-		session.sourceInstanceId = previousSession.sourceInstanceId
-	else
+	if sourcePosition or sourceThing then
+		if not hasExplicitAccessContext(sourceThing, sourcePosition) then
+			return rejectMissingAccessContext(player, silent)
+		end
 		setAccessContext(session, player, sourceThing, sourcePosition)
+	elseif previousSession and previousSession.sourcePosition then
+		if not isSessionInRange(player, previousSession) then
+			ImbuingWindow.sendClose(player)
+			return false
+		end
+		copySessionAccessContext(session, previousSession)
+	else
+		return rejectMissingAccessContext(player, silent)
 	end
 	sessions[player:getId()] = session
 	return sendWindow(player, item)
@@ -805,7 +790,7 @@ local function applyScrollImbuement(player, def)
 	sendScrollWindow(player)
 end
 
-function ImbuingWindow.apply(player, slot, imbuementId, protection)
+function ImbuingWindow.apply(player, slot, imbuementId)
 	if not isEnabled() then
 		return
 	end
@@ -868,25 +853,8 @@ function ImbuingWindow.apply(player, slot, imbuementId, protection)
 	end
 
 	local cost = def.price or 0
-	if protection then
-		cost = cost + getProtectionCost(def)
-	end
 	if cost > 0 and player:getMoney() + player:getBankBalance() < cost then
 		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You do not have enough gold.")
-		sendWindow(player, item)
-		return
-	end
-
-	local success = protection or math.random(100) <= getSuccessRate(def)
-	if not success then
-		for _, req in ipairs(def.items or {}) do
-			player:removeItem(req.itemId, req.count, -1, true)
-		end
-		if cost > 0 then
-			player:removeTotalMoney(cost)
-		end
-
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Imbuement failed.")
 		sendWindow(player, item)
 		return
 	end

--- a/data/lib/core/imbuing.lua
+++ b/data/lib/core/imbuing.lua
@@ -3,6 +3,8 @@ ImbuingWindow = ImbuingWindow or {}
 local WINDOW_OPCODE = 0xEB
 local CLOSE_OPCODE = 0xEC
 local RESOURCE_BALANCE_OPCODE = 0xEE
+local RESOURCE_BANK_BALANCE = 0
+local RESOURCE_GOLD_EQUIPPED = 1
 local USE_RANGE = 1
 local BLANK_IMBUEMENT_SCROLL_ID = 51442
 
@@ -350,19 +352,27 @@ local function writeNeededItems(msg, player, definitions, includeBlankScroll)
 	end
 end
 
-local function sendBalances(player)
+local function sendResourceBalance(player, resourceType, value)
 	if not supportsCustomNetwork(player) then
 		return false
 	end
 
+	local amount = value or 0
+	if amount < 0 then
+		amount = 0
+	end
+
 	local msg = NetworkMessage(player)
 	msg:addByte(RESOURCE_BALANCE_OPCODE)
-	msg:addByte(0)
-	msg:addU64(player:getBankBalance())
-	msg:addByte(RESOURCE_BALANCE_OPCODE)
-	msg:addByte(1)
-	msg:addU64(player:getMoney())
+	msg:addByte(resourceType)
+	msg:addU64(amount)
 	return msg:sendToPlayer(player)
+end
+
+local function sendBalances(player)
+	local bankSent = sendResourceBalance(player, RESOURCE_BANK_BALANCE, player:getBankBalance())
+	local inventorySent = sendResourceBalance(player, RESOURCE_GOLD_EQUIPPED, player:getMoney())
+	return bankSent and inventorySent
 end
 
 local function findEquipment(container)
@@ -483,7 +493,6 @@ local function sendWindow(player, item)
 	end
 
 	local definitions = getApplicableDefinitions(item)
-	sendBalances(player)
 
 	local msg = NetworkMessage(player)
 	msg:addByte(WINDOW_OPCODE)
@@ -519,8 +528,11 @@ local function sendWindow(player, item)
 	end
 
 	writeNeededItems(msg, player, definitions)
-	msg:sendToPlayer(player)
-	return true
+	local sent = msg:sendToPlayer(player)
+	if sent then
+		sendBalances(player)
+	end
+	return sent
 end
 
 local function sendChoiceWindow(player)
@@ -528,16 +540,17 @@ local function sendChoiceWindow(player)
 		return false
 	end
 
-	sendBalances(player)
-
 	local msg = NetworkMessage(player)
 	msg:addByte(WINDOW_OPCODE)
 	msg:addByte(IMBUEMENT_WINDOW_CHOICE)
 	msg:addByte(getPlayerItemCount(player, BLANK_IMBUEMENT_SCROLL_ID) > 0 and 1 or 0)
 	-- NOTE: client reads only U16 for CHOICE window (item id placeholder = 0)
 	msg:addU16(0)
-	msg:sendToPlayer(player)
-	return true
+	local sent = msg:sendToPlayer(player)
+	if sent then
+		sendBalances(player)
+	end
+	return sent
 end
 
 
@@ -547,7 +560,6 @@ local function sendScrollWindow(player)
 	end
 
 	local definitions = getScrollDefinitions()
-	sendBalances(player)
 
 	local msg = NetworkMessage(player)
 	msg:addByte(WINDOW_OPCODE)
@@ -561,8 +573,11 @@ local function sendScrollWindow(player)
 	end
 
 	writeNeededItems(msg, player, definitions, true)
-	msg:sendToPlayer(player)
-	return true
+	local sent = msg:sendToPlayer(player)
+	if sent then
+		sendBalances(player)
+	end
+	return sent
 end
 
 function ImbuingWindow.openChoice(player, silent, sourcePosition, sourceThing)

--- a/data/lib/core/imbuing.lua
+++ b/data/lib/core/imbuing.lua
@@ -499,6 +499,7 @@ local function sendWindow(player, item)
 	msg:addByte(IMBUEMENT_WINDOW_SELECT_ITEM)
 	msg:addByte(getPlayerItemCount(player, BLANK_IMBUEMENT_SCROLL_ID) > 0 and 1 or 0)
 	msg:addU16(item:getId())
+	msg:addString(getItemName(item:getId()))
 	msg:addByte(item.getTier and item:getTier() or 0)
 	msg:addByte(math.min(slots, 3))
 

--- a/data/lib/core/imbuing.lua
+++ b/data/lib/core/imbuing.lua
@@ -75,6 +75,22 @@ local function setAccessContext(session, player, sourceThing, sourcePosition)
 	session.sourceInstanceId = sourceThing and getThingInstanceId(sourceThing) or (player and player:getInstanceId() or 0)
 end
 
+local function hasExplicitAccessContext(sourceThing, sourcePosition)
+	return sourcePosition or getThingPosition(sourceThing)
+end
+
+local function rejectMissingAccessContext(player, silent)
+	if not silent then
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Use an imbuing shrine first.")
+	end
+	return false
+end
+
+local function copySessionAccessContext(session, sourceSession)
+	session.sourcePosition = copyPosition(sourceSession.sourcePosition)
+	session.sourceInstanceId = sourceSession.sourceInstanceId
+end
+
 local function isSessionInRange(player, session)
 	if not player or not session or not session.sourcePosition then
 		return true
@@ -474,10 +490,7 @@ local function sendWindow(player, item)
 	msg:addByte(IMBUEMENT_WINDOW_SELECT_ITEM)
 	msg:addByte(getPlayerItemCount(player, BLANK_IMBUEMENT_SCROLL_ID) > 0 and 1 or 0)
 	msg:addU16(item:getId())
-	local classification = item.getClassification and item:getClassification() or 0
-	if classification > 0 then
-		msg:addByte(item.getTier and item:getTier() or 0)
-	end
+	msg:addByte(item.getTier and item:getTier() or 0)
 	msg:addByte(math.min(slots, 3))
 
 	local activeImbuements = getActiveImbuements(item)
@@ -568,6 +581,10 @@ function ImbuingWindow.openChoice(player, silent, sourcePosition, sourceThing)
 	end
 
 	local session = { mode = "choice" }
+	if not hasExplicitAccessContext(sourceThing, sourcePosition) then
+		return rejectMissingAccessContext(player, silent)
+	end
+
 	setAccessContext(session, player, sourceThing, sourcePosition)
 	sessions[player:getId()] = session
 	return sendChoiceWindow(player)
@@ -588,11 +605,23 @@ function ImbuingWindow.openScroll(player, silent, sourcePosition, sourceThing)
 		return false
 	end
 
-	local session = sessions[player:getId()] or {}
-	session.mode = "scroll"
-	if sourcePosition or sourceThing or not session.sourcePosition then
+	local previousSession = sessions[player:getId()]
+	local session = { mode = "scroll" }
+	if sourcePosition or sourceThing then
+		if not hasExplicitAccessContext(sourceThing, sourcePosition) then
+			return rejectMissingAccessContext(player, silent)
+		end
 		setAccessContext(session, player, sourceThing, sourcePosition)
+	elseif previousSession and previousSession.sourcePosition then
+		if not isSessionInRange(player, previousSession) then
+			ImbuingWindow.sendClose(player)
+			return false
+		end
+		copySessionAccessContext(session, previousSession)
+	else
+		return rejectMissingAccessContext(player, silent)
 	end
+
 	sessions[player:getId()] = session
 	return sendScrollWindow(player)
 end
@@ -700,6 +729,17 @@ function ImbuingWindow.sendClose(player)
 	return sent
 end
 
+local function restoreScrollResources(player, def, cost)
+	for _, req in ipairs(def.items or {}) do
+		player:addItem(req.itemId, req.count)
+	end
+	player:addItem(BLANK_IMBUEMENT_SCROLL_ID, 1)
+
+	if cost > 0 then
+		player:addMoney(cost)
+	end
+end
+
 local function applyScrollImbuement(player, def)
 	if not def or not def.scrollId or def.scrollId == 0 then
 		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
@@ -739,6 +779,7 @@ local function applyScrollImbuement(player, def)
 
 	local created = player:addItem(def.scrollId, 1)
 	if not created then
+		restoreScrollResources(player, def, cost)
 		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Failed to create imbuement scroll.")
 		sendScrollWindow(player)
 		return

--- a/data/scripts/actions/systems/imbuement_scroll.lua
+++ b/data/scripts/actions/systems/imbuement_scroll.lua
@@ -415,3 +415,68 @@ end
 action:id(ETCHER_ID)
 action:allowFarUse(true)
 action:register()
+
+local directScrollAction = Action()
+function directScrollAction.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    if not isImbuementEnabled() then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return true
+    end
+
+    if not target or not target:isItem() then
+        player:sendTextMessage(MESSAGE_STATUS_SMALL, "Use the imbuement scroll on an item.")
+        return true
+    end
+
+    if target:getImbuementSlots() <= 0 then
+        player:sendTextMessage(MESSAGE_STATUS_SMALL, "This item is not imbuable.")
+        return true
+    end
+
+    local def = Game.getImbuementByScroll(item:getId())
+    if not def then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        return true
+    end
+
+    if target:getFreeImbuementSlots() <= 0 then
+        player:sendTextMessage(MESSAGE_STATUS_SMALL, "The equipment has no free imbuement slots.")
+        return true
+    end
+
+    if target:hasImbuementType(def.imbuementType) then
+        local typeName = TYPE_NAMES[def.imbuementType] or def.name
+        player:sendTextMessage(MESSAGE_STATUS_SMALL,
+            string.format("The equipment already has '%s'. Remove it first.", typeName))
+        return true
+    end
+
+    if not target:canApplyImbuement(def.categoryId, def.baseId) then
+        local typeName = TYPE_NAMES[def.imbuementType] or def.name
+        player:sendTextMessage(MESSAGE_STATUS_SMALL,
+            string.format("This equipment does not accept imbuement '%s' (tier %d).", typeName, def.baseId))
+        return true
+    end
+
+    local imbuement = Imbuement(def.imbuementType, def.value, def.duration, def.decayType, def.baseId)
+    if not target:addImbuement(imbuement) then
+        player:sendTextMessage(MESSAGE_STATUS_SMALL, "Failed to apply imbuement. Unequip the item first.")
+        return true
+    end
+
+    item:remove(1)
+    player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
+        string.format("%s %s applied.\nDuration: %s | Slots: %d/%d",
+            def.baseName,
+            def.name,
+            formatDuration(def.duration),
+            #target:getImbuements(),
+            target:getImbuementSlots()))
+    return true
+end
+
+for _, scrollId in ipairs(SCROLL_IDS) do
+    directScrollAction:id(scrollId)
+end
+directScrollAction:register()

--- a/data/scripts/actions/systems/imbuement_scroll.lua
+++ b/data/scripts/actions/systems/imbuement_scroll.lua
@@ -434,6 +434,11 @@ function directScrollAction.onUse(player, item, fromPosition, target, toPosition
         return true
     end
 
+    if target:getTopParent() ~= player then
+        player:sendTextMessage(MESSAGE_STATUS_SMALL, "Use the imbuement scroll on an item from your inventory.")
+        return true
+    end
+
     local def = Game.getImbuementByScroll(item:getId())
     if not def then
         player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)

--- a/data/scripts/actions/systems/imbuing_shrine_open.lua
+++ b/data/scripts/actions/systems/imbuing_shrine_open.lua
@@ -89,11 +89,7 @@ function action.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	if not selectedItem then
-		selectedItem = findPlayerBackpackItem(player)
-	end
-
-	if not selectedItem then
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Use an item with imbuement slots from your backpack on the imbuing shrine.")
+		ImbuingWindow.openChoice(player, nil, item:getPosition(), item)
 		return true
 	end
 

--- a/data/scripts/actions/systems/imbuing_shrine_open.lua
+++ b/data/scripts/actions/systems/imbuing_shrine_open.lua
@@ -44,32 +44,6 @@ local function isPlayerBackpackItem(player, thing)
 	return container and containerHasItem(container, thing)
 end
 
-local function findImbuableItem(container)
-	for _, item in ipairs(container:getItems()) do
-		if hasImbuementSlots(item) then
-			return item
-		end
-
-		local childContainer = item:getContainer()
-		if childContainer then
-			local found = findImbuableItem(childContainer)
-			if found then
-				return found
-			end
-		end
-	end
-	return nil
-end
-
-local function findPlayerBackpackItem(player)
-	local backpack = player:getSlotItem(CONST_SLOT_BACKPACK)
-	local container = backpack and backpack:getContainer()
-	if container then
-		return findImbuableItem(container)
-	end
-	return nil
-end
-
 local action = Action()
 
 function action.onUse(player, item, fromPosition, target, toPosition, isHotkey)

--- a/data/scripts/network/imbuements/imbuing.lua
+++ b/data/scripts/network/imbuements/imbuing.lua
@@ -3,8 +3,8 @@ local apply = PacketHandler(0xD5)
 function apply.onReceive(player, msg)
 	local slot = msg:getByte()
 	local imbuementId = msg:getU32()
-	local protection = msg:getByte() ~= 0
-	ImbuingWindow.apply(player, slot, imbuementId, protection)
+	msg:getByte() -- legacy protection flag
+	ImbuingWindow.apply(player, slot, imbuementId)
 end
 
 apply:register()

--- a/data/scripts/network/imbuements/imbuing.lua
+++ b/data/scripts/network/imbuements/imbuing.lua
@@ -66,14 +66,12 @@ function action.onReceive(player, msg)
 		local stackpos = msg:getByte()
 		local item = getItemFromSelection(player, position, itemId, stackpos)
 		if item then
-			ImbuingWindow.openItem(player, item, true)
+			ImbuingWindow.openItem(player, item, false)
 		else
 			player:sendTextMessage(MESSAGE_STATUS_SMALL, "Select an item with imbuement slots from your backpack.")
 		end
 	elseif actionType == 2 then
 		ImbuingWindow.openScroll(player, true)
-	else
-		ImbuingWindow.openChoice(player, true)
 	end
 end
 

--- a/data/scripts/network/imbuements/imbuing.lua
+++ b/data/scripts/network/imbuements/imbuing.lua
@@ -24,3 +24,57 @@ function close.onReceive(player, msg)
 end
 
 close:register()
+
+local action = PacketHandler(0xB2)
+
+local function getItemFromSelection(player, position, itemId, stackpos)
+	if not position then
+		return nil
+	end
+
+	local item
+	if position.x == 0xFFFF then
+		if position.y >= 64 then
+			local container = player:getContainerById(position.y - 64)
+			item = container and container:getItem(position.z) or nil
+		else
+			item = player:getSlotItem(position.y)
+		end
+	else
+		local tile = Tile(position)
+		local thing = tile and tile:getThing(stackpos)
+		if thing then
+			if thing.isItem and thing:isItem() then
+				item = thing
+			elseif thing.getItem then
+				item = thing:getItem()
+			end
+		end
+	end
+
+	if item and item:getId() == itemId then
+		return item
+	end
+	return nil
+end
+
+function action.onReceive(player, msg)
+	local actionType = msg:getByte()
+	if actionType == 1 then
+		local position = msg:getPosition()
+		local itemId = msg:getU16()
+		local stackpos = msg:getByte()
+		local item = getItemFromSelection(player, position, itemId, stackpos)
+		if item then
+			ImbuingWindow.openItem(player, item, true)
+		else
+			player:sendTextMessage(MESSAGE_STATUS_SMALL, "Select an item with imbuement slots from your backpack.")
+		end
+	elseif actionType == 2 then
+		ImbuingWindow.openScroll(player, true)
+	else
+		ImbuingWindow.openChoice(player, true)
+	end
+end
+
+action:register()


### PR DESCRIPTION
…TC clients

The sendChoiceWindow function was sending an extra addU32(0) after the U16 item placeholder. Both OTC Classic (8.6) and OTC Fonticak clients only read a U16 for IMBUEMENT_WINDOW_CHOICE, causing:

  InputMessage eof reached (last opcode 0xEB)

Also includes the full new imbuement system port:
- IMBUEMENT_WINDOW_CHOICE (shrine opens selection screen)
- IMBUEMENT_WINDOW_SELECT_ITEM (pick item from backpack)
- IMBUEMENT_WINDOW_SCROLL (use blank scroll to create imbuement scroll)
- sendChoiceWindow / sendScrollWindow / sendWindow helpers
- Action handler 0xB2 for item/scroll selection from client
- Apply (0xD5), Clear (0xD6), Close (0xD7) packet handlers

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Novas janelas de escolha e de scroll para o sistema de imbuements, com fluxo de aplicação via scroll.
  * Interface de seleção ativada ao usar o altar de imbuement (em vez de seleção automática).
  * Sessões preservam/validam contexto de origem ao abrir janelas; suporte a inclusão opcional do blank scroll em listas e payloads.

* **Bug Fixes**
  * Reabertura da janela ajustada para cenários de falha na aplicação, restaurando recursos quando necessário.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->