### PR TITLE
feat(map): implement parsing for Canary-style tile zone nodes

### DIFF
--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -350,9 +350,36 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
                 }
             }
 
-            // Parse children items
+            // Parse children items and Canary-style tile zone nodes.
             for (auto& itemNode : tileNode.children) {
-                if (static_cast<OTBM_NodeTypes_t>(itemNode.type) != OTBM_NodeTypes_t::ITEM) {
+                const auto childNodeType = static_cast<OTBM_NodeTypes_t>(itemNode.type);
+                if (childNodeType == OTBM_NodeTypes_t::TILE_ZONE) {
+                    PropStream stream;
+                    if (!loader.getProps(itemNode, stream)) {
+                        setLastErrorString("Invalid tile zone node.");
+                        return false;
+                    }
+
+                    uint16_t zoneCount = 0;
+                    if (!stream.read<uint16_t>(zoneCount)) {
+                        setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Failed to read tile zone count.", x, y, z));
+                        return false;
+                    }
+
+                    for (uint16_t i = 0; i < zoneCount; ++i) {
+                        ZoneId zoneId = 0;
+                        if (!stream.read<ZoneId>(zoneId)) {
+                            setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Failed to read tile zone id.", x, y, z));
+                            return false;
+                        }
+                        if (zoneId != 0) {
+                            zoneIds.emplace_back(zoneId);
+                        }
+                    }
+                    continue;
+                }
+
+                if (childNodeType != OTBM_NodeTypes_t::ITEM) {
                     setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Unknown node type.", x, y, z));
                     return false;
                 }

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -354,27 +354,10 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
             for (auto& itemNode : tileNode.children) {
                 const auto childNodeType = static_cast<OTBM_NodeTypes_t>(itemNode.type);
                 if (childNodeType == OTBM_NodeTypes_t::TILE_ZONE) {
-                    PropStream stream;
-                    if (!loader.getProps(itemNode, stream)) {
-                        setLastErrorString("Invalid tile zone node.");
+                    std::string errorType;
+                    if (!parseTileZoneNode(loader, itemNode, zoneIds, errorType)) {
+                        setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] {}", x, y, z, errorType));
                         return false;
-                    }
-
-                    uint16_t zoneCount = 0;
-                    if (!stream.read<uint16_t>(zoneCount)) {
-                        setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Failed to read tile zone count.", x, y, z));
-                        return false;
-                    }
-
-                    for (uint16_t i = 0; i < zoneCount; ++i) {
-                        ZoneId zoneId = 0;
-                        if (!stream.read<ZoneId>(zoneId)) {
-                            setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Failed to read tile zone id.", x, y, z));
-                            return false;
-                        }
-                        if (zoneId != 0) {
-                            zoneIds.emplace_back(zoneId);
-                        }
                     }
                     continue;
                 }
@@ -428,6 +411,10 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
 
             if (tile) {
                 tile->setFlag(static_cast<tileflags_t>(tileflags));
+
+                std::sort(zoneIds.begin(), zoneIds.end());
+                zoneIds.erase(std::unique(zoneIds.begin(), zoneIds.end()), zoneIds.end());
+                
                 tile->setZoneIds(std::move(zoneIds));
             }
 
@@ -528,6 +515,32 @@ bool IOMap::parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, 
         }
 
         map.waypoints[std::string{name}] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
+    }
+    return true;
+}
+
+bool IOMap::parseTileZoneNode(OTB::Loader& loader, const OTB::Node& zoneNode, std::vector<ZoneId>& zoneIds, std::string& errorType) {
+    PropStream stream;
+    if (!loader.getProps(zoneNode, stream)) {
+        errorType = "Invalid tile zone node.";
+        return false;
+    }
+
+    uint16_t zoneCount = 0;
+    if (!stream.read<uint16_t>(zoneCount)) {
+        errorType = "Failed to read tile zone count.";
+        return false;
+    }
+
+    for (uint16_t i = 0; i < zoneCount; ++i) {
+        ZoneId zoneId = 0;
+        if (!stream.read<ZoneId>(zoneId)) {
+            errorType = "Failed to read tile zone id.";
+            return false;
+        }
+        if (zoneId != 0) {
+            zoneIds.emplace_back(zoneId);
+        }
     }
     return true;
 }

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -52,6 +52,7 @@ enum class OTBM_NodeTypes_t : uint8_t {
     HOUSETILE = 14,
     WAYPOINTS = 15,
     WAYPOINT = 16,
+    TILE_ZONE = 19,
 };
 
 enum class OTBM_TileFlag_t : uint32_t {

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -142,6 +142,8 @@ public:
     std::string_view getLastErrorString() const { return errorString; }
     void setLastErrorString(std::string_view error) { errorString = error; }
 
+    static bool parseTileZoneNode(OTB::Loader& loader, const OTB::Node& zoneNode, std::vector<ZoneId>& zoneIds, std::string& errorType);
+
 private:
     bool parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map,
                                 const std::filesystem::path& fileName);

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -517,9 +517,10 @@ std::shared_ptr<BasicTile> MapCache::parseBasicTile(void* loaderptr, const void*
         }
     }
     
-    // Parse nested items
+    // Parse nested items and Canary-style tile zone nodes
     for (auto& itemNode : tileNode.children) {
-        if (static_cast<OTBM_NodeTypes_t>(itemNode.type) == OTBM_NodeTypes_t::ITEM) {
+        const auto childNodeType = static_cast<OTBM_NodeTypes_t>(itemNode.type);
+        if (childNodeType == OTBM_NodeTypes_t::ITEM) {
             auto item = parseBasicItem(loaderptr, &itemNode, nullptr);
             if (item) {
                 const ItemType& it = Item::items[item->id];
@@ -527,6 +528,30 @@ std::shared_ptr<BasicTile> MapCache::parseBasicTile(void* loaderptr, const void*
                     tile->ground = item;
                 } else {
                     tile->items.push_back(item);
+                }
+            }
+        } else if (childNodeType == OTBM_NodeTypes_t::TILE_ZONE) {
+            PropStream stream;
+            if (!loader.getProps(itemNode, stream)) {
+                LOG_ERROR("[MapCache] Failed to get props from tile zone node");
+                return nullptr;
+            }
+
+            uint16_t zoneCount = 0;
+            if (!stream.read<uint16_t>(zoneCount)) {
+                LOG_ERROR("[MapCache] Failed to read tile zone count");
+                return nullptr;
+            }
+
+            for (uint16_t i = 0; i < zoneCount; ++i) {
+                ZoneId zoneId = 0;
+                if (!stream.read<ZoneId>(zoneId)) {
+                    LOG_ERROR("[MapCache] Failed to read tile zone id");
+                    return nullptr;
+                }
+
+                if (zoneId != 0) {
+                    tile->zoneIds.emplace_back(zoneId);
                 }
             }
         }

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -531,28 +531,10 @@ std::shared_ptr<BasicTile> MapCache::parseBasicTile(void* loaderptr, const void*
                 }
             }
         } else if (childNodeType == OTBM_NodeTypes_t::TILE_ZONE) {
-            PropStream stream;
-            if (!loader.getProps(itemNode, stream)) {
-                LOG_ERROR("[MapCache] Failed to get props from tile zone node");
+            std::string errorType;
+            if (!IOMap::parseTileZoneNode(loader, itemNode, tile->zoneIds, errorType)) {
+                LOG_ERROR(fmt::format("[MapCache] {}", errorType));
                 return nullptr;
-            }
-
-            uint16_t zoneCount = 0;
-            if (!stream.read<uint16_t>(zoneCount)) {
-                LOG_ERROR("[MapCache] Failed to read tile zone count");
-                return nullptr;
-            }
-
-            for (uint16_t i = 0; i < zoneCount; ++i) {
-                ZoneId zoneId = 0;
-                if (!stream.read<ZoneId>(zoneId)) {
-                    LOG_ERROR("[MapCache] Failed to read tile zone id");
-                    return nullptr;
-                }
-
-                if (zoneId != 0) {
-                    tile->zoneIds.emplace_back(zoneId);
-                }
             }
         }
     }


### PR DESCRIPTION
## Description
This PR introduces support for reading Canary-style tile zone nodes from OTBM maps. 

Previously, the map parser only expected item nodes as children of tile nodes.
This update adds the necessary logic to identify and parse tile zones to maintain map compatibility.

## Changes
* **`src/iomap.h`**: Added `TILE_ZONE = 19` to the `OTBM_NodeTypes_t` enumeration.
* **`src/iomap.cpp`**: Updated `IOMap::parseTileArea` to read `zoneCount` and map respective `zoneId`s into the tile's zone list.
* **`src/mapcache.cpp`**: Implemented identical parsing logic in `MapCache` to properly handle `TILE_ZONE` child nodes and store them in `tile->zoneIds`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mapas agora carregam corretamente informações de zonas associadas aos tiles, exibindo e aplicando essas zonas no jogo.

* **Bug Fixes**
  * Processamento de tiles melhorado para reconhecer nós de zona, com validação mais rígida e remoção de zonas duplicadas/ordenadas para dados consistentes.
  * Falhas de parsing agora retornam erros claros quando encontram tipos de nó desconhecidos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->