### PR TITLE
Update: New Monsters 2025

### DIFF
--- a/data/monsters/newhaven_update_2025/bosses/muglex_clan_chief.lua
+++ b/data/monsters/newhaven_update_2025/bosses/muglex_clan_chief.lua
@@ -14,8 +14,21 @@ monster.outfit = {
 	lookMount = 0,
 }
 
-monster.health = 100
-monster.maxHealth = 100
+monster.raceId = 2710
+monster.Bestiary = {
+	class = "Humanoid",
+	race = BESTY_RACE_HUMANOID,
+	toKill = 500,
+	FirstUnlock = 25,
+	SecondUnlock = 250,
+	CharmsPoints = 15,
+	Stars = 2,
+	Occurrence = 1,
+	Locations = "Muglex Clan Camp, Newhaven Underground.",
+}
+
+monster.health = 500
+monster.maxHealth = 500
 monster.race = "blood"
 monster.corpse = 52117
 monster.speed = 100
@@ -44,7 +57,7 @@ monster.flags = {
 	canPushCreatures = false,
 	staticAttackChance = 90,
 	targetDistance = 1,
-	runHealth = 30,
+	runHealth = 0,
 	healthHidden = false,
 	isBlockable = false,
 	canWalkOnEnergy = false,
@@ -88,7 +101,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, skill = 25, attack = 30 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -80 },
 	-- Earth damage attacks (as per wiki info about Muglex Clan Chief using earth damage)
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -15, maxDamage = -40, range = 5, shootEffect = CONST_ANI_SMALLEARTH, effect = CONST_ME_POISONAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_EARTHDAMAGE, minDamage = -20, maxDamage = -45, radius = 3, effect = CONST_ME_POISONAREA, target = false },

--- a/data/monsters/newhaven_update_2025/bosses/muglex_clan_chief.lua
+++ b/data/monsters/newhaven_update_2025/bosses/muglex_clan_chief.lua
@@ -1,0 +1,125 @@
+local mType = Game.createMonsterType("Muglex Clan Chief")
+local monster = {}
+
+monster.name = "Muglex Clan Chief"
+monster.description = "Muglex Clan Chief"
+monster.experience = 175
+monster.outfit = {
+	lookType = 297,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 100
+monster.maxHealth = 100
+monster.race = "blood"
+monster.corpse = 52117
+monster.speed = 100
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 20,
+	damage = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = true,
+	rewardBoss = true,
+	illusionable = true,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 30,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Me smash you!", yell = false },
+	{ text = "Muglex Clan strongest!", yell = true },
+	{ text = "You no take our stuff!", yell = false },
+}
+
+-- Loot based on statistics (53 kills, avg 86.08 gold)
+monster.loot = {
+	{ id = 3031, chance = 100000, minCount = 10, maxCount = 50 }, -- gold coin (100%)
+	{ id = 7618, chance = 54720, minCount = 1, maxCount = 2 }, -- health potion (54.72%)
+	{ id = 3578, chance = 24530, minCount = 1, maxCount = 3 }, -- fish (24.53%)
+	{ id = 7620, chance = 18870, minCount = 1, maxCount = 3 }, -- mana potion (18.87%)
+	{ id = 3277, chance = 16980, minCount = 1, maxCount = 3 }, -- spear (16.98%)
+	{ id = 3286, chance = 15090 }, -- mace (15.09%)
+	{ id = 3576, chance = 7550 }, -- mage hat (7.55%)
+	{ id = 44773, chance = 5660 }, -- refined bow (5.66%)
+	{ id = 3059, chance = 5660 }, -- spellbook (5.66%)
+	{ id = 3074, chance = 5660 }, -- wand of vortex (5.66%)
+	{ id = 3285, chance = 3770 }, -- longsword (3.77%)
+	{ id = 7884, chance = 3770 }, -- ranger legs (3.77%)
+	{ id = 3003, chance = 3770 }, -- rope (3.77%)
+	{ id = 3372, chance = 1890 }, -- brass legs (1.89%)
+	{ id = 44775, chance = 1890 }, -- harmony amulet (1.89%)
+	{ id = 44772, chance = 1890 }, -- simple jo staff (1.89%)
+	{ id = 3066, chance = 1890 }, -- snakebite rod (1.89%)
+	{ id = 3409, chance = 1890 }, -- steel shield (1.89%)
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 25, attack = 30 },
+	-- Earth damage attacks (as per wiki info about Muglex Clan Chief using earth damage)
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -15, maxDamage = -40, range = 5, shootEffect = CONST_ANI_SMALLEARTH, effect = CONST_ME_POISONAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_EARTHDAMAGE, minDamage = -20, maxDamage = -45, radius = 3, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -35, range = 7, shootEffect = CONST_ANI_SMALLSTONE, target = false },
+}
+
+monster.defenses = {
+	defense = 15,
+	armor = 12,
+	mitigation = 0.40,
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HEALING, minDamage = 15, maxDamage = 30, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 20 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/newhaven_update_2025/bosses/the_corruptor.lua
+++ b/data/monsters/newhaven_update_2025/bosses/the_corruptor.lua
@@ -14,8 +14,21 @@ monster.outfit = {
 	lookMount = 0,
 }
 
-monster.health = 100
-monster.maxHealth = 100
+monster.raceId = 2711
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 500,
+	FirstUnlock = 25,
+	SecondUnlock = 250,
+	CharmsPoints = 15,
+	Stars = 2,
+	Occurrence = 1,
+	Locations = "Newhaven Crypts, Corrupted Chambers.",
+}
+
+monster.health = 450
+monster.maxHealth = 450
 monster.race = "undead"
 monster.corpse = 52113
 monster.speed = 25
@@ -38,7 +51,7 @@ monster.flags = {
 	hostile = true,
 	convinceable = false,
 	pushable = true,
-	rewardBoss = false,
+	rewardBoss = true,
 	illusionable = false,
 	canPushItems = true,
 	canPushCreatures = false,

--- a/data/monsters/newhaven_update_2025/bosses/the_corruptor.lua
+++ b/data/monsters/newhaven_update_2025/bosses/the_corruptor.lua
@@ -1,0 +1,113 @@
+local mType = Game.createMonsterType("The Corruptor")
+local monster = {}
+
+monster.name = "The Corruptor"
+monster.description = "The Corruptor"
+monster.experience = 170
+monster.outfit = {
+	lookType = 233,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 100
+monster.maxHealth = 100
+monster.race = "undead"
+monster.corpse = 52113
+monster.speed = 25
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 60,
+	health = 20,
+	damage = 20,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = true,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Let me corrupt you!", yell = false },
+	{ text = "Glonk!", yell = false },
+}
+
+-- Loot based on statistics (21 kills, avg 88.57 gold)
+monster.loot = {
+	{ id = 3031, chance = 100000, minCount = 13, maxCount = 46 }, -- gold coin (100%)
+	{ id = 7618, chance = 23810, minCount = 1, maxCount = 3 }, -- health potion (23.81%)
+	{ id = 7620, chance = 23810, minCount = 1, maxCount = 3 }, -- mana potion (23.81%)
+	{ id = 3338, chance = 14290 }, -- bone sword (14.29%)
+	{ id = 3359, chance = 4760 }, -- brass armor (4.76%)
+	{ id = 8820, chance = 4760 }, -- magician's robe (4.76%)
+	{ id = 3375, chance = 4760 }, -- soldier helmet (4.76%)
+	{ id = 3074, chance = 4760 }, -- wand of vortex (4.76%)
+	{ id = 3723, chance = 4760, maxCount = 2 }, -- white mushroom (4.76%)
+	{ id = 44773, chance = 4760 }, -- refined bow (4.76%)
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -5, maxDamage = -15 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -5, maxDamage = -15, range = 5, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = -5, maxDamage = -10, length = 4, spread = 0, effect = CONST_ME_MORTAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 10,
+	armor = 0,
+	mitigation = 0.03,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/newhaven_update_2025/corrupted_ghost.lua
+++ b/data/monsters/newhaven_update_2025/corrupted_ghost.lua
@@ -113,7 +113,7 @@ monster.elements = {
 	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
 	{ type = COMBAT_ICEDAMAGE, percent = -5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
 }
 
 monster.immunities = {

--- a/data/monsters/newhaven_update_2025/corrupted_ghost.lua
+++ b/data/monsters/newhaven_update_2025/corrupted_ghost.lua
@@ -1,0 +1,126 @@
+local mType = Game.createMonsterType("Corrupted Ghost")
+local monster = {}
+
+monster.name = "Corrupted Ghost"
+monster.description = "a corrupted ghost"
+monster.experience = 29
+monster.outfit = {
+	lookType = 48,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2708
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 250,
+	FirstUnlock = 17,
+	SecondUnlock = 175,
+	CharmsPoints = 5,
+	Stars = 1,
+	Occurrence = 2,
+	Locations = "Corrupted Mines, Yalahar Cemetery Quarter",
+}
+
+monster.health = 30
+monster.maxHealth = 30
+monster.race = "undead"
+monster.corpse = 5993
+monster.speed = 58
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 80,
+	health = 10,
+	damage = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = true,
+	pushable = true,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Vaia!", yell = true },
+	{ text = "Swishh!", yell = true },
+}
+
+-- Loot based on statistics (1,449 kills, avg 19.59 gold)
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 14 }, -- gold coin (100%)
+	{ id = 7618, chance = 21390 }, -- health potion (21.39%)
+	{ id = 7620, chance = 20010 }, -- mana potion (20.01%)
+	{ id = 3723, chance = 11530, maxCount = 2 }, -- white mushroom (11.53%)
+	{ id = 2643, chance = 3040 }, -- cape (3.04%)
+	{ id = 3178, chance = 1790, maxCount = 2 }, -- light stone shower rune (1.79%)
+	{ id = 3174, chance = 1520, maxCount = 5 }, -- lightest missile rune (1.52%)
+	{ id = 10319, chance = 140 }, -- ranger's cloak (0.14%)
+	{ id = 3375, chance = 140 }, -- soldier helmet (0.14%)
+	{ id = 3081, chance = 70 }, -- stone skin amulet (0.07%)
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
+	{ name = "combat", interval = 2000, chance = 18, type = COMBAT_LIFEDRAIN, minDamage = -30, maxDamage = -60, range = 1, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_DEATHDAMAGE, minDamage = -25, maxDamage = -55, range = 5, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true },
+}
+
+monster.defenses = {
+	defense = 8,
+	armor = 0,
+	mitigation = 0.03,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/newhaven_update_2025/corrupted_skeleton.lua
+++ b/data/monsters/newhaven_update_2025/corrupted_skeleton.lua
@@ -40,7 +40,9 @@ monster.changeTarget = {
 }
 
 monster.strategiesTarget = {
-	nearest = 100,
+	nearest = 70,
+	health = 10,
+	damage = 20,
 }
 
 monster.flags = {

--- a/data/monsters/newhaven_update_2025/corrupted_skeleton.lua
+++ b/data/monsters/newhaven_update_2025/corrupted_skeleton.lua
@@ -1,0 +1,124 @@
+local mType = Game.createMonsterType("Corrupted Skeleton")
+local monster = {}
+
+monster.name = "Corrupted Skeleton"
+monster.description = "a corrupted skeleton"
+monster.experience = 34
+monster.outfit = {
+	lookType = 298,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2709
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 500,
+	FirstUnlock = 25,
+	SecondUnlock = 250,
+	CharmsPoints = 15,
+	Stars = 2,
+	Occurrence = 0,
+	Locations = "Newhaven Crypts.",
+}
+
+monster.health = 45
+monster.maxHealth = 45
+monster.race = "undead"
+monster.corpse = 5972
+monster.speed = 65
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = true,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Clatter!", yell = false },
+	{ text = "Corrupted...", yell = false },
+}
+
+-- Loot based on statistics (1,408 kills, avg 9.5 gold)
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 15 }, -- gold coin (100%)
+	{ id = 7618, chance = 26280 }, -- health potion (26.28%)
+	{ id = 3723, chance = 15130, maxCount = 2 }, -- white mushroom (15.13%)
+	{ id = 3337, chance = 4470 }, -- bone club (4.47%)
+	{ id = 3115, chance = 2980 }, -- bone (2.98%)
+	{ id = 3447, chance = 2340, maxCount = 14 }, -- simple arrow (2.34%)
+	{ id = 3375, chance = 1140 }, -- soldier helmet (1.14%)
+	{ id = 10319, chance = 210 }, -- ranger's cloak (0.21%)
+	{ id = 8820, chance = 140 }, -- magician's robe (0.14%)
+	{ id = 44771, chance = 70 }, -- plain monk robe (0.07%)
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -35 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -10, maxDamage = -20, range = 1, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -8, maxDamage = -18, range = 1, effect = CONST_ME_MORTAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 12,
+	armor = 0,
+	mitigation = 0.03,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -25 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bone_bear.lua
+++ b/data/monsters/winter_update_2025/bone_bear.lua
@@ -1,0 +1,95 @@
+local mType = Game.createMonsterType("Bone Bear")
+local monster = {}
+
+monster.name = "Bone Bear"
+monster.description = "a bone bear"
+monster.experience = 0
+monster.outfit = {
+	lookType = 384,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 600
+monster.maxHealth = 600
+monster.race = "undead"
+monster.corpse = 52567
+monster.speed = 125
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 }, -- Not confirmed (attacks unknown on tibiopedia)
+}
+
+monster.defenses = {
+	defense = 50, -- Not confirmed
+	armor = 50, -- Not confirmed
+	mitigation = 1.50, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/adlerauge.lua
+++ b/data/monsters/winter_update_2025/bosses/adlerauge.lua
@@ -1,0 +1,142 @@
+local mType = Game.createMonsterType("Adlerauge")
+local monster = {}
+
+monster.name = "Adlerauge"
+monster.description = "Adlerauge"
+monster.experience = 75000
+monster.outfit = {
+	lookType = 1901,
+	lookHead = 94,
+	lookBody = 38,
+	lookLegs = 67,
+	lookFeet = 19,
+	lookAddons = 2,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2754,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 45000
+monster.maxHealth = 45000
+monster.race = "blood"
+monster.corpse = 52853
+monster.speed = 180
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000, -- Not confirmed
+	chance = 15, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 2,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Bull's Eye!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, maxCount = 50 },
+	{ id = 3039, chance = 32560 }, -- red gem
+	{ name = "yellow gem", chance = 29070 },
+	{ name = "small sapphire", chance = 22090, maxCount = 5 },
+	-- { name = "repair kit for boats", chance = 22090 },
+	{ name = "assassin star", chance = 19770, maxCount = 20 },
+	{ name = "small diamond", chance = 19770, maxCount = 5 },
+	{ name = "small ruby", chance = 18600, maxCount = 5 },
+	{ name = "black pearl", chance = 18600 },
+	{ name = "blue gem", chance = 16280 },
+	{ name = "prismatic bolt", chance = 12790, maxCount = 17 },
+	-- { name = "stag parchment", chance = 11630 },
+	{ name = "white pearl", chance = 11630 },
+	{ name = "green gem", chance = 11630 },
+	{ id = 6299, chance = 11630 }, -- death ring
+	-- { name = "cuirass plate", chance = 10470 },
+	-- { name = "personal letter of adlerauge i", chance = 9300 },
+	{ name = "gold ingot", chance = 9300 },
+	{ name = "assassin dagger", chance = 8140 },
+	{ name = "dark armor", chance = 8140 },
+	-- { name = "salvaged silver parts", chance = 6980 },
+	{ name = "violet gem", chance = 6980 },
+	{ name = "white gem", chance = 3490 },
+	{ name = "red quiver", chance = 3490 },
+	{ name = "strange helmet", chance = 3490 },
+	{ name = "terra mantle", chance = 3490 },
+	{ name = "ornate crossbow", chance = 3490 },
+	{ name = "composite hornbow", chance = 2330 },
+	{ name = "crystalline arrow", chance = 1160, maxCount = 30 },
+	-- { name = "personal letter of adlerauge ii", chance = 4170 }, -- Not confirmed
+	-- { name = "personal letter of adlerauge iii", chance = 2080 }, -- Not confirmed
+	-- { name = "stag shield refinement plans", chance = 5000 }, -- Not confirmed
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -900 }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -600, maxDamage = -1100, range = 5, shootEffect = CONST_ANI_ROYALSPEAR, target = true }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -500, maxDamage = -950, length = 6, spread = 2, effect = CONST_ME_ENERGYHIT, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_PHYSICALDAMAGE, minDamage = -700, maxDamage = -1200, radius = 4, effect = CONST_ME_EXPLOSIONHIT, target = true }, -- Not confirmed
+	{ name = "speed", interval = 4000, chance = 12, speedChange = -400, radius = 5, effect = CONST_ME_POFF, target = false, duration = 8000 }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 85, -- Not confirmed
+	armor = 85, -- Not confirmed
+	mitigation = 2.50, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_HEALING, minDamage = 800, maxDamage = 1500, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/adventurer_group.lua
+++ b/data/monsters/winter_update_2025/bosses/adventurer_group.lua
@@ -1,0 +1,130 @@
+local mType = Game.createMonsterType("Adventurer Group")
+local monster = {}
+
+monster.name = "Adventurer Group"
+monster.description = "an adventurer group"
+monster.experience = 100000
+monster.outfit = {
+	lookTypeEx = 52836,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2773,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+}
+
+monster.health = 80000
+monster.maxHealth = 80000
+monster.race = "blood"
+monster.corpse = 52836 -- Not confirmed
+monster.speed = 175
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 3000, -- Not confirmed
+	chance = 20, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 60, -- Not confirmed
+	health = 20, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 85, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "Together we are unstoppable!", yell = true }, -- Not confirmed
+	{ text = "Cover me, allies!", yell = false }, -- Not confirmed
+	{ text = "For glory and treasure!", yell = true }, -- Not confirmed
+	{ text = "Work together, team!", yell = false }, -- Not confirmed
+	{ text = "No beast can defeat us united!", yell = true }, -- Not confirmed
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, maxCount = 60 }, -- Not confirmed
+	{ name = "crystal coin", chance = 35000, maxCount = 5 }, -- Not confirmed
+	{ name = "gold ingot", chance = 25000, maxCount = 3 }, -- Not confirmed
+	{ name = "blue gem", chance = 18000 }, -- Not confirmed
+	{ name = "green gem", chance = 16000 }, -- Not confirmed
+	{ name = "violet gem", chance = 14000 }, -- Not confirmed
+	{ name = "yellow gem", chance = 12000 }, -- Not confirmed
+	{ id = 3039, chance = 10000 }, -- red gem (não confirmado)
+	{ name = "crown armor", chance = 5000 }, -- Not confirmed
+	{ name = "crown shield", chance = 5500 }, -- Not confirmed
+	{ name = "crown helmet", chance = 4500 }, -- Not confirmed
+	{ name = "crown legs", chance = 4000 }, -- Not confirmed
+	{ name = "mastermind shield", chance = 2000 }, -- Not confirmed
+	{ name = "great shield", chance = 1500 }, -- Not confirmed
+	{ name = "giant sword", chance = 3000 }, -- Not confirmed
+	{ name = "magic longsword", chance = 2500 }, -- Not confirmed
+	{ name = "small diamond", chance = 30000, maxCount = 5 }, -- Not confirmed
+	{ name = "small ruby", chance = 28000, maxCount = 5 }, -- Not confirmed
+	{ name = "small sapphire", chance = 26000, maxCount = 5 }, -- Not confirmed
+	{ name = "small emerald", chance = 24000, maxCount = 5 },
+	-- { name = "ancient crypt rune", chance = 100000 }, -- Not confirmed
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1000 }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 22, type = COMBAT_PHYSICALDAMAGE, minDamage = -700, maxDamage = -1300, range = 5, shootEffect = CONST_ANI_ARROW, target = true }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -600, maxDamage = -1100, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_HOLYDAMAGE, minDamage = -500, maxDamage = -900, radius = 4, effect = CONST_ME_HOLYAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -550, maxDamage = -1000, length = 6, spread = 2, effect = CONST_ME_ICEAREA, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 90, -- Not confirmed
+	armor = 90, -- Not confirmed
+	mitigation = 2.80, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_HEALING, minDamage = 1000, maxDamage = 2000, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+	{ name = "speed", interval = 4000, chance = 12, speedChange = 350, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 6000 }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/bone_overlord.lua
+++ b/data/monsters/winter_update_2025/bosses/bone_overlord.lua
@@ -1,0 +1,130 @@
+local mType = Game.createMonsterType("Bone Overlord")
+local monster = {}
+
+monster.name = "Bone Overlord"
+monster.description = "Bone Overlord"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 52831,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2771,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+	storageCooldown = 82070, -- Not confirmed
+}
+
+monster.health = 500000
+monster.maxHealth = 500000
+monster.race = "undead"
+monster.corpse = 44822 -- Not confirmed
+monster.speed = 200
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 3000, -- Not confirmed
+	chance = 25, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 60, -- Not confirmed
+	health = 15, -- Not confirmed
+	damage = 15, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = false,
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 0,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 4, -- Not confirmed
+	color = 30, -- Not confirmed
+}
+
+monster.summon = {
+	maxSummons = 4, -- Not confirmed
+	summons = {
+		{ name = "Spectral Eye", chance = 15, interval = 3000, count = 2 }, -- Not confirmed
+		{ name = "Restless Spirit", chance = 12, interval = 4000, count = 2 }, -- Not confirmed
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 15,
+	{ text = "ALL DRAGON SOULS BELONG TO ME!", yell = true },
+	{ text = "MY RULE OVER LIFE AND DEATH WILL BE UNCHALLENGED!", yell = true },
+	{ text = "THE SOULS ARE MINE!", yell = true },
+	{ text = "BY THE ELDRITCH POWERS THAT I COMMAND - I WILL CRUSH YOU!", yell = true },
+	{ text = "BEHOLD THE LAST OF THE TRUE BONELORDS!", yell = true },
+	{ text = "I DON'T NEED THE SHIRON'FAL!", yell = true },
+	{ text = "YOU WILL SUFFER FOR THIS!", yell = true },
+	{ text = "DEATH AWAITS THOSE WHO DEFY ME!", yell = true },
+	{ text = "IN THE END VICTORY WILL BE MINE NONTHELESS!", yell = true },
+	{ text = "MY VICTORY WILL BE GLORIOUS!", yell = true },
+	{ text = "YOU PUNY CREATURES CAN'T STOP ME!", yell = true },
+}
+
+monster.loot = {
+	-- { name = "ancient scales", chance = 15000 },
+	-- { name = "soul trap", chance = 10000 },
+	-- { name = "necromantic crypt rune", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1200 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_DEATHDAMAGE, minDamage = -900, maxDamage = -1800, range = 7, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 22, type = COMBAT_ENERGYDAMAGE, minDamage = -800, maxDamage = -1600, radius = 6, effect = CONST_ME_ENERGYAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = -700, maxDamage = -1400, length = 8, spread = 3, effect = CONST_ME_ICEATTACK, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_DEATHDAMAGE, minDamage = -1000, maxDamage = -2000, radius = 5, effect = CONST_ME_DRAWBLOOD, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -600, maxDamage = -1200, radius = 4, effect = CONST_ME_MAGIC_RED, target = false }, -- Not confirmed
+	{ name = "speed", interval = 4000, chance = 12, speedChange = -500, radius = 6, effect = CONST_ME_POFF, target = false, duration = 10000 }, -- Not confirmed
+	{ name = "condition", type = CONDITION_CURSED, interval = 5000, chance = 10, minDamage = -200, maxDamage = -400, radius = 5, effect = CONST_ME_BLACKSMOKE, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 100, -- Not confirmed
+	armor = 100, -- Not confirmed
+	mitigation = 3.50, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 20, type = COMBAT_HEALING, minDamage = 2000, maxDamage = 4000, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+	{ name = "speed", interval = 5000, chance = 10, speedChange = 400, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 5000 }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/clavius.lua
+++ b/data/monsters/winter_update_2025/bosses/clavius.lua
@@ -1,0 +1,146 @@
+local mType = Game.createMonsterType("Clavius")
+local monster = {}
+
+monster.name = "Clavius"
+monster.description = "Clavius"
+monster.experience = 75000
+monster.outfit = {
+	lookType = 1902,
+	lookHead = 94,
+	lookBody = 19,
+	lookLegs = 36,
+	lookFeet = 56,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2755,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 40000
+monster.maxHealth = 40000
+monster.race = "undead"
+monster.corpse = 52857
+monster.speed = 175
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000, -- Not confirmed
+	chance = 15, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 2, -- Not confirmed
+	color = 45, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Never will I let your agression stand!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, maxCount = 50 },
+	{ id = 3039, chance = 33070 }, -- red gem
+	{ name = "yellow gem", chance = 29920 },
+	{ name = "small ruby", chance = 23620, maxCount = 5 },
+	{ name = "crystal coin", chance = 22830, maxCount = 10 },
+	{ name = "small diamond", chance = 22050, maxCount = 5 },
+	{ id = 6299, chance = 21260 }, -- death ring
+	{ name = "small sapphire", chance = 20470, maxCount = 5 },
+	{ name = "black pearl", chance = 18110 },
+	-- { name = "cuirass plate", chance = 17320 },
+	-- { name = "battle tactics", chance = 16540 },
+	{ name = "green gem", chance = 15750 },
+	{ name = "dark armor", chance = 14170 },
+	{ name = "white pearl", chance = 12600 },
+	{ name = "blue gem", chance = 11810 },
+	{ name = "wand of cosmic energy", chance = 10240 },
+	-- { name = "silver poniard", chance = 9450 },
+	-- { name = "stag parchment", chance = 9450 },
+	{ id = 3059, chance = 7870 }, -- spellbook
+	{ name = "gold ingot", chance = 7090 },
+	-- { name = "repair kit for boats", chance = 7090 },
+	{ name = "strange helmet", chance = 5510 },
+	{ name = "white gem", chance = 5510 },
+	{ name = "wand of starstorm", chance = 4720 },
+	{ name = "clerical mace", chance = 3940 },
+	{ name = "terra hood", chance = 3940 },
+	{ name = "magma monocle", chance = 2360 },
+	{ name = "violet gem", chance = 2360 },
+	{ name = "wooden spellbook", chance = 1570 },
+	{ name = "lightning robe", chance = 790 },
+	{ name = "shockwave amulet", chance = 790 },
+	{ name = "magma amulet", chance = 790 }, -- Not confirmed
+	-- { name = "salvaged iron parts", chance = 7740 },
+	-- { name = "personal letter of clavius i", chance = 8330 },
+	-- { name = "personal letter of clavius ii", chance = 4170 },
+	-- { name = "personal letter of clavius iii", chance = 2080 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -950 }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 24, type = COMBAT_DEATHDAMAGE, minDamage = -600, maxDamage = -1100, range = 6, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -700, maxDamage = -1200, radius = 4, effect = CONST_ME_GROUNDSHAKER, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_DEATHDAMAGE, minDamage = -550, maxDamage = -1000, length = 6, spread = 2, effect = CONST_ME_BLACKSMOKE, target = false }, -- Not confirmed
+	{ name = "condition", type = CONDITION_CURSED, interval = 4000, chance = 12, minDamage = -150, maxDamage = -300, radius = 4, effect = CONST_ME_BLACKSMOKE, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 88, -- Not confirmed
+	armor = 88, -- Not confirmed
+	mitigation = 2.60, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_HEALING, minDamage = 900, maxDamage = 1600, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/court_warlock.lua
+++ b/data/monsters/winter_update_2025/bosses/court_warlock.lua
@@ -1,0 +1,162 @@
+local mType = Game.createMonsterType("Court Warlock")
+local monster = {}
+
+monster.name = "Court Warlock"
+monster.description = "a court warlock"
+monster.experience = 147000
+monster.outfit = {
+	lookType = 1903,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 1,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2741,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "blood"
+monster.corpse = 52696
+monster.speed = 170
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 3500, -- Not confirmed
+	chance = 18, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 60, -- Not confirmed
+	health = 15, -- Not confirmed
+	damage = 15, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 85, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 500, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 3, -- Not confirmed
+	color = 60, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I welcome you, towitness the spectacular destruction of the outside menace that cost so many of your dear bretheren's lives!", yell = false },
+	{ text = "You're just flies in my bed-chamber.", yell = false },
+	{ text = "Oh? Maybe it shold get a little more COSY IN HERE!", yell = true },
+	{ text = "Enough of this! Stop gawking and GET OVER THERE TO FINIFH IT!", yell = true },
+	{ text = "DO I REALLY HAVE TO DO EVERYTHING... EEEVERYTHIIING MYSELF!", yell = true },
+	{ text = "Your medding with my affairs was a grave mistake!", yell = false },
+	{ text = "NO, not like this, not without... NOOO!!!", yell = true },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, maxCount = 100 },
+	{ name = "crystal coin", chance = 100000, maxCount = 2 },
+	{ id = 3039, chance = 56250, maxCount = 3 }, -- red gem
+	{ name = "great spirit potion", chance = 50000, maxCount = 30 },
+	{ name = "yellow gem", chance = 43750, maxCount = 4 },
+	{ name = "blue gem", chance = 43750, maxCount = 2 },
+	{ name = "ultimate mana potion", chance = 37500, maxCount = 39 },
+	{ name = "great mana potion", chance = 37500, maxCount = 30 },
+	{ name = "supreme health potion", chance = 37500, maxCount = 8 },
+	{ name = "strong mana potion", chance = 31250, maxCount = 25 },
+	{ name = "ultimate health potion", chance = 31250, maxCount = 16 },
+	{ name = "wooden spellbook", chance = 31250 },
+	{ id = 6299, chance = 31250 }, -- death ring
+	{ name = "mind stone", chance = 25000 },
+	{ name = "skull staff", chance = 18750 },
+	{ name = "magma coat", chance = 18750 },
+	{ name = "giant sapphire", chance = 18750 },
+	{ name = "wand of defiance", chance = 18750 },
+	{ name = "ultimate spirit potion", chance = 12500, maxCount = 11 },
+	{ name = "giant ruby", chance = 12500 },
+	{ name = "lightning robe", chance = 12500 },
+	{ name = "might ring", chance = 12500 },
+	{ name = "terra mantle", chance = 12500 },
+	{ name = "glacier robe", chance = 6250 },
+	{ name = "terra hood", chance = 6250 },
+	{ name = "lightning headband", chance = 6250 },
+	{ name = "giant amethyst", chance = 5000 }, -- Not confirmed
+	{ name = "giant emerald", chance = 5000 }, -- Not confirmed
+	{ id = 37335, chance = 5000 }, -- black skull (não confirmado)
+	{ name = "magma monocle", chance = 5000 }, -- Not confirmed
+	{ name = "glacier mask", chance = 5000 }, -- Not confirmed
+	-- { name = "broken staff of mind control", chance = 5000 }, -- Not confirmed
+	-- { name = "twisted marionette", chance = 5000 }, -- Not confirmed
+	-- { name = "stag shinguards", chance = 3000 }, -- Not confirmed
+	-- { name = "stag boots", chance = 3000 }, -- Not confirmed
+	-- { name = "stag footwraps", chance = 3000 }, -- Not confirmed
+	-- { name = "stag scrolls", chance = 3000 }, -- Not confirmed
+	-- { name = "stag spellbook", chance = 3000 }, -- Not confirmed
+	-- { name = "stag shield", chance = 3000 }, -- Not confirmed
+	-- { name = "stag helmet", chance = 3000 }, -- Not confirmed
+	-- { name = "stag legs", chance = 3000 }, -- Not confirmed
+	-- { name = "stag plate", chance = 3000 }, -- Not confirmed
+	-- { name = "stag robe", chance = 3000 }, -- Not confirmed
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -700 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 28, type = COMBAT_FIREDAMAGE, minDamage = -700, maxDamage = -1300, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -650, maxDamage = -1200, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 22, type = COMBAT_DEATHDAMAGE, minDamage = -600, maxDamage = -1100, radius = 5, effect = CONST_ME_MORTAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_FIREDAMAGE, minDamage = -800, maxDamage = -1400, length = 7, spread = 2, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -700, maxDamage = -1250, radius = 4, effect = CONST_ME_ENERGYAREA, target = false }, -- Not confirmed
+	{ name = "condition", type = CONDITION_FIRE, interval = 4000, chance = 12, minDamage = -200, maxDamage = -350, radius = 4, effect = CONST_ME_HITBYFIRE, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 75, -- Not confirmed
+	armor = 80, -- Not confirmed
+	mitigation = 2.40, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 18, type = COMBAT_HEALING, minDamage = 1000, maxDamage = 1800, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+	{ name = "invisible", interval = 6000, chance = 8, effect = CONST_ME_MAGIC_RED }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/eldritch_dragon_lord.lua
+++ b/data/monsters/winter_update_2025/bosses/eldritch_dragon_lord.lua
@@ -1,0 +1,161 @@
+local mType = Game.createMonsterType("Eldritch Dragon Lord")
+local monster = {}
+
+monster.name = "Eldritch Dragon Lord"
+monster.description = "an eldritch dragon lord"
+monster.experience = 750000
+monster.outfit = {
+	lookType = 1879,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2739,
+	bossRace = RARITY_ARCHFOE,
+	storageCooldown = 82071, -- Not confirmed
+}
+
+monster.health = 350000
+monster.maxHealth = 350000
+monster.race = "blood"
+monster.corpse = 44828 -- Not confirmed
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 3000, -- Not confirmed
+	chance = 20, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 60, -- Not confirmed
+	health = 20, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 3, -- Not confirmed
+	summons = {
+		{ name = "Eruption", chance = 12, interval = 4000, count = 2 }, -- Not confirmed
+		{ name = "Flame Totem", chance = 10, interval = 5000, count = 1 }, -- Not confirmed
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 12,
+	{ text = "THIS HOARD IS MINE NOW!", yell = true },
+	{ text = "ALL MIIINE!", yell = true },
+	{ text = "RISE UP MY COMPANIONS!!!", yell = true },
+	{ text = "RISE UP MY FELLOWS!!!", yell = true },
+	{ text = "THIEFS!", yell = true },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 100000, maxCount = 61 },
+	{ name = "dragon ham", chance = 50000, maxCount = 4 }, -- Not confirmed
+	{ name = "strong mana potion", chance = 54550, maxCount = 93 }, -- Not confirmed
+	{ name = "great mana potion", chance = 54550, maxCount = 69 },
+	{ name = "great spirit potion", chance = 54550, maxCount = 57 },
+	{ name = "ultimate mana potion", chance = 45450, maxCount = 24 },
+	{ name = "ultimate spirit potion", chance = 63640, maxCount = 25 },
+	{ name = "ultimate health potion", chance = 54550, maxCount = 37 },
+	{ name = "supreme health potion", chance = 54550, maxCount = 18 },
+	{ id = 3039, chance = 36360, maxCount = 9 }, -- red gem
+	{ name = "yellow gem", chance = 27270, maxCount = 8 },
+	{ name = "blue gem", chance = 18180, maxCount = 3 },
+	{ name = "giant ruby", chance = 9090, maxCount = 2 },
+	{ name = "giant amethyst", chance = 9090 }, -- Not confirmed
+	{ name = "giant emerald", chance = 9090 },
+	{ name = "guardian gem", chance = 5000 }, -- Not confirmed
+	{ name = "marksman gem", chance = 5000 }, -- Not confirmed
+	{ name = "mystic gem", chance = 5000 }, -- Not confirmed
+	{ name = "sage gem", chance = 5000 }, -- Not confirmed
+	{ name = "spiritualist gem", chance = 5000 }, -- Not confirmed
+	{ name = "greater guardian gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater marksman gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater mystic gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater sage gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater spiritualist gem", chance = 3000 }, -- Not confirmed
+	{ name = "dragon tongue", chance = 10000 }, -- Not confirmed
+	-- { name = "golden claw", chance = 5000 }, -- Not confirmed
+	-- { name = "cryptic fossil", chance = 5000 }, -- Not confirmed
+	-- { name = "fetid heart", chance = 5000 }, -- Not confirmed
+	{ name = "dragonbone staff", chance = 5000 }, -- Not confirmed
+	{ name = "dragon shield", chance = 5000 }, -- Not confirmed
+	{ name = "wand of inferno", chance = 5000 }, -- Not confirmed
+	{ name = "fire sword", chance = 5000 }, -- Not confirmed
+	{ name = "dragon slayer", chance = 27270 }, -- Not confirmed
+	-- { name = "fiery crypt rune", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1400 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 28, type = COMBAT_FIREDAMAGE, minDamage = -1000, maxDamage = -1800, length = 10, spread = 3, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 24, type = COMBAT_ENERGYDAMAGE, minDamage = -800, maxDamage = -1500, radius = 6, effect = CONST_ME_PURPLEENERGY, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -900, maxDamage = -1600, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_ENERGYDAMAGE, minDamage = -700, maxDamage = -1300, length = 8, spread = 2, effect = CONST_ME_ENERGYHIT, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -1100, maxDamage = -2000, radius = 7, effect = CONST_ME_EXPLOSIONAREA, target = false }, -- Not confirmed
+	{ name = "condition", type = CONDITION_FIRE, interval = 4000, chance = 12, minDamage = -300, maxDamage = -500, radius = 5, effect = CONST_ME_HITBYFIRE, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 95, -- Not confirmed
+	armor = 95, -- Not confirmed
+	mitigation = 3.20, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_HEALING, minDamage = 1500, maxDamage = 3000, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+	{ name = "speed", interval = 5000, chance = 10, speedChange = 400, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 5000 }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/fiona_firstdream.lua
+++ b/data/monsters/winter_update_2025/bosses/fiona_firstdream.lua
@@ -1,0 +1,113 @@
+local mType = Game.createMonsterType("Fiona Firstdream")
+local monster = {}
+
+monster.name = "Fiona Firstdream"
+monster.description = "Fiona Firstdream"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1681,
+	lookHead = 92,
+	lookBody = 91,
+	lookLegs = 94,
+	lookFeet = 79,
+	lookAddons = 3,
+}
+
+monster.health = 155000
+monster.maxHealth = 155000
+monster.race = "blood"
+monster.corpse = 6081
+monster.speed = 125
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2715,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false,
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 4, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "I'll burn you to a crisp!", yell = false },
+	{ text = "You look shockingly flammable!", yell = false },
+	{ text = "You're playing with FIRE!", yell = false },
+	{ text = "Mana low? That's cute.", yell = false },
+	{ text = "Your death is only a matter of time!", yell = false },
+	{ text = "This is outrageous, I quit!", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -400, maxDamage = -650, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_ICEDAMAGE, minDamage = -350, maxDamage = -600, length = 6, spread = 3, effect = CONST_ME_ICEATTACK, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -500, maxDamage = -800, radius = 4, effect = CONST_ME_ENERGYAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_ICEDAMAGE, minDamage = -300, maxDamage = -550, range = 7, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEAREA, target = true }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 80, -- Not confirmed
+	armor = 80, -- Not confirmed
+	mitigation = 2.10, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 400, maxDamage = 700, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/grendel_greenlunch.lua
+++ b/data/monsters/winter_update_2025/bosses/grendel_greenlunch.lua
@@ -1,0 +1,114 @@
+local mType = Game.createMonsterType("Grendel Greenlunch")
+local monster = {}
+
+monster.name = "Grendel Greenlunch"
+monster.description = "Grendel Greenlunch"
+monster.experience = 0
+monster.outfit = {
+	lookType = 144,
+	lookHead = 22,
+	lookBody = 62,
+	lookLegs = 101,
+	lookFeet = 58,
+	lookAddons = 3,
+}
+
+monster.health = 155000
+monster.maxHealth = 155000
+monster.race = "blood"
+monster.corpse = 6081
+monster.speed = 120
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2714,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false,
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 4, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "As long as I live, my friends have nothing to fear.", yell = false },
+	{ text = "Let me invoke the fear of nature in you!", yell = false },
+	{ text = "Let's kill those noobs an' loot 'em!", yell = false },
+	{ text = "Nature heals.", yell = false },
+	{ text = "Don't worry, I'll heal you!", yell = false },
+	{ text = "You woke the beast, now deal with it!", yell = false },
+	{ text = "I'm out of there!", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -450, maxDamage = -700, range = 7, shootEffect = CONST_ANI_EARTH, effect = CONST_ME_CARNIPHILA, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_EARTHDAMAGE, minDamage = -400, maxDamage = -650, length = 7, spread = 3, effect = CONST_ME_POISONAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -550, maxDamage = -850, radius = 5, effect = CONST_ME_BIGPLANTS, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_LIFEDRAIN, minDamage = -300, maxDamage = -500, radius = 4, effect = CONST_ME_MAGIC_GREEN, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 85, -- Not confirmed
+	armor = 85, -- Not confirmed
+	mitigation = 2.20, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 18, type = COMBAT_HEALING, minDamage = 500, maxDamage = 800, effect = CONST_ME_MAGIC_GREEN, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/ice_horror.lua
+++ b/data/monsters/winter_update_2025/bosses/ice_horror.lua
@@ -1,0 +1,165 @@
+local mType = Game.createMonsterType("Ice Horror")
+local monster = {}
+
+monster.name = "Ice Horror"
+monster.description = "an ice horror"
+monster.experience = 259000
+monster.outfit = {
+	lookType = 1881,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2733,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+	storageCooldown = 82072, -- Not confirmed
+}
+
+monster.health = 550000
+monster.maxHealth = 550000
+monster.race = "undead"
+monster.corpse = 44830 -- Not confirmed
+monster.speed = 180
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 3000, -- Not confirmed
+	chance = 22, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 65, -- Not confirmed
+	health = 15, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 4, -- Not confirmed
+	summons = {
+		{ name = "Ice Blockade", chance = 15, interval = 4000, count = 2 }, -- Not confirmed
+		{ name = "Ice Crawler", chance = 12, interval = 5000, count = 2 }, -- Not confirmed
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 12,
+	{ text = "COME HERE!!!", yell = true },
+	{ text = "KRRRRK!", yell = true },
+	{ text = "<SHATER>!", yell = true },
+	{ text = "C'HHRRR!", yell = true },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 100000, maxCount = 51 },
+	{ name = "yellow gem", chance = 50000, maxCount = 10 }, -- Not confirmed
+	{ name = "strong mana potion", chance = 50000, maxCount = 95 }, -- Not confirmed
+	{ name = "great mana potion", chance = 50000, maxCount = 69 }, -- Not confirmed
+	{ name = "great spirit potion", chance = 50000, maxCount = 53 }, -- Not confirmed
+	{ name = "ultimate mana potion", chance = 41670, maxCount = 25 }, -- Not confirmed
+	{ name = "ultimate spirit potion", chance = 41670, maxCount = 23 }, -- Not confirmed
+	{ name = "ultimate health potion", chance = 41670, maxCount = 38 }, -- Not confirmed
+	{ name = "supreme health potion", chance = 41670, maxCount = 15 }, -- Not confirmed
+	{ name = "blue gem", chance = 25000, maxCount = 3 }, -- Not confirmed
+	{ id = 3039, chance = 25000, maxCount = 7 }, -- red gem (não confirmado)
+	{ name = "giant ruby", chance = 10000, maxCount = 2 }, -- Not confirmed
+	{ name = "giant emerald", chance = 10000 }, -- Not confirmed
+	{ name = "giant sapphire", chance = 10000, maxCount = 3 }, -- Not confirmed
+	{ name = "guardian gem", chance = 5000 }, -- Not confirmed
+	{ name = "marksman gem", chance = 5000 }, -- Not confirmed
+	{ name = "mystic gem", chance = 5000 }, -- Not confirmed
+	{ name = "sage gem", chance = 5000 }, -- Not confirmed
+	{ name = "spiritualist gem", chance = 5000 }, -- Not confirmed
+	{ name = "greater guardian gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater marksman gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater mystic gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater sage gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater spiritualist gem", chance = 3000 }, -- Not confirmed
+	{ id = 7441, chance = 10000 }, -- ice cube (não confirmado)
+	{ id = 2992, chance = 10000, maxCount = 6 }, -- snowball (não confirmado)
+	{ name = "frosty heart", chance = 8000 }, -- Not confirmed
+	{ id = 3007, chance = 5000 }, -- crystal ring (não confirmado)
+	{ name = "pair of earmuffs", chance = 5000 }, -- Not confirmed
+	{ name = "crystal mace", chance = 5000 }, -- Not confirmed
+	{ name = "glacier mask", chance = 5000 }, -- Not confirmed
+	{ name = "glacial rod", chance = 5000 }, -- Not confirmed
+	{ name = "ice rapier", chance = 5000 },
+	-- { name = "cryptic fossil", chance = 5000 }, -- Not confirmed
+	-- { name = "fetid heart", chance = 5000 }, -- Not confirmed
+	-- { name = "frozen crapace", chance = 5000 },
+	{ id = 52729, chance = 3000 }, -- frozen claw (não confirmado)
+	-- { name = "icy scales", chance = 5000 },
+	-- { name = "icy horns", chance = 5000 },
+	-- { name = "icy crypt rune", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1200 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 28, type = COMBAT_ICEDAMAGE, minDamage = -900, maxDamage = -1700, length = 9, spread = 3, effect = CONST_ME_ICEAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 24, type = COMBAT_ICEDAMAGE, minDamage = -800, maxDamage = -1500, radius = 6, effect = CONST_ME_ICEATTACK, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = -700, maxDamage = -1400, range = 7, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_ICEDAMAGE, minDamage = -850, maxDamage = -1600, length = 7, spread = 2, effect = CONST_ME_GIANTICE, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -1000, maxDamage = -1800, radius = 5, effect = CONST_ME_BIGCLOUDS, target = false }, -- Not confirmed
+	{ name = "speed", interval = 4000, chance = 15, speedChange = -600, radius = 6, effect = CONST_ME_ICEAREA, target = false, duration = 12000 }, -- Not confirmed
+	{ name = "condition", type = CONDITION_FREEZING, interval = 4500, chance = 12, minDamage = -200, maxDamage = -400, radius = 5, effect = CONST_ME_ICEATTACK, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 92, -- Not confirmed
+	armor = 92, -- Not confirmed
+	mitigation = 3.00, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_HEALING, minDamage = 1200, maxDamage = 2500, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/michael_the_stalwart.lua
+++ b/data/monsters/winter_update_2025/bosses/michael_the_stalwart.lua
@@ -1,0 +1,145 @@
+local mType = Game.createMonsterType("Michael the Stalwart")
+local monster = {}
+
+monster.name = "Michael the Stalwart"
+monster.description = "Michael the Stalwart"
+monster.experience = 75000
+monster.outfit = {
+	lookType = 1900,
+	lookHead = 94,
+	lookBody = 31,
+	lookLegs = 19,
+	lookFeet = 38,
+	lookAddons = 3,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2753,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 60000
+monster.maxHealth = 60000
+monster.race = "blood"
+monster.corpse = 44832 -- Not confirmed
+monster.speed = 190
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 3500, -- Not confirmed
+	chance = 20, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Fight me, outsider!", yell = false },
+	{ text = "You think you have this under control?", yell = false },
+	{ text = "This will be the end of you", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, maxCount = 50 },
+	{ id = 3039, chance = 34000 }, -- red gem
+	{ name = "yellow gem", chance = 29330 },
+	{ name = "small ruby", chance = 20670, maxCount = 5 },
+	-- { name = "repair kit for boats", chance = 19330 },
+	{ name = "small sapphire", chance = 19330, maxCount = 5 },
+	{ id = 6299, chance = 18670 }, -- death ring
+	{ name = "small diamond", chance = 18670, maxCount = 5 },
+	{ name = "black pearl", chance = 18000 },
+	{ name = "green gem", chance = 17330 },
+	{ name = "dark armor", chance = 16000 },
+	-- { name = "cuirass plate", chance = 14000 },
+	{ name = "white pearl", chance = 14000 },
+	{ id = 3091, chance = 12670 }, -- sword ring
+	-- { name = "silver poniard", chance = 11330 },
+	{ name = "blue gem", chance = 10000 },
+	-- { name = "personal letter of michael the stalwart i", chance = 10000 },
+	{ name = "gold ingot", chance = 9330 },
+	{ name = "dark shield", chance = 8670 },
+	{ name = "violet gem", chance = 6670 },
+	-- { name = "salvaged bronze parts", chance = 6000 },
+	{ name = "fur armor", chance = 4670 },
+	{ name = "mercenary sword", chance = 4000 },
+	{ name = "strange helmet", chance = 4000 },
+	{ name = "terra legs", chance = 2670 },
+	{ name = "white gem", chance = 2670 },
+	{ name = "crown shield", chance = 1330 },
+	{ name = "crystalline armor", chance = 1330 },
+	{ name = "crown armor", chance = 670 },
+	-- { name = "personal letter of michael the stalwart ii", chance = 670 },
+	-- { name = "personal letter of michael the stalwart iii", chance = 670 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1100 }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -800, maxDamage = -1400, radius = 4, effect = CONST_ME_GROUNDSHAKER, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 22, type = COMBAT_HOLYDAMAGE, minDamage = -600, maxDamage = -1200, range = 5, shootEffect = CONST_ANI_HOLY, effect = CONST_ME_HOLYAREA, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -700, maxDamage = -1300, length = 6, spread = 2, effect = CONST_ME_HITAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 18, type = COMBAT_HOLYDAMAGE, minDamage = -650, maxDamage = -1150, radius = 5, effect = CONST_ME_HOLYAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 4000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = -900, maxDamage = -1500, radius = 3, effect = CONST_ME_EXPLOSIONHIT, target = true }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 92, -- Not confirmed
+	armor = 92, -- Not confirmed
+	mitigation = 2.80, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 18, type = COMBAT_HEALING, minDamage = 1100, maxDamage = 2000, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+	{ name = "speed", interval = 5000, chance = 12, speedChange = 350, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 6000 }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/nigel_neverguess.lua
+++ b/data/monsters/winter_update_2025/bosses/nigel_neverguess.lua
@@ -1,0 +1,114 @@
+local mType = Game.createMonsterType("Nigel Neverguess")
+local monster = {}
+
+monster.name = "Nigel Neverguess"
+monster.description = "Nigel Neverguess"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1837,
+	lookHead = 38,
+	lookBody = 4,
+	lookLegs = 8,
+	lookFeet = 11,
+	lookAddons = 3,
+}
+
+monster.health = 155000
+monster.maxHealth = 155000
+monster.race = "blood"
+monster.corpse = 6081
+monster.speed = 130
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2716,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 4, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "Sorry, I'm late guys.", yell = false },
+	{ text = "I don't need weapons to beat you up!", yell = false },
+	{ text = "Embrace harmony!", yell = false },
+	{ text = "You meditate, I devastate.", yell = false },
+	{ text = "Your balance is off!", yell = false },
+	{ text = "I'll show you what inner balance looks like!", yell = false },
+	{ text = "Last one in, first one out! Sorry guys!", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -320 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_ENERGYDAMAGE, minDamage = -350, maxDamage = -600, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_DEATHDAMAGE, minDamage = -400, maxDamage = -650, length = 5, spread = 3, effect = CONST_ME_MORTAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -450, maxDamage = -700, radius = 4, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_ICEDAMAGE, minDamage = -300, maxDamage = -500, range = 7, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEAREA, target = true }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 75, -- Not confirmed
+	armor = 75, -- Not confirmed
+	mitigation = 2.00, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_HEALING, minDamage = 350, maxDamage = 600, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/overseer_osverger.lua
+++ b/data/monsters/winter_update_2025/bosses/overseer_osverger.lua
@@ -1,0 +1,153 @@
+local mType = Game.createMonsterType("Overseer Osverger")
+local monster = {}
+
+monster.name = "Overseer Osverger"
+monster.description = "Overseer Osverger"
+monster.experience = 75000
+monster.outfit = {
+	lookType = 1902,
+	lookHead = 114,
+	lookBody = 76,
+	lookLegs = 57,
+	lookFeet = 57,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2756,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 75000
+monster.maxHealth = 75000
+monster.race = "blood"
+monster.corpse = 52861
+monster.speed = 175
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000, -- Not confirmed
+	chance = 15, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.summon = {
+	maxSummons = 2, -- Not confirmed
+	summons = {
+		{ name = "Raubritter", chance = 15, interval = 6000, count = 2 }, -- Not confirmed
+	},
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "Raubritters, to me!", yell = true }, -- Not confirmed
+	{ text = "You will not disrupt my operations!", yell = false }, -- Not confirmed
+	{ text = "I oversee your destruction!", yell = true }, -- Not confirmed
+	{ text = "Fall in line or fall in battle!", yell = false }, -- Not confirmed
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, maxCount = 50 },
+	{ name = "yellow gem", chance = 36670 },
+	{ id = 3039, chance = 30000 }, -- red gem
+	-- { name = "battle tactics", chance = 28330 },
+	{ name = "crystal coin", chance = 25830, maxCount = 10 },
+	{ name = "small sapphire", chance = 24170, maxCount = 5 },
+	{ name = "dark armor", chance = 22500 },
+	{ name = "small diamond", chance = 20000, maxCount = 5 },
+	{ name = "small ruby", chance = 20000, maxCount = 5 },
+	{ name = "white pearl", chance = 16670 },
+	{ name = "black pearl", chance = 14170 },
+	-- { name = "repair kit for boats", chance = 14170 },
+	-- { name = "stag parchment", chance = 14170 },
+	{ name = "blue gem", chance = 11670 },
+	{ name = "green gem", chance = 11670 },
+	{ id = 6299, chance = 10000 }, -- death ring
+	-- { name = "silver poniard", chance = 9170 },
+	{ name = "wand of cosmic energy", chance = 9170 },
+	{ name = "white gem", chance = 7500 },
+	{ id = 3059, chance = 6670 }, -- spellbook
+	{ name = "gold ingot", chance = 5000 },
+	{ name = "strange helmet", chance = 5000 },
+	{ name = "wand of starstorm", chance = 5000 },
+	{ name = "terra hood", chance = 4170 },
+	{ name = "clerical mace", chance = 3330 },
+	{ name = "wooden spellbook", chance = 3330 }, -- Not confirmed
+	{ name = "magma monocle", chance = 2500 },
+	{ name = "violet gem", chance = 2500 },
+	{ name = "terra helmet", chance = 2000 }, -- Not confirmed
+	{ name = "lightning robe", chance = 1670 },
+	{ name = "magma amulet", chance = 1670 }, -- Not confirmed
+	{ name = "shockwave amulet", chance = 1670 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -950 }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 24, type = COMBAT_PHYSICALDAMAGE, minDamage = -650, maxDamage = -1150, radius = 4, effect = CONST_ME_GROUNDSHAKER, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -550, maxDamage = -1000, range = 6, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 18, type = COMBAT_PHYSICALDAMAGE, minDamage = -700, maxDamage = -1200, length = 6, spread = 2, effect = CONST_ME_HITAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -600, maxDamage = -1100, radius = 4, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+	{ name = "speed", interval = 4000, chance = 12, speedChange = -400, radius = 5, effect = CONST_ME_POFF, target = false, duration = 8000 }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 86, -- Not confirmed
+	armor = 86, -- Not confirmed
+	mitigation = 2.55, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 16, type = COMBAT_HEALING, minDamage = 850, maxDamage = 1500, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/percy_peacetinker.lua
+++ b/data/monsters/winter_update_2025/bosses/percy_peacetinker.lua
@@ -1,0 +1,111 @@
+local mType = Game.createMonsterType("Percy Peacetinker")
+local monster = {}
+
+monster.name = "Percy Peacetinker"
+monster.description = "Percy Peacetinker"
+monster.experience = 0
+monster.outfit = {
+	lookType = 137,
+	lookHead = 79,
+	lookBody = 31,
+	lookLegs = 101,
+	lookFeet = 130,
+	lookAddons = 3,
+}
+
+monster.health = 155000
+monster.maxHealth = 155000
+monster.race = "blood"
+monster.corpse = 6081
+monster.speed = 125
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2713,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 5, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "THE LOOT IS OURS!", yell = false },
+	{ text = "You won't get away with this!", yell = false },
+	{ text = "Let's see if you can dodge these holy arrows!", yell = false },
+	{ text = "Time to stock up on diamond arrows!", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -380 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -400, maxDamage = -700, range = 7, shootEffect = CONST_ANI_ROYALSPEAR, effect = CONST_ME_EXPLOSIONHIT, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_HOLYDAMAGE, minDamage = -350, maxDamage = -600, range = 7, shootEffect = CONST_ANI_HOLY, effect = CONST_ME_HOLYDAMAGE, target = true }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_HOLYDAMAGE, minDamage = -500, maxDamage = -750, radius = 4, effect = CONST_ME_HOLYAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_PHYSICALDAMAGE, minDamage = -450, maxDamage = -650, length = 6, spread = 2, effect = CONST_ME_EXPLOSIONHIT, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 82, -- Not confirmed
+	armor = 82, -- Not confirmed
+	mitigation = 2.15, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 450, maxDamage = 750, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/the_gravedigger.lua
+++ b/data/monsters/winter_update_2025/bosses/the_gravedigger.lua
@@ -1,0 +1,153 @@
+local mType = Game.createMonsterType("The Gravedigger")
+local monster = {}
+
+monster.name = "The Gravedigger"
+monster.description = "The Gravedigger"
+monster.experience = 750000
+monster.outfit = {
+	lookType = 1880,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2721,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.health = 65000
+monster.maxHealth = 65000
+monster.race = "undead"
+monster.corpse = 44836 -- Not confirmed
+monster.speed = 180
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000, -- Not confirmed
+	chance = 15, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1,
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 3, -- Not confirmed
+	summons = {
+		{ name = "Undead Minion", chance = 12, interval = 5000, count = 3 }, -- Not confirmed
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I am death!", yell = true },
+	{ text = "You shouldn't have meddeled with our affairs!", yell = false },
+	{ text = "Ahhhh! ... MORE... POWER!", yell = true },
+	{ text = "The master will be pleased with your demise!", yell = false },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 100000, maxCount = 54 },
+	{ name = "yellow gem", chance = 50000, maxCount = 9 }, -- Not confirmed
+	{ name = "strong mana potion", chance = 50000, maxCount = 96 }, -- Not confirmed
+	{ name = "great mana potion", chance = 40000, maxCount = 42 }, -- Not confirmed
+	{ name = "ultimate mana potion", chance = 40000, maxCount = 24 }, -- Not confirmed
+	{ name = "ultimate spirit potion", chance = 30000, maxCount = 20 }, -- Not confirmed
+	{ name = "ultimate health potion", chance = 30000, maxCount = 37 }, -- Not confirmed
+	{ name = "supreme health potion", chance = 30000, maxCount = 17 }, -- Not confirmed
+	{ id = 3039, chance = 25000, maxCount = 4 }, -- red gem (não confirmado)
+	{ name = "blue gem", chance = 15000, maxCount = 2 }, -- Not confirmed
+	{ name = "giant ruby", chance = 10000, maxCount = 2 }, -- Not confirmed
+	{ name = "guardian gem", chance = 5000 }, -- Not confirmed
+	{ name = "marksman gem", chance = 5000 }, -- Not confirmed
+	{ name = "mystic gem", chance = 5000 }, -- Not confirmed
+	{ name = "sage gem", chance = 5000 }, -- Not confirmed
+	{ name = "spiritualist gem", chance = 5000 }, -- Not confirmed
+	{ name = "greater guardian gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater marksman gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater mystic gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater sage gem", chance = 3000 }, -- Not confirmed
+	{ name = "greater spiritualist gem", chance = 3000 }, -- Not confirmed
+	{ name = "small flask of eyedrops", chance = 15000, maxCount = 2 }, -- Not confirmed
+	{ name = "bonelord eye", chance = 10000 }, -- Not confirmed
+	{ id = 3457, chance = 10000 }, -- shovel (não confirmado)
+	{ name = "terra rod", chance = 10000 }, -- Not confirmed
+	{ name = "necrotic rod", chance = 10000 }, -- Not confirmed
+	{ name = "bonelord shield", chance = 8000 }, -- Not confirmed
+	-- { name = "shrunken head", chance = 5000 }, -- Not confirmed
+	-- { name = "cryptic fossil", chance = 5000 }, -- Not confirmed
+	-- { name = "fetid heart", chance = 5000 }, -- Not confirmed
+	-- { name = "deathly crypt rune", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1050 }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 25, type = COMBAT_DEATHDAMAGE, minDamage = -700, maxDamage = -1300, range = 6, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 22, type = COMBAT_EARTHDAMAGE, minDamage = -600, maxDamage = -1150, radius = 5, effect = CONST_ME_POISONAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2800, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -650, maxDamage = -1200, length = 7, spread = 2, effect = CONST_ME_BLACKSMOKE, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3500, chance = 18, type = COMBAT_EARTHDAMAGE, minDamage = -550, maxDamage = -1100, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_GREEN_RINGS, target = true }, -- Not confirmed
+	{ name = "condition", type = CONDITION_CURSED, interval = 4000, chance = 12, minDamage = -180, maxDamage = -350, radius = 4, effect = CONST_ME_BLACKSMOKE, target = false }, -- Not confirmed
+	{ name = "condition", type = CONDITION_POISON, interval = 4500, chance = 10, minDamage = -150, maxDamage = -300, radius = 5, effect = CONST_ME_POISONAREA, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 90, -- Not confirmed
+	armor = 90, -- Not confirmed
+	mitigation = 2.70, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 17, type = COMBAT_HEALING, minDamage = 1000, maxDamage = 1800, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/bosses/yorik_youngbook.lua
+++ b/data/monsters/winter_update_2025/bosses/yorik_youngbook.lua
@@ -1,0 +1,112 @@
+local mType = Game.createMonsterType("Yorik Youngbook")
+local monster = {}
+
+monster.name = "Yorik Youngbook"
+monster.description = "Yorik Youngbook"
+monster.experience = 0
+monster.outfit = {
+	lookType = 268,
+	lookHead = 57,
+	lookBody = 77,
+	lookLegs = 79,
+	lookFeet = 114,
+	lookAddons = 3,
+}
+
+monster.health = 155000
+monster.maxHealth = 155000
+monster.race = "blood"
+monster.corpse = 6081
+monster.speed = 135
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.bosstiary = {
+	bossRaceId = 2712,
+	bossRace = RARITY_ARCHFOE, -- Not confirmed
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 4, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "What? How did they get in?", yell = false },
+	{ text = "Stand together, team!", yell = false },
+	{ text = "It's time to get serious!", yell = false },
+	{ text = "You swing like a rookie!", yell = false },
+	{ text = "Sorry, my guild needs me!", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_FIREDAMAGE, minDamage = -400, maxDamage = -700, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2500, chance = 18, type = COMBAT_ENERGYDAMAGE, minDamage = -450, maxDamage = -750, length = 6, spread = 3, effect = CONST_ME_ENERGYHIT, target = false }, -- Not confirmed
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -550, maxDamage = -850, radius = 5, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_ENERGYDAMAGE, minDamage = -350, maxDamage = -550, radius = 4, effect = CONST_ME_PURPLEENERGY, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 70, -- Not confirmed
+	armor = 70, -- Not confirmed
+	mitigation = 1.90, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_HEALING, minDamage = 300, maxDamage = 550, effect = CONST_ME_MAGIC_BLUE, target = false }, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/creepy_crawler.lua
+++ b/data/monsters/winter_update_2025/creepy_crawler.lua
@@ -1,0 +1,126 @@
+local mType = Game.createMonsterType("Creepy Crawler")
+local monster = {}
+
+monster.name = "Creepy Crawler"
+monster.description = "a creepy crawler"
+monster.experience = 23000
+monster.outfit = {
+	lookType = 1890,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2763
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 5000,
+	FirstUnlock = 200,
+	SecondUnlock = 2000,
+	CharmsPoints = 100,
+	Stars = 5,
+	Occurrence = 0,
+	Locations = "Unhallowed Crypt.",
+}
+
+monster.health = 27000
+monster.maxHealth = 27000
+monster.race = "undead"
+monster.corpse = 52575
+monster.speed = 260
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 39120 },
+	-- { name = "crystallized death", chance = 5190 },
+	-- { name = "giant tusk", chance = 5030 },
+	{ name = "cyan crystal fragment", chance = 4380, maxCount = 4 },
+	{ name = "blue crystal shard", chance = 3080, maxCount = 4 },
+	-- { name = "necromantic core", chance = 2270 },
+	{ name = "amber", chance = 1790 },
+	-- { name = "cluster of crystallized death", chance = 970 },
+	{ name = "blue gem", chance = 810, maxCount = 4 },
+	{ name = "amber with a bug", chance = 650 },
+	{ name = "amber with a dragonfly", chance = 650 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -300, maxDamage = -800 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -380, maxDamage = -800, spread = 5, effect = CONST_ME_WHITE_ENERGYPULSE, target = false },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_PHYSICALDAMAGE, minDamage = -400, maxDamage = -1200, range = 1, effect = CONST_ME_BIG_SCRATCH, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = -320, maxDamage = -1050, range = 7, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_SMALL_WHITE_ENERGYSHOCK, target = true },
+}
+
+monster.defenses = {
+	defense = 100,
+	armor = 100,
+	mitigation = 4.11,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 6 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 12 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -12 },
+	{ type = COMBAT_FIREDAMAGE, percent = -12 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 6 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -6 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 3 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/crypt_construct.lua
+++ b/data/monsters/winter_update_2025/crypt_construct.lua
@@ -1,0 +1,128 @@
+local mType = Game.createMonsterType("Crypt Construct")
+local monster = {}
+
+monster.name = "Crypt Construct"
+monster.description = "a crypt construct"
+monster.experience = 20500
+monster.outfit = {
+	lookType = 1887,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2760
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 5000,
+	FirstUnlock = 200,
+	SecondUnlock = 2000,
+	CharmsPoints = 100,
+	Stars = 5,
+	Occurrence = 0,
+	Locations = "Forgotten Crypt, Outer Crypt.",
+}
+
+monster.health = 25000
+monster.maxHealth = 25000
+monster.race = "undead"
+monster.corpse = 52563
+monster.speed = 240
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 41980 },
+	{ name = "cyan crystal fragment", chance = 7390, maxCount = 4 },
+	{ name = "blue crystal shard", chance = 5700, maxCount = 4 },
+	{ name = "small sapphire", chance = 5210, maxCount = 15 },
+	-- { name = "crystallized death", chance = 4390 },
+	-- { name = "toe nails", chance = 2750 },
+	-- { name = "cluster of crystallized death", chance = 1750 },
+	{ name = "blue gem", chance = 1460, maxCount = 4 },
+	{ name = "amber", chance = 1090 },
+	{ name = "amber staff", chance = 710 },
+	{ name = "amber with a bug", chance = 490 },
+	{ name = "amber with a dragonfly", chance = 180 },
+	-- { name = "fetid heart", chance = 160 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -300, maxDamage = -800 },
+	{ name = "Crypt Construct Wave", interval = 2000, chance = 30, minDamage = -1000, maxDamage = -1700, target = false },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_DEATHDAMAGE, minDamage = -400, maxDamage = -900, radius = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -400, maxDamage = -900, range = 7, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_SMALL_WHITE_ENERGYSHOCK, target = true },
+}
+
+monster.defenses = {
+	defense = 100,
+	armor = 100,
+	mitigation = 3.34,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -6 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 18 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -9 },
+	{ type = COMBAT_FIREDAMAGE, percent = -6 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 12 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 8 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 8 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/crypt_fiend.lua
+++ b/data/monsters/winter_update_2025/crypt_fiend.lua
@@ -1,0 +1,128 @@
+local mType = Game.createMonsterType("Crypt Fiend")
+local monster = {}
+
+monster.name = "Crypt Fiend"
+monster.description = "a crypt fiend"
+monster.experience = 22500
+monster.outfit = {
+	lookType = 1885,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2758
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 5000,
+	FirstUnlock = 200,
+	SecondUnlock = 2000,
+	CharmsPoints = 100,
+	Stars = 5,
+	Occurrence = 0,
+	Locations = "Unhallowed Crypt.",
+}
+
+monster.health = 30000
+monster.maxHealth = 30000
+monster.race = "undead"
+monster.corpse = 52555
+monster.speed = 240
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 33540 },
+	{ name = "cyan crystal fragment", chance = 5580, maxCount = 4 },
+	{ name = "small sapphire", chance = 4960, maxCount = 15 },
+	-- { name = "giant tusk", chance = 4600 },
+	-- { name = "crystallized death", chance = 2570 },
+	{ name = "blue crystal shard", chance = 1860, maxCount = 4 },
+	-- { name = "necromantic core", chance = 1770 },
+	{ name = "amber", chance = 1590 },
+	{ name = "amber with a bug", chance = 1150 },
+	-- { name = "cluster of crystallized death", chance = 1150 },
+	{ name = "blue gem", chance = 530, maxCount = 3 },
+	{ name = "amber with a dragonfly", chance = 440 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -300, maxDamage = -800 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -400, maxDamage = -1100, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = -550, maxDamage = -900, range = 7, radius = 5, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -200, maxDamage = -700, radius = 5, effect = CONST_ME_STONE_STORM, target = false },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -350, maxDamage = -1200, radius = 6, effect = CONST_ME_LOSEENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 140,
+	armor = 140,
+	mitigation = 2.75,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -6 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -12 },
+	{ type = COMBAT_FIREDAMAGE, percent = -9 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 9 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -3 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/crypt_mage.lua
+++ b/data/monsters/winter_update_2025/crypt_mage.lua
@@ -1,0 +1,127 @@
+local mType = Game.createMonsterType("Crypt Mage")
+local monster = {}
+
+monster.name = "Crypt Mage"
+monster.description = "a crypt mage"
+monster.experience = 14700
+monster.outfit = {
+	lookType = 1905,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2766
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 0,
+	Locations = "Forsaken Crypt.",
+}
+
+monster.health = 14000
+monster.maxHealth = 14000
+monster.race = "undead"
+monster.corpse = 52563
+monster.speed = 180
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 4,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Maaahhh!", yell = false },
+	{ text = "Czchhh!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 23660, minCount = 10, maxCount = 20 },
+	{ name = "crystal coin", chance = 11180 },
+	{ name = "green crystal fragment", chance = 4090, maxCount = 4 },
+	{ name = "green crystal shard", chance = 3440, maxCount = 4 },
+	{ name = "skull staff", chance = 3230 },
+	{ name = "small emerald", chance = 2580, maxCount = 15 },
+	-- { name = "crystallized death", chance = 2150 },
+	-- { name = "toe nails", chance = 1940 },
+	{ name = "spellbook of mind control", chance = 860 },
+	-- { name = "cryptic fossil", chance = 650 },
+	{ name = "green gem", chance = 650, maxCount = 3 },
+	-- { name = "necromantic core", chance = 650 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 30, minDamage = -100, maxDamage = -700 },
+	{ name = "Crypt X", interval = 2000, chance = 20, minDamage = -350, maxDamage = -1050, target = false },
+	{ name = "Energy Cruz", interval = 2000, chance = 20, minDamage = -300, maxDamage = -1200, target = false },
+	{ name = "Wave Death Crypt", interval = 2000, chance = 15, minDamage = -1000, maxDamage = -1700, target = false },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_PHYSICALDAMAGE, minDamage = -900, maxDamage = -1480, radius = 3, effect = CONST_ME_GREEN_ENERGYPULSE, target = false },
+}
+
+monster.defenses = {
+	defense = 105,
+	armor = 105,
+	mitigation = 3.04,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 10 },
+	{ type = COMBAT_FIREDAMAGE, percent = 10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/cyclursus.lua
+++ b/data/monsters/winter_update_2025/cyclursus.lua
@@ -1,0 +1,125 @@
+local mType = Game.createMonsterType("Cyclursus")
+local monster = {}
+
+monster.name = "Cyclursus"
+monster.description = "a cyclursus"
+monster.experience = 13375
+monster.outfit = {
+	lookType = 1884,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2757
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 0,
+	Locations = "Forsaken Crypt.",
+}
+
+monster.health = 13500
+monster.maxHealth = 13500
+monster.race = "undead"
+monster.corpse = 52551
+monster.speed = 200
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 3,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Crrrrk!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 24010, minCount = 10, maxCount = 20 },
+	{ name = "crystal coin", chance = 9820 },
+	{ name = "cyan crystal fragment", chance = 5950, maxCount = 4 },
+	-- { name = "crystallized death", chance = 4070 },
+	{ name = "small sapphire", chance = 3470, maxCount = 15 },
+	{ name = "blue crystal shard", chance = 2380, maxCount = 4 },
+	-- { name = "deadly fangs", chance = 1090 },
+	{ name = "crystal crossbow", chance = 890 },
+	{ name = "blue gem", chance = 790, maxCount = 4 },
+	-- { name = "necromantic core", chance = 690 },
+	{ name = "skull helmet", chance = 400 },
+	{ name = "honeycomb", chance = 100 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -700 },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -900, maxDamage = -1480, radius = 3, effect = CONST_ME_PINK_ENERGYPULSE, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -900, maxDamage = -1480, range = 4, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ENERGYDAMAGE, minDamage = -900, maxDamage = -1480, range = 4, shootEffect = CONST_ANI_ENERGY, target = true },
+}
+
+monster.defenses = {
+	defense = 95,
+	armor = 95,
+	mitigation = 3.19,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -3 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -3 },
+	{ type = COMBAT_FIREDAMAGE, percent = -3 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -3 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -3 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -12 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/day_night_harpy.lua
+++ b/data/monsters/winter_update_2025/day_night_harpy.lua
@@ -1,0 +1,125 @@
+local mType = Game.createMonsterType("Day Night Harpy")
+local monster = {}
+
+monster.name = "Day Night Harpy"
+monster.description = "a night harpy"
+monster.experience = 21000
+monster.outfit = {
+	lookType = 1899,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2764
+monster.Bestiary = {
+	class = "Bird",
+	race = BESTY_RACE_BIRD,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 2,
+	Locations = "Arean Outskirts, Isle of Ada, Stag Bastion",
+}
+
+monster.health = 14000
+monster.maxHealth = 14000
+monster.race = "blood"
+monster.corpse = 52680
+monster.speed = 190
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 3,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "WHEEE!!! WHEEE!!!", yell = false },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 70, minCount = 100 },
+	{ name = "strong mana potion", chance = 9090, minCount = 8, maxCount = 12 },
+	{ name = "great mana potion", chance = 10630, minCount = 8, maxCount = 12 },
+	{ name = "great spirit potion", chance = 9840, minCount = 4, maxCount = 8 },
+	{ name = "giant ruby", chance = 220, maxCount = 1 },
+	{ name = "giant emerald", chance = 130, maxCount = 1 },
+	{ name = "giant topaz", chance = 130, maxCount = 1 },
+	{ name = "giant topaz", chance = 130, maxCount = 1 },
+	-- { name = "night harpy feathers", chance = 570, minCount = 5, maxCount = 10 },
+}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 1000, type = COMBAT_DEATHDAMAGE, minDamage = -0, maxDamage = -350, range = 5, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2200, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -850, maxDamage = -930, radius = 3, effect = CONST_ME_ENERGYHIT, target = false },
+	{ name = "deathcircle", interval = 2500, chance = 25 },
+	{ name = "night harpy shielding ball", interval = 5000, chance = 25 },
+	{ name = "night harpy cone wave", interval = 2000, chance = 23, minDamage = -570, maxDamage = -870 },
+	{ name = "combat", interval = 2000, chance = 27, type = COMBAT_DEATHDAMAGE, minDamage = -610, maxDamage = -810, range = 5, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "night harpy scratch", interval = 2000, chance = 25, minDamage = -700, maxDamage = -890 },
+}
+
+monster.defenses = {
+	defense = 90,
+	armor = 90,
+	mitigation = 2.45,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 40 },
+	{ type = COMBAT_FIREDAMAGE, percent = 30 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -12 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -9 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -9 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/destrier.lua
+++ b/data/monsters/winter_update_2025/destrier.lua
@@ -1,0 +1,90 @@
+local mType = Game.createMonsterType("Destrier")
+local monster = {}
+
+monster.name = "Destrier"
+monster.description = "a destrier"
+monster.experience = 0
+monster.outfit = {
+	lookType = 434,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 75
+monster.maxHealth = 75
+monster.race = "blood"
+monster.corpse = 0
+monster.speed = 124
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 20,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = false,
+	convinceable = false,
+	pushable = true,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 75,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.defenses = {
+	defense = 5,
+	armor = 10,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/haunted_hunter.lua
+++ b/data/monsters/winter_update_2025/haunted_hunter.lua
@@ -1,0 +1,134 @@
+local mType = Game.createMonsterType("Haunted Hunter")
+local monster = {}
+
+monster.name = "Haunted Hunter"
+monster.description = "a haunted hunter"
+monster.experience = 19500
+monster.outfit = {
+	lookType = 1889,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2762
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 5000,
+	FirstUnlock = 200,
+	SecondUnlock = 2000,
+	CharmsPoints = 100,
+	Stars = 5,
+	Occurrence = 0,
+	Locations = "Outer Crypt.",
+}
+
+monster.health = 23000
+monster.maxHealth = 23000
+monster.race = "undead"
+monster.corpse = 52571
+monster.speed = 240
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 2,
+	summons = {
+		{ name = "Bone Bear", chance = 100, interval = 4000, count = 2 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Uhhhh", yell = false },
+	{ text = "<rattle>", yell = false },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 38260 },
+	-- { name = "deadly fangs", chance = 5760 },
+	{ name = "small sapphire", chance = 4990, maxCount = 15 },
+	{ name = "cyan crystal fragment", chance = 4420, maxCount = 4 },
+	-- { name = "toe nails", chance = 2520 },
+	{ name = "blue crystal shard", chance = 2330, maxCount = 4 },
+	-- { name = "crystallized death", chance = 2240 },
+	{ name = "crystalline armor", chance = 1920 },
+	{ name = "blue gem", chance = 1880, maxCount = 4 },
+	{ name = "crystal crossbow", chance = 1020 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -300, maxDamage = -800 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -750, maxDamage = -1200, length = 6, effect = CONST_ME_WHITE_ENERGYPULSE, target = false },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -750, maxDamage = -1200, distance = 4, shootEffect = CONST_ANI_ENERGYBALL, effect = CONST_ME_ENERGYHIT, target = true },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_DEATHDAMAGE, minDamage = -400, maxDamage = -900, radius = 3, effect = CONST_ME_MORTAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 90,
+	armor = 90,
+	mitigation = 3.04,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -3 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -6 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 15 },
+	{ type = COMBAT_FIREDAMAGE, percent = 9 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -9 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 6 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -12 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/imperial.lua
+++ b/data/monsters/winter_update_2025/imperial.lua
@@ -1,0 +1,105 @@
+local mType = Game.createMonsterType("Imperial")
+local monster = {}
+
+monster.name = "Imperial"
+monster.description = "an imperial"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1914,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2775
+monster.Bestiary = {
+	class = "Mammal",
+	race = BESTY_RACE_MAMMAL,
+	toKill = 5,
+	FirstUnlock = 2,
+	SecondUnlock = 3,
+	CharmsPoints = 10,
+	Stars = 1,
+	Occurrence = 3,
+	Locations = "Arean Outskirts",
+}
+
+monster.health = 100
+monster.maxHealth = 100
+monster.race = "blood"
+monster.corpse = 52845
+monster.speed = 98
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = false,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 5,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+	isPreyExclusive = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {
+	-- { name = "tender venison", chance = 100000 },
+	{ name = "meat", chance = 84000, maxCount = 4 },
+	{ name = "ham", chance = 48000 },
+	{ id = 10297, chance = 4000 }, -- antlers
+}
+
+monster.defenses = {
+	defense = 2,
+	armor = 2,
+	mitigation = 0.05,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/night_harpy.lua
+++ b/data/monsters/winter_update_2025/night_harpy.lua
@@ -1,0 +1,131 @@
+local mType = Game.createMonsterType("Night Harpy")
+local monster = {}
+
+monster.name = "Night Harpy"
+monster.description = "a night harpy"
+monster.experience = 21000
+monster.outfit = {
+	lookType = 1899,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2764
+monster.Bestiary = {
+	class = "Bird",
+	race = BESTY_RACE_BIRD,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 2,
+	Locations = "Arean Outskirts, Isle of Ada, Stag Bastion",
+}
+
+monster.health = 14000
+monster.maxHealth = 14000
+monster.race = "blood"
+monster.corpse = 52680
+monster.speed = 190
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 3,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "WHEEE!!! WHEEE!!!", yell = false },
+}
+
+monster.respawnType = {
+	period = RESPAWNPERIOD_NIGHT,
+	underground = false,
+}
+
+monster.loot = {
+	{ name = "strong mana potion", chance = 10360, minCount = 8, maxCount = 12 },
+	{ name = "great mana potion", chance = 10170, minCount = 8, maxCount = 12 },
+	{ name = "great spirit potion", chance = 9630, minCount = 4, maxCount = 8 },
+	-- { name = "night harpy feathers", chance = 540, minCount = 6, maxCount = 10 },
+	{ name = "giant sapphire", chance = 230 },
+	{ name = "crystal coin", chance = 120 },
+	{ name = "giant amethyst", chance = 80 },
+	{ name = "giant emerald", chance = 80 },
+	{ name = "giant ruby", chance = 80 },
+	{ name = "giant topaz", chance = 80 },
+}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 1000, type = COMBAT_DEATHDAMAGE, minDamage = -0, maxDamage = -350, range = 5, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2200, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -850, maxDamage = -930, radius = 3, effect = CONST_ME_ENERGYHIT, target = false },
+	{ name = "deathcircle", interval = 2500, chance = 25 },
+	{ name = "night harpy shielding ball", interval = 5000, chance = 25 },
+	{ name = "night harpy cone wave", interval = 2000, chance = 23, minDamage = -570, maxDamage = -870 },
+	{ name = "combat", interval = 2000, chance = 27, type = COMBAT_DEATHDAMAGE, minDamage = -610, maxDamage = -810, range = 5, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "night harpy scratch", interval = 2000, chance = 25, minDamage = -700, maxDamage = -890 },
+}
+
+monster.defenses = {
+	defense = 90,
+	armor = 90,
+	mitigation = 2.45,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 40 },
+	{ type = COMBAT_FIREDAMAGE, percent = 30 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -12 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -9 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -9 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/an_eye.lua
+++ b/data/monsters/winter_update_2025/quests/an_eye.lua
@@ -1,0 +1,91 @@
+local mType = Game.createMonsterType("An Eye")
+local monster = {}
+
+monster.name = "An Eye"
+monster.description = "an eye"
+monster.experience = 0
+monster.outfit = {
+	lookType = 925,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 5000 -- Not confirmed
+monster.maxHealth = 5000 -- Not confirmed
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0 -- Not confirmed
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = false, -- Not confirmed
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 3, -- Not confirmed
+	color = 180, -- Not confirmed
+}
+
+monster.loot = {}
+
+-- Agony Explosion - deals 30% of player's max HP
+monster.attacks = {
+	{ name = "combat", interval = 3000, chance = 100, type = COMBAT_LIFEDRAIN, minDamage = -500, maxDamage = -1500, radius = 5, effect = CONST_ME_DRAWBLOOD, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 50, -- Not confirmed
+	armor = 50, -- Not confirmed
+	mitigation = 1.50, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/bone_barrier.lua
+++ b/data/monsters/winter_update_2025/quests/bone_barrier.lua
@@ -1,0 +1,82 @@
+local mType = Game.createMonsterType("Bone Barrier")
+local monster = {}
+
+monster.name = "Bone Barrier"
+monster.description = "a bone barrier"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 6973,
+}
+
+monster.health = 10000
+monster.maxHealth = 10000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = false, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = false, -- Not confirmed
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = true, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.loot = {}
+
+monster.attacks = {} -- Not confirmed
+
+monster.defenses = {
+	defense = 100, -- Not confirmed
+	armor = 100, -- Not confirmed
+	mitigation = 3.00, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/bonelord_totem.lua
+++ b/data/monsters/winter_update_2025/quests/bonelord_totem.lua
@@ -1,0 +1,93 @@
+local mType = Game.createMonsterType("Bonelord Totem")
+local monster = {}
+
+monster.name = "Bonelord Totem"
+monster.description = "Bonelord Totem"
+-- monster.raceid = 0  -- TODO: raceid not found in staticdata.dat
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 51192,
+}
+
+-- monster.health = 100  -- TODO (max % seen: 100%)
+-- monster.maxHealth = 100  -- TODO
+-- monster.race = "blood"  -- TODO (blood, venom, undead, fire, energy)
+-- monster.corpse = 0  -- TODO
+monster.speed = 0
+-- monster.manaCost = 0  -- TODO
+
+-- monster.changeTarget = {  -- TODO
+--	interval = 4000,
+--	chance = 10,
+-- }
+
+-- monster.strategiesTarget = {  -- TODO
+--	nearest = 70,
+--	health = 20,
+--	damage = 10,
+-- }
+
+monster.flags = {
+	-- summonable = false,  -- TODO
+	attackable = true,
+	-- hostile = true,  -- TODO
+	-- convinceable = false,  -- TODO
+	-- pushable = false,  -- TODO
+	-- rewardBoss = false,  -- TODO
+	-- illusionable = false,  -- TODO
+	-- canPushItems = true,  -- TODO
+	-- canPushCreatures = true,  -- TODO
+	-- staticAttackChance = 90,  -- TODO
+	-- targetDistance = 1,  -- TODO
+	-- runHealth = 0,  -- TODO
+	healthHidden = false,
+	isBlockable = false,
+	-- canWalkOnEnergy = false,  -- TODO
+	-- canWalkOnFire = false,  -- TODO
+	-- canWalkOnPoison = false,  -- TODO
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+-- monster.voices = {  -- TODO
+--	interval = 5000,
+--	chance = 10,
+-- }
+
+monster.loot = {}
+
+monster.attacks = {
+	-- TODO: Add attacks
+	-- Example: { name = "melee", interval = 2000, chance = 100, skill = 10, attack = 10 },
+}
+
+-- monster.defenses = {  -- TODO
+--	defense = 5,
+--	armor = 5,
+--	mitigation = 0.00,
+-- }
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+-- monster.immunities = {  -- TODO
+--	{ type = "paralyze", condition = false },
+--	{ type = "outfit", condition = false },
+--	{ type = "invisible", condition = false },
+--	{ type = "bleed", condition = false },
+-- }
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/bonelords_phylactery.lua
+++ b/data/monsters/winter_update_2025/quests/bonelords_phylactery.lua
@@ -1,0 +1,116 @@
+local mType = Game.createMonsterType("Bonelord's Phylactery")
+local monster = {}
+
+monster.description = "a bonelord's phylactery"
+monster.experience = 0 -- unknown
+monster.outfit = {
+	lookTypeEx = 52466,
+}
+
+monster.health = 50000 -- não confirmado
+monster.maxHealth = 50000 -- não confirmado
+monster.race = "undead"
+monster.corpse = 44831 -- não confirmado
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false, -- não confirmado
+	attackable = true, -- não confirmado
+	hostile = true, -- não confirmado
+	convinceable = false, -- não confirmado
+	pushable = false, -- não confirmado
+	rewardBoss = false, -- não confirmado
+	illusionable = false, -- não confirmado
+	canPushItems = false, -- não confirmado
+	canPushCreatures = false, -- não confirmado
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 1, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true, -- não confirmado
+	canWalkOnFire = true, -- não confirmado
+	canWalkOnPoison = true, -- não confirmado
+}
+
+monster.light = {
+	level = 0, -- não confirmado
+	color = 0, -- não confirmado
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 100000, maxCount = 49 }, -- não confirmado (chance)
+	{ name = "blue gem", chance = 100000, maxCount = 3 }, -- não confirmado (chance)
+	{ id = 3039, chance = 100000, maxCount = 8 }, -- red gem (não confirmado (chance))
+	{ name = "yellow gem", chance = 100000, maxCount = 9 }, -- não confirmado (chance)
+	{ name = "giant ruby", chance = 100000, maxCount = 2 }, -- não confirmado (chance)
+	{ name = "strong mana potion", chance = 100000, maxCount = 93 }, -- não confirmado (chance)
+	{ name = "great mana potion", chance = 100000, maxCount = 62 }, -- não confirmado (chance)
+	{ name = "great spirit potion", chance = 100000, maxCount = 51 }, -- não confirmado (chance)
+	{ name = "ultimate mana potion", chance = 100000, maxCount = 22 }, -- não confirmado (chance)
+	{ name = "ultimate spirit potion", chance = 100000, maxCount = 24 }, -- não confirmado (chance)
+	{ name = "ultimate health potion", chance = 100000, maxCount = 33 }, -- não confirmado (chance)
+	{ name = "supreme health potion", chance = 100000, maxCount = 14 }, -- não confirmado (chance)
+	{ name = "guardian gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "marksman gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "mystic gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "sage gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "spiritualist gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "greater guardian gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "greater marksman gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "greater mystic gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "greater sage gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "greater spiritualist gem", chance = 100000 }, -- não confirmado (chance)
+	{ name = "small flask of eyedrops", chance = 100000 }, -- não confirmado (chance)
+	{ name = "bonelord eye", chance = 100000 }, -- não confirmado (chance)
+	{ id = 6299, chance = 100000 }, -- death ring (não confirmado (chance))
+	{ name = "haunted blade", chance = 100000 }, -- não confirmado (chance)
+	{ name = "bonelord shield", chance = 100000 }, -- não confirmado (chance)
+	{ name = "skull helmet", chance = 100000 }, -- não confirmado (chance)
+	-- { name = "bone spikes", chance = 100000 }, -- não confirmado (chance)
+	-- { name = "ancient scales", chance = 100000 }, -- não confirmado (chance)
+	-- { name = "soul trap", chance = 100000 }, -- não confirmado (chance)
+	-- { name = "necromantic crypt rune", chance = 100000 }, -- não confirmado (chance)
+}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_DEATHDAMAGE, minDamage = -800, maxDamage = -1200, radius = 5, effect = CONST_ME_MORTAREA, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 100, -- não confirmado
+	armor = 100, -- não confirmado
+	mitigation = 3.00, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- não confirmado
+	{ type = "outfit", condition = true }, -- não confirmado
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- não confirmado
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/bright_crystal.lua
+++ b/data/monsters/winter_update_2025/quests/bright_crystal.lua
@@ -1,0 +1,82 @@
+local mType = Game.createMonsterType("Bright Crystal")
+local monster = {}
+
+monster.name = "Bright Crystal"
+monster.description = "a bright crystal"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 7806,
+}
+
+monster.health = 3000
+monster.maxHealth = 3000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = false,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 0,
+	targetDistance = 0,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 4,
+	color = 120,
+}
+
+monster.loot = {}
+
+monster.attacks = {}
+
+monster.defenses = {
+	defense = 20,
+	armor = 20,
+	mitigation = 0.50,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/elyraxa_spirit.lua
+++ b/data/monsters/winter_update_2025/quests/elyraxa_spirit.lua
@@ -1,0 +1,94 @@
+local mType = Game.createMonsterType("Elyrax's Spirit")
+local monster = {}
+
+monster.description = "Elyrax's spirit"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1883,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- não confirmado
+	health = 10, -- não confirmado
+	damage = 10, -- não confirmado
+	random = 10, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 4, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Holy Missile (1150+), Holy Explosion
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_HOLYDAMAGE, minDamage = -800, maxDamage = -1150, range = 7, shootEffect = CONST_ANI_HOLY, effect = CONST_ME_HOLYDAMAGE, target = true }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HOLYDAMAGE, minDamage = -600, maxDamage = -900, radius = 4, effect = CONST_ME_HOLYAREA, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 75, -- não confirmado
+	armor = 75, -- não confirmado
+	mitigation = 2.30, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- não confirmado
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- não confirmado
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/elyraxs_soulcage.lua
+++ b/data/monsters/winter_update_2025/quests/elyraxs_soulcage.lua
@@ -1,0 +1,85 @@
+local mType = Game.createMonsterType("Elyrax's Soulcage")
+local monster = {}
+
+monster.description = "Elyrax's soulcage"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 52546,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 1, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true, -- não confirmado
+	canWalkOnFire = true, -- não confirmado
+	canWalkOnPoison = true, -- não confirmado
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Holy Explosion (700+), Holy Chain (700+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_HOLYDAMAGE, minDamage = -700, maxDamage = -1200, length = 8, spread = 3, effect = CONST_ME_HOLYDAMAGE, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HOLYDAMAGE, minDamage = -700, maxDamage = -1000, radius = 4, effect = CONST_ME_HOLYAREA, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 80, -- não confirmado
+	armor = 80, -- não confirmado
+	mitigation = 2.50, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/energised_raubritter.lua
+++ b/data/monsters/winter_update_2025/quests/energised_raubritter.lua
@@ -1,0 +1,99 @@
+local mType = Game.createMonsterType("Energised Raubritter")
+local monster = {}
+
+monster.name = "Energised Raubritter"
+monster.description = "a energised raubritter"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1901,
+	lookHead = 94,
+	lookBody = 14,
+	lookLegs = 72,
+	lookFeet = 129,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 35000
+monster.maxHealth = 35000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 3,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 200, maxDamage = -1000 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -800, maxDamage = -1200, target = false, radius = 3, effect = CONST_ME_ENERGYHIT },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -800, maxDamage = -1200, range = 7, radius = 3, effect = CONST_ME_PURPLEENERGY, shootEffect = CONST_ANI_FLASHARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -600, maxDamage = -1000, range = 7, radius = 1, effect = CONST_ME_ENERGYAREA, shootEffect = CONST_ANI_ENERGY, target = true },
+	{ name = "energy chain", interval = 2000, chance = 15, minDamage = -600, maxDamage = -1500 },
+}
+
+monster.defenses = {
+	defense = 80,
+	armor = 80,
+	mitigation = 2.31,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/enthralled_dragon.lua
+++ b/data/monsters/winter_update_2025/quests/enthralled_dragon.lua
@@ -1,0 +1,95 @@
+local mType = Game.createMonsterType("Enthralled Dragon")
+local monster = {}
+
+monster.name = "Enthralled Dragon"
+monster.description = "an enthralled dragon"
+monster.experience = 0
+monster.outfit = {
+	lookType = 231,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 40000 -- Not confirmed
+monster.maxHealth = 40000 -- Not confirmed
+monster.race = "blood"
+monster.corpse = 0
+monster.speed = 160 -- Not confirmed
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true, -- Not confirmed
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -800 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -700, maxDamage = -1200, length = 8, spread = 3, effect = CONST_ME_FIREATTACK, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -600, maxDamage = -1000, radius = 5, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 70, -- Not confirmed
+	armor = 70, -- Not confirmed
+	mitigation = 2.50, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/eruption.lua
+++ b/data/monsters/winter_update_2025/quests/eruption.lua
@@ -1,0 +1,84 @@
+local mType = Game.createMonsterType("Eruption")
+local monster = {}
+
+monster.name = "Eruption"
+monster.description = "an eruption"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 51952,
+}
+
+monster.health = 10000 -- Not confirmed
+monster.maxHealth = 10000 -- Not confirmed
+monster.race = "fire"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = false, -- Not confirmed
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 4, -- Not confirmed
+	color = 208, -- Not confirmed
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 100, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -1000, radius = 5, effect = CONST_ME_FIREAREA, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 50, -- Not confirmed
+	armor = 50, -- Not confirmed
+	mitigation = 1.50, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/fatal_bug.lua
+++ b/data/monsters/winter_update_2025/quests/fatal_bug.lua
@@ -1,0 +1,137 @@
+local mType = Game.createMonsterType("Fatal Bug")
+local monster = {}
+
+monster.name = "Fatal Bug"
+monster.description = "a fatal bug"
+monster.experience = 668000
+monster.outfit = {
+	lookType = 79,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 250000
+monster.maxHealth = 250000
+monster.race = "venom"
+monster.corpse = 0
+monster.speed = 130 -- Not confirmed
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false,
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true,
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.voices = {
+	interval = 5000, -- Not confirmed
+	chance = 10, -- Not confirmed
+	{ text = "BZZT", yell = false },
+	{ text = "BRRRRMM", yell = false },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 100000, maxCount = 64 }, -- Not confirmed (chance)
+	{ name = "yellow gem", chance = 100000, maxCount = 10 }, -- Not confirmed (chance)
+	{ id = 3039, chance = 100000, maxCount = 10 }, -- red gem (não confirmado (chance))
+	{ name = "blue gem", chance = 100000, maxCount = 2 }, -- Not confirmed (chance)
+	{ name = "giant amethyst", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "giant sapphire", chance = 100000, maxCount = 3 }, -- Not confirmed (chance)
+	{ name = "strong mana potion", chance = 100000, maxCount = 92 }, -- Not confirmed (chance)
+	{ name = "great mana potion", chance = 100000, maxCount = 67 }, -- Not confirmed (chance)
+	{ name = "great spirit potion", chance = 100000, maxCount = 56 }, -- Not confirmed (chance)
+	{ name = "ultimate mana potion", chance = 100000, maxCount = 25 }, -- Not confirmed (chance)
+	{ name = "ultimate spirit potion", chance = 100000, maxCount = 25 }, -- Not confirmed (chance)
+	{ name = "ultimate health potion", chance = 100000, maxCount = 35 }, -- Not confirmed (chance)
+	{ name = "supreme health potion", chance = 100000, maxCount = 11 }, -- Not confirmed (chance)
+	{ name = "guardian gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "marksman gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "mystic gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "sage gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "spiritualist gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "greater guardian gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "greater marksman gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "greater mystic gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "greater sage gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "greater spiritualist gem", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "berserk potion", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "bullseye potion", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "transcendence potion", chance = 100000 }, -- Not confirmed (chance)
+	-- { name = "cryptic fossil", chance = 100000 }, -- Not confirmed (chance)
+	-- { name = "fetid heart", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "wand of everblazing", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "composite hornbow", chance = 100000 }, -- Not confirmed (chance)
+	{ name = "muck rod", chance = 100000 }, -- Not confirmed (chance)
+	-- { name = "worn guide book", chance = 100000 }, -- Not confirmed (chance)
+	-- { name = "ancient crypt rune", chance = 100000 }, -- Not confirmed (chance)
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -300, maxDamage = -500, range = 5, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -400, maxDamage = -600, radius = 3, effect = CONST_ME_GREEN_RINGS, target = false }, -- Not confirmed
+	{ name = "condition", interval = 2000, chance = 15, type = CONDITION_POISON, totalDamage = 200, effect = CONST_ME_HITBYPOISON, target = true }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 40, -- Not confirmed
+	armor = 40, -- Not confirmed
+	mitigation = 1.50, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/flame_totem.lua
+++ b/data/monsters/winter_update_2025/quests/flame_totem.lua
@@ -1,0 +1,84 @@
+local mType = Game.createMonsterType("Flame Totem")
+local monster = {}
+
+monster.name = "Flame Totem"
+monster.description = "a flame totem"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 51953,
+}
+
+monster.health = 15000 -- Not confirmed
+monster.maxHealth = 15000 -- Not confirmed
+monster.race = "fire"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = false, -- Not confirmed
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 100, type = COMBAT_FIREDAMAGE, minDamage = -600, maxDamage = -1000, radius = 6, effect = CONST_ME_HITBYFIRE, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 70, -- Not confirmed
+	armor = 70, -- Not confirmed
+	mitigation = 2.00, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/frozen_raubritter.lua
+++ b/data/monsters/winter_update_2025/quests/frozen_raubritter.lua
@@ -1,0 +1,99 @@
+local mType = Game.createMonsterType("Frozen Raubritter")
+local monster = {}
+
+monster.name = "Frozen Raubritter"
+monster.description = "a frozen raubritter"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1900,
+	lookHead = 86,
+	lookBody = 86,
+	lookLegs = 10,
+	lookFeet = 87,
+	lookAddons = 1,
+	lookMount = 0,
+}
+
+monster.health = 35000
+monster.maxHealth = 35000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 200, maxDamage = -1000 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = -800, maxDamage = -1200, target = false, radius = 3, effect = CONST_ME_ICEATTACK },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = -800, maxDamage = -1200, range = 7, radius = 3, effect = CONST_ME_ICETORNADO, shootEffect = CONST_ANI_SHIVERARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = -600, maxDamage = -1000, range = 7, radius = 1, effect = CONST_ME_GIANTICE, shootEffect = CONST_ANI_SMALLICE, target = true },
+	{ name = "ice chain", interval = 2000, chance = 15, minDamage = -600, maxDamage = -1500 },
+}
+
+monster.defenses = {
+	defense = 80,
+	armor = 80,
+	mitigation = 2.31,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/ice_blockade.lua
+++ b/data/monsters/winter_update_2025/quests/ice_blockade.lua
@@ -1,0 +1,82 @@
+local mType = Game.createMonsterType("Ice Blockade")
+local monster = {}
+
+monster.name = "Ice Blockade"
+monster.description = "an ice blockade"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 6707,
+}
+
+monster.health = 600
+monster.maxHealth = 600
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = false, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = false, -- Not confirmed
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = true, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.loot = {}
+
+monster.attacks = {} -- Not confirmed
+
+monster.defenses = {
+	defense = 100, -- Not confirmed
+	armor = 100, -- Not confirmed
+	mitigation = 3.00, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/ice_crawler.lua
+++ b/data/monsters/winter_update_2025/quests/ice_crawler.lua
@@ -1,0 +1,95 @@
+local mType = Game.createMonsterType("Ice Crawler")
+local monster = {}
+
+monster.name = "Ice Crawler"
+monster.description = "an ice crawler"
+monster.experience = 0
+monster.outfit = {
+	lookType = 263,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 12000 -- Not confirmed
+monster.maxHealth = 12000 -- Not confirmed
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- Not confirmed
+	health = 10, -- Not confirmed
+	damage = 10, -- Not confirmed
+	random = 10, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false, -- Not confirmed
+	attackable = true, -- Not confirmed
+	hostile = true, -- Not confirmed
+	convinceable = false, -- Not confirmed
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = true, -- Not confirmed
+	canPushCreatures = true, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = -400, maxDamage = -700, range = 5, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = true }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -500, maxDamage = -800, radius = 4, effect = CONST_ME_ICEAREA, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 55, -- Not confirmed
+	armor = 55, -- Not confirmed
+	mitigation = 2.00, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/myzaretha_spirit.lua
+++ b/data/monsters/winter_update_2025/quests/myzaretha_spirit.lua
@@ -1,0 +1,94 @@
+local mType = Game.createMonsterType("Myzareth's Spirit")
+local monster = {}
+
+monster.description = "Myzareth's spirit"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1883,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- não confirmado
+	health = 10, -- não confirmado
+	damage = 10, -- não confirmado
+	random = 10, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 4, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Energy Missile (450+), Bleed Explosion (800+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -300, maxDamage = -450, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -600, maxDamage = -800, radius = 4, effect = CONST_ME_DRAWBLOOD, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 75, -- não confirmado
+	armor = 75, -- não confirmado
+	mitigation = 2.30, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- não confirmado
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- não confirmado
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/myzareths_soulcage.lua
+++ b/data/monsters/winter_update_2025/quests/myzareths_soulcage.lua
@@ -1,0 +1,86 @@
+local mType = Game.createMonsterType("Myzareth's Soulcage")
+local monster = {}
+
+monster.description = "Myzareth's soulcage"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 52546,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 1, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true, -- não confirmado
+	canWalkOnFire = true, -- não confirmado
+	canWalkOnPoison = true, -- não confirmado
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Dust Explosion, Energy Explosion (700+), Energy Chain (700+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_EARTHDAMAGE, minDamage = -500, maxDamage = -900, radius = 4, effect = CONST_ME_SMALLCLOUDS, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -700, maxDamage = -1200, length = 8, spread = 3, effect = CONST_ME_ENERGYHIT, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -700, maxDamage = -1000, radius = 4, effect = CONST_ME_ENERGYAREA, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 80, -- não confirmado
+	armor = 80, -- não confirmado
+	mitigation = 2.50, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/poisoned_raubritter.lua
+++ b/data/monsters/winter_update_2025/quests/poisoned_raubritter.lua
@@ -1,0 +1,99 @@
+local mType = Game.createMonsterType("Poisoned Raubritter")
+local monster = {}
+
+monster.name = "Poisoned Raubritter"
+monster.description = "a poisoned raubritter"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1902,
+	lookHead = 82,
+	lookBody = 120,
+	lookLegs = 102,
+	lookFeet = 120,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 35000
+monster.maxHealth = 35000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 200, maxDamage = -1000 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -800, maxDamage = -1200, target = false, radius = 3, effect = CONST_ME_GREEN_RINGS },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -800, maxDamage = -1200, range = 7, radius = 3, effect = CONST_ME_CARNIPHILA, shootEffect = CONST_ANI_EARTHARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -600, maxDamage = -1000, range = 7, radius = 1, effect = CONST_ME_BIGPLANTS, shootEffect = CONST_ANI_EARTH, target = true },
+	{ name = "poison chain", interval = 2000, chance = 15, minDamage = -600, maxDamage = -1500 },
+}
+
+monster.defenses = {
+	defense = 80,
+	armor = 80,
+	mitigation = 2.31,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/pulsating_lava.lua
+++ b/data/monsters/winter_update_2025/quests/pulsating_lava.lua
@@ -1,0 +1,84 @@
+local mType = Game.createMonsterType("Pulsating Lava")
+local monster = {}
+
+monster.name = "Pulsating Lava"
+monster.description = "pulsating lava"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 391,
+}
+
+monster.health = 0
+monster.maxHealth = 0
+monster.race = "fire"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- Not confirmed
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false, -- Not confirmed
+	rewardBoss = false, -- Not confirmed
+	illusionable = false, -- Not confirmed
+	canPushItems = false, -- Not confirmed
+	canPushCreatures = false, -- Not confirmed
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 4, -- Not confirmed
+	color = 208, -- Not confirmed
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 100, type = COMBAT_FIREDAMAGE, minDamage = -400, maxDamage = -800, radius = 4, effect = CONST_ME_FIREATTACK, target = false }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 40, -- Not confirmed
+	armor = 40, -- Not confirmed
+	mitigation = 1.50, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/raging_raubritter.lua
+++ b/data/monsters/winter_update_2025/quests/raging_raubritter.lua
@@ -1,0 +1,100 @@
+local mType = Game.createMonsterType("Raging Raubritter")
+local monster = {}
+
+monster.name = "Raging Raubritter"
+monster.description = "a raging raubritter"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1900,
+	lookHead = 94,
+	lookBody = 113,
+	lookLegs = 113,
+	lookFeet = 113,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 35000
+monster.maxHealth = 35000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "IT BURNS... MASTER.", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 200, maxDamage = -1000 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -800, maxDamage = -1200, target = false, radius = 3, effect = CONST_ME_BLOOD_RAIN },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -800, maxDamage = -1200, range = 7, radius = 3, effect = CONST_ME_YELLOWENERGY, shootEffect = CONST_ANI_BURSTARROW, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -600, maxDamage = -1000, range = 7, radius = 1, effect = CONST_ME_HITBYFIRE, shootEffect = CONST_ANI_FIRE, target = true },
+	{ name = "fire chain", interval = 2000, chance = 15, minDamage = -600, maxDamage = -1500 },
+}
+
+monster.defenses = {
+	defense = 80,
+	armor = 80,
+	mitigation = 2.31,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/scaritha_spirit.lua
+++ b/data/monsters/winter_update_2025/quests/scaritha_spirit.lua
@@ -1,0 +1,94 @@
+local mType = Game.createMonsterType("Scarith's Spirit")
+local monster = {}
+
+monster.description = "Scarith's spirit"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1883,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- não confirmado
+	health = 10, -- não confirmado
+	damage = 10, -- não confirmado
+	random = 10, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 4, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Death Wave (900+), Death Strike (900+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_DEATHDAMAGE, minDamage = -650, maxDamage = -900, length = 8, spread = 3, effect = CONST_ME_MORTAREA, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_DEATHDAMAGE, minDamage = -650, maxDamage = -900, range = 7, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 75, -- não confirmado
+	armor = 75, -- não confirmado
+	mitigation = 2.30, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- não confirmado
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- não confirmado
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/scariths_soulcage.lua
+++ b/data/monsters/winter_update_2025/quests/scariths_soulcage.lua
@@ -1,0 +1,85 @@
+local mType = Game.createMonsterType("Scarith's Soulcage")
+local monster = {}
+
+monster.description = "Scarith's soulcage"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 52546,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 1, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true, -- não confirmado
+	canWalkOnFire = true, -- não confirmado
+	canWalkOnPoison = true, -- não confirmado
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Death Chain (1400+), Death Explosion (700+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_DEATHDAMAGE, minDamage = -1400, maxDamage = -2000, length = 8, spread = 3, effect = CONST_ME_MORTAREA, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_DEATHDAMAGE, minDamage = -700, maxDamage = -1000, radius = 4, effect = CONST_ME_MORTAREA, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 80, -- não confirmado
+	armor = 80, -- não confirmado
+	mitigation = 2.50, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/tamed_frazzlemaw.lua
+++ b/data/monsters/winter_update_2025/quests/tamed_frazzlemaw.lua
@@ -1,0 +1,92 @@
+local mType = Game.createMonsterType("Tamed Frazzlemaw")
+local monster = {}
+
+monster.name = "Tamed Frazzlemaw"
+monster.description = "a tamed frazzlemaw"
+monster.experience = 0
+monster.outfit = {
+	lookType = 594,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1000
+monster.maxHealth = 1000
+monster.race = "blood"
+monster.corpse = 0
+monster.speed = 165 -- Not confirmed
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = false,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90, -- Not confirmed
+	targetDistance = 1, -- Not confirmed
+	runHealth = 0, -- Not confirmed
+	healthHidden = false, -- Not confirmed
+	isBlockable = false, -- Not confirmed
+	canWalkOnEnergy = true, -- Not confirmed
+	canWalkOnFire = true, -- Not confirmed
+	canWalkOnPoison = true, -- Not confirmed
+}
+
+monster.light = {
+	level = 0, -- Not confirmed
+	color = 0, -- Not confirmed
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -800 }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -500, maxDamage = -900, radius = 4, effect = CONST_ME_HITAREA, target = false }, -- Not confirmed
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -400, maxDamage = -700, range = 1, effect = CONST_ME_DRAWBLOOD, target = true }, -- Not confirmed
+}
+
+monster.defenses = {
+	defense = 90, -- Not confirmed
+	armor = 90, -- Not confirmed
+	mitigation = 2.60, -- Not confirmed
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- Not confirmed
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true }, -- Not confirmed
+	{ type = "outfit", condition = true }, -- Not confirmed
+	{ type = "invisible", condition = true }, -- Not confirmed
+	{ type = "bleed", condition = true }, -- Not confirmed
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/zharvorina_spirit.lua
+++ b/data/monsters/winter_update_2025/quests/zharvorina_spirit.lua
@@ -1,0 +1,94 @@
+local mType = Game.createMonsterType("Zharvorin's Spirit")
+local monster = {}
+
+monster.description = "Zharvorin's Spirit"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1883,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70, -- não confirmado
+	health = 10, -- não confirmado
+	damage = 10, -- não confirmado
+	random = 10, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 4, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Ice Wave (900+), Ice Strike (1700+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ICEDAMAGE, minDamage = -650, maxDamage = -900, length = 8, spread = 3, effect = CONST_ME_ICEAREA, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ICEDAMAGE, minDamage = -1200, maxDamage = -1700, range = 7, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = true }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 75, -- não confirmado
+	armor = 75, -- não confirmado
+	mitigation = 2.30, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true }, -- não confirmado
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = true }, -- não confirmado
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/quests/zharvorins_soulcage.lua
+++ b/data/monsters/winter_update_2025/quests/zharvorins_soulcage.lua
@@ -1,0 +1,85 @@
+local mType = Game.createMonsterType("Zharvorin's Soulcage")
+local monster = {}
+
+monster.description = "Zharvorin's Soulcage"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 52546,
+}
+
+monster.health = 120000
+monster.maxHealth = 120000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100, -- não confirmado
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90, -- não confirmado
+	targetDistance = 1, -- não confirmado
+	runHealth = 0, -- não confirmado
+	healthHidden = false, -- não confirmado
+	isBlockable = false, -- não confirmado
+	canWalkOnEnergy = true, -- não confirmado
+	canWalkOnFire = true, -- não confirmado
+	canWalkOnPoison = true, -- não confirmado
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.loot = {}
+
+-- Ice Explosion (700+), Ice Chain (700+)
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ICEDAMAGE, minDamage = -700, maxDamage = -1200, length = 8, spread = 3, effect = CONST_ME_ICEATTACK, target = false }, -- não confirmado
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ICEDAMAGE, minDamage = -700, maxDamage = -1000, radius = 4, effect = CONST_ME_ICEAREA, target = false }, -- não confirmado
+}
+
+monster.defenses = {
+	defense = 80, -- não confirmado
+	armor = 80, -- não confirmado
+	mitigation = 2.50, -- não confirmado
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_MANADRAIN, percent = 0 }, -- não confirmado
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 }, -- não confirmado
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/raubritter_chastener.lua
+++ b/data/monsters/winter_update_2025/raubritter_chastener.lua
@@ -1,0 +1,133 @@
+local mType = Game.createMonsterType("Raubritter Chastener")
+local monster = {}
+
+monster.name = "Raubritter Chastener"
+monster.description = "a raubritter chastener"
+monster.experience = 9500
+monster.outfit = {
+	lookType = 1902,
+	lookHead = 94,
+	lookBody = 19,
+	lookLegs = 21,
+	lookFeet = 78,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2752
+monster.Bestiary = {
+	class = "Human",
+	race = BESTY_RACE_HUMAN,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 0,
+	Locations = "Adaean Shore, Adaean Silver Mines, Arean Outskirts, Bloodfire Gorge, Isle of Ada, Stag Bastion, Adaean Crystal Mines.",
+}
+
+monster.health = 10000
+monster.maxHealth = 10000
+monster.race = "blood"
+monster.corpse = 52692
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "This is ours now!", yell = false },
+	{ text = "Purification! Sal... vation! Deliver...", yell = false },
+	{ text = "I'll... hunt you... down!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, minCount = 4, maxCount = 10 },
+	{ name = "small amethyst", chance = 9810 },
+	{ name = "small ruby", chance = 7700 },
+	{ id = 3039, chance = 5350 }, -- red gem
+	{ name = "magma monocle", chance = 3710 },
+	{ name = "wand of cosmic energy", chance = 2520 },
+	-- { name = "stag parchment", chance = 2050 },
+	-- { name = "silver poniard", chance = 1530 },
+	{ name = "wand of starstorm", chance = 1390 },
+	{ name = "violet gem", chance = 1090 },
+	{ name = "wooden spellbook", chance = 1050 },
+	{ name = "lightning robe", chance = 780 },
+	{ id = 23531, chance = 580 }, -- ring of green plasma
+	{ name = "shockwave amulet", chance = 560 },
+	{ name = "magma amulet", chance = 280 },
+	-- { name = "bottle of raubritter lager", chance = 110 },
+	{ name = "crystal coin", chance = 50, minCount = 56, maxCount = 128 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 80, minDamage = 0, maxDamage = -500 },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -300, maxDamage = -380, radius = 4, effect = CONST_ME_EXPLOSIONAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -300, maxDamage = -380, range = 1, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HOLYDAMAGE, minDamage = -300, maxDamage = -380, radius = 3, effect = CONST_ME_HOLYAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -380, radius = 3, effect = CONST_ME_BLOOD_RAIN, target = false },
+}
+
+monster.defenses = {
+	defense = 80,
+	armor = 80,
+	mitigation = 2.31,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -20 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -12 },
+	{ type = COMBAT_FIREDAMAGE, percent = -6 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/raubritter_marksman.lua
+++ b/data/monsters/winter_update_2025/raubritter_marksman.lua
@@ -1,0 +1,129 @@
+local mType = Game.createMonsterType("Raubritter Marksman")
+local monster = {}
+
+monster.name = "Raubritter Marksman"
+monster.description = "a raubritter marksman"
+monster.experience = 9025
+monster.outfit = {
+	lookType = 1901,
+	lookHead = 94,
+	lookBody = 19,
+	lookLegs = 118,
+	lookFeet = 2,
+	lookAddons = 2,
+	lookMount = 0,
+}
+
+monster.raceId = 2751
+monster.Bestiary = {
+	class = "Human",
+	race = BESTY_RACE_HUMAN,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 0,
+	Locations = "Adaean Shore, Adaean Silver Mines, Arean Outskirts, Bloodfire Gorge, Isle of Ada, Stag Bastion, Adaean Crystal Mines.",
+}
+
+monster.health = 10500
+monster.maxHealth = 10500
+monster.race = "blood"
+monster.corpse = 52688
+monster.speed = 170
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 4,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "This is ours now!", yell = false },
+	{ text = "Gnnnah!!!", yell = false },
+	{ text = "I'll... hunt you... down!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, minCount = 6, maxCount = 12 },
+	-- { name = "cuirass plate", chance = 5210 },
+	-- { name = "stag parchment", chance = 2490, maxCount = 2 },
+	{ name = "blue crystal shard", chance = 1850 },
+	{ name = "violet crystal shard", chance = 1840 },
+	{ name = "green crystal shard", chance = 1770 },
+	{ name = "terra mantle", chance = 850 },
+	{ name = "green gem", chance = 820 },
+	{ name = "blue gem", chance = 810 },
+	{ id = 23529, chance = 520 }, -- ring of blue plasma
+	{ name = "crystalline arrow", chance = 480, minCount = 10, maxCount = 20 },
+	{ name = "composite hornbow", chance = 310 },
+	{ name = "violet gem", chance = 210 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 80, minDamage = 0, maxDamage = -500 },
+	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_FIREDAMAGE, minDamage = -350, maxDamage = -450, range = 4, shootEffect = CONST_ANI_INFERNALBOLT, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_HOLYDAMAGE, minDamage = -350, maxDamage = -450, range = 4, shootEffect = CONST_ANI_BOLT, effect = CONST_ME_HOLYAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_PHYSICALDAMAGE, minDamage = -350, maxDamage = -450, range = 4, shootEffect = CONST_ANI_VORTEXBOLT, effect = CONST_ME_DRAWBLOOD, target = true },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -350, maxDamage = -450, range = 4, radius = 3, shootEffect = CONST_ANI_POWERBOLT, effect = CONST_ME_ENERGYAREA, target = true },
+}
+
+monster.defenses = {
+	defense = 100,
+	armor = 100,
+	mitigation = 2.16,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -16 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 12 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -12 },
+	{ type = COMBAT_FIREDAMAGE, percent = -12 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/raubritter_skirmisher.lua
+++ b/data/monsters/winter_update_2025/raubritter_skirmisher.lua
@@ -1,0 +1,131 @@
+local mType = Game.createMonsterType("Raubritter Skirmisher")
+local monster = {}
+
+monster.name = "Raubritter Skirmisher"
+monster.description = "a raubritter skirmisher"
+monster.experience = 8550
+monster.outfit = {
+	lookType = 1900,
+	lookHead = 94,
+	lookBody = 19,
+	lookLegs = 3,
+	lookFeet = 19,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2750
+monster.Bestiary = {
+	class = "Human",
+	race = BESTY_RACE_HUMAN,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 0,
+	Locations = "Adaean Shore, Adaean Silver Mines, Arean Outskirts, Bloodfire Gorge, Isle of Ada, Stag Bastion, Adaean Crystal Mines.",
+}
+
+monster.health = 11000
+monster.maxHealth = 11000
+monster.race = "blood"
+monster.corpse = 52684
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I'll... hunt you... down!", yell = false },
+	{ text = "This is ours now!", yell = false },
+	{ text = "Purification! Sal... vation! Deliver...", yell = false },
+	{ text = "Nnnooo... not... yesss, KILL!", yell = false },
+	{ text = "Out... sider, hrngh!", yell = false },
+	{ text = "Must... resist!", yell = false },
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 100000, minCount = 5, maxCount = 10 },
+	-- { name = "cuirass plate", chance = 4150 },
+	-- { name = "silver poniard", chance = 1950 },
+	{ name = "gold ring", chance = 1910 },
+	{ name = "fur armor", chance = 1180 },
+	{ name = "mercenary sword", chance = 1050 },
+	{ name = "crown shield", chance = 1030 },
+	{ name = "gold ingot", chance = 840 },
+	{ name = "crown armor", chance = 720 },
+	-- { name = "marinated sturgeon", chance = 270 },
+	{ id = 50150, chance = 170 }, -- ring of orange plasma
+	{ id = 23533, chance = 120 }, -- ring of red plasma
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 80, minDamage = 0, maxDamage = -500 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -300, maxDamage = -380, radius = 4, effect = CONST_ME_GROUNDSHAKER, target = false },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -350, maxDamage = -450, range = 4, shootEffect = CONST_ANI_WHIRLWINDSWORD, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -150, maxDamage = -250, range = 4, shootEffect = CONST_ANI_THROWINGKNIFE, target = true },
+	{ name = "Skirmisher Wave", interval = 2000, chance = 15, minDamage = -220, maxDamage = -300, target = false },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 120,
+	mitigation = 2.45,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -12 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 9 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -6 },
+	{ type = COMBAT_FIREDAMAGE, percent = -15 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/roaming_dread.lua
+++ b/data/monsters/winter_update_2025/roaming_dread.lua
@@ -1,0 +1,124 @@
+local mType = Game.createMonsterType("Roaming Dread")
+local monster = {}
+
+monster.name = "Roaming Dread"
+monster.description = "a roaming dread"
+monster.experience = 12040
+monster.outfit = {
+	lookType = 1904,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2765
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 2500,
+	FirstUnlock = 100,
+	SecondUnlock = 1000,
+	CharmsPoints = 50,
+	Stars = 4,
+	Occurrence = 0,
+	Locations = "Forsaken Crypt.",
+}
+
+monster.health = 14500
+monster.maxHealth = 14500
+monster.race = "undead"
+monster.corpse = 52559
+monster.speed = 190
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "platinum coin", chance = 23870, minCount = 10, maxCount = 20 },
+	{ name = "crystal coin", chance = 11370 },
+	{ name = "green crystal fragment", chance = 4970, maxCount = 4 },
+	-- { name = "crystallized death", chance = 4290 },
+	{ name = "small emerald", chance = 3010, maxCount = 15 },
+	-- { name = "toe nails", chance = 2480 },
+	{ name = "green crystal shard", chance = 1730, maxCount = 4 },
+	{ name = "jade hammer", chance = 1510 },
+	-- { name = "necromantic core", chance = 900 },
+	{ name = "crystal mace", chance = 830 },
+	{ name = "crystalline armor", chance = 830 },
+	{ name = "green gem", chance = 150, minCount = 2, maxCount = 4 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -700 },
+	{ name = "Roaming Physical Ring", interval = 2000, chance = 30, minDamage = -300, maxDamage = -1050, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -250, maxDamage = -1300, range = 1, effect = CONST_ME_REAPER, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -900, maxDamage = -1480, range = 3, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 120,
+	mitigation = 2.75,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -9 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -9 },
+	{ type = COMBAT_FIREDAMAGE, percent = -9 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -9 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -18 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/stag.lua
+++ b/data/monsters/winter_update_2025/stag.lua
@@ -1,0 +1,121 @@
+local mType = Game.createMonsterType("Stag")
+local monster = {}
+
+monster.name = "Stag"
+monster.description = "a stag"
+monster.experience = 0
+monster.outfit = {
+	lookType = 1913,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2774
+monster.Bestiary = {
+	class = "Mammal",
+	race = BESTY_RACE_MAMMAL,
+	toKill = 250,
+	FirstUnlock = 10,
+	SecondUnlock = 100,
+	CharmsPoints = 5,
+	Stars = 1,
+	Occurrence = 0,
+	Locations = "Arean Outskirts",
+}
+
+monster.health = 50
+monster.maxHealth = 50
+monster.race = "blood"
+monster.corpse = 52841
+monster.speed = 98
+monster.manaCost = 260
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = true,
+	attackable = true,
+	hostile = false,
+	convinceable = true,
+	pushable = true,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 25,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+	isPreyExclusive = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "meat", chance = 77890, maxCount = 4 },
+	{ name = "ham", chance = 46770 },
+	-- { name = "tender venison", chance = 25850 },
+	{ id = 10297, chance = 1700 }, -- antlers
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1 },
+}
+
+monster.defenses = {
+	defense = 5,
+	armor = 5,
+	mitigation = 0.05,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+monster.onSpawn = function(self, position)
+	if math.random(100) <= 5 then
+		self:remove()
+		Game.createMonster("Imperial", position, false, true)
+	end
+end
+
+mType:register(monster)

--- a/data/monsters/winter_update_2025/walking_dread.lua
+++ b/data/monsters/winter_update_2025/walking_dread.lua
@@ -1,0 +1,128 @@
+local mType = Game.createMonsterType("Walking Dread")
+local monster = {}
+
+monster.name = "Walking Dread"
+monster.description = "a walking dread"
+monster.experience = 18000
+monster.outfit = {
+	lookType = 1886,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 2759
+monster.Bestiary = {
+	class = "Undead",
+	race = BESTY_RACE_UNDEAD,
+	toKill = 5000,
+	FirstUnlock = 200,
+	SecondUnlock = 2000,
+	CharmsPoints = 100,
+	Stars = 5,
+	Occurrence = 0,
+	Locations = "Outer Crypt.",
+}
+
+monster.health = 25000
+monster.maxHealth = 25000
+monster.race = "undead"
+monster.corpse = 52559
+monster.speed = 225
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Haaarrgh!", yell = false },
+	{ text = "Uuuhmmm!", yell = false },
+}
+
+monster.loot = {
+	{ name = "crystal coin", chance = 38990 },
+	{ name = "cyan crystal fragment", chance = 6150, maxCount = 4 },
+	{ name = "small sapphire", chance = 5100, maxCount = 15 },
+	{ name = "blue crystal shard", chance = 4370, maxCount = 4 },
+	-- { name = "toe nails", chance = 2730 },
+	-- { name = "crystallized death", chance = 1890 },
+	{ name = "blue gem", chance = 1020, maxCount = 4 },
+	-- { name = "necromantic core", chance = 770 },
+	{ name = "relic sword", chance = 370 },
+	{ name = "abyss hammer", chance = 270 },
+	{ name = "onyx flail", chance = 200 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -300, maxDamage = -800 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -750, maxDamage = -1200, radius = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -750, maxDamage = -1200, radius = 5, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -400, maxDamage = -900, radius = 6, effect = CONST_ME_LOSEENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 120,
+	mitigation = 2.75,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -9 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -9 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 8 },
+	{ type = COMBAT_FIREDAMAGE, percent = 12 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -12 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -3 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data/scripts/spells/spells_monsters/crypt_construct_wave.lua
+++ b/data/scripts/spells/spells_monsters/crypt_construct_wave.lua
@@ -1,0 +1,28 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GREEN_EXPLOSIONHIT)
+
+local arr = {
+	{ 1, 1, 1, 1, 1, 1, 1 },
+	{ 0, 1, 1, 1, 1, 1, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 0, 0, 3, 0, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("Crypt Construct Wave")
+spell:words("###crypt_construct_wave")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(true)
+spell:register()

--- a/data/scripts/spells/spells_monsters/crypt_x.lua
+++ b/data/scripts/spells/spells_monsters/crypt_x.lua
@@ -1,0 +1,34 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_PURPLESMOKE)
+
+local arr = {
+	{ 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("Crypt X")
+spell:words("###crypt_x")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()

--- a/data/scripts/spells/spells_monsters/deathcircle.lua
+++ b/data/scripts/spells/spells_monsters/deathcircle.lua
@@ -1,0 +1,32 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_DEATHDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MORTAREA)
+
+local arr = {
+	{ 0, 0, 0, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 1, 1, 1, 1, 1, 0, 0 },
+	{ 0, 1, 1, 1, 0, 1, 1, 1, 0 },
+	{ 1, 1, 1, 0, 0, 0, 1, 1, 1 },
+	{ 1, 1, 0, 0, 2, 0, 0, 1, 1 },
+	{ 1, 1, 1, 0, 0, 0, 1, 1, 1 },
+	{ 0, 1, 1, 1, 0, 1, 1, 1, 0 },
+	{ 0, 0, 1, 1, 1, 1, 1, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 0, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("deathcircle")
+spell:words("###deathcircle")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()

--- a/data/scripts/spells/spells_monsters/energy_cruz.lua
+++ b/data/scripts/spells/spells_monsters/energy_cruz.lua
@@ -1,0 +1,34 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYAREA)
+
+local arr = {
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("Energy Cruz")
+spell:words("###energy_cruz")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()

--- a/data/scripts/spells/spells_monsters/fire_chain.lua
+++ b/data/scripts/spells/spells_monsters/fire_chain.lua
@@ -1,0 +1,23 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_FIREDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_FIREATTACK)
+combat:setParameter(COMBAT_PARAM_CHAIN_EFFECT, CONST_ME_FIREATTACK)
+
+function getChainValue(creature)
+	return 3, 3, false
+end
+
+combat:setCallback(CALLBACK_PARAM_CHAINVALUE, "getChainValue")
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("fire chain")
+spell:words("###fire_chain")
+spell:needLearn(true)
+spell:cooldown("2000")
+spell:isSelfTarget(true)
+spell:register()

--- a/data/scripts/spells/spells_monsters/night_harpy_cone_wave.lua
+++ b/data/scripts/spells/spells_monsters/night_harpy_cone_wave.lua
@@ -1,0 +1,28 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_DEATHDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MORTAREA)
+
+local arr = {
+	{ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("night harpy cone wave")
+spell:words("###night_harpy_cone_wave")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(true)
+spell:register()

--- a/data/scripts/spells/spells_monsters/night_harpy_scratch.lua
+++ b/data/scripts/spells/spells_monsters/night_harpy_scratch.lua
@@ -1,0 +1,28 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_SLASH)
+
+local arr = {
+	{ 0, 0, 1, 0, 0 },
+	{ 0, 1, 1, 1, 0 },
+	{ 1, 1, 2, 1, 1 },
+	{ 0, 1, 1, 1, 0 },
+	{ 0, 0, 1, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("night harpy scratch")
+spell:words("###night_harpy_scratch")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()

--- a/data/scripts/spells/spells_monsters/night_harpy_shielding_ball.lua
+++ b/data/scripts/spells/spells_monsters/night_harpy_shielding_ball.lua
@@ -1,0 +1,30 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYAREA)
+
+local arr = {
+	{ 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 1, 1, 1, 1, 1, 0 },
+	{ 1, 1, 1, 1, 1, 1, 1 },
+	{ 1, 1, 1, 2, 1, 1, 1 },
+	{ 1, 1, 1, 1, 1, 1, 1 },
+	{ 0, 1, 1, 1, 1, 1, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("night harpy shielding ball")
+spell:words("###night_harpy_shielding_ball")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()

--- a/data/scripts/spells/spells_monsters/roaming_physical_ring.lua
+++ b/data/scripts/spells/spells_monsters/roaming_physical_ring.lua
@@ -1,0 +1,34 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_WHITE_EXPLOSIONHIT)
+
+local arr = {
+	{ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0 },
+	{ 0, 1, 1, 1, 0, 0, 2, 0, 0, 1, 1, 1, 0 },
+	{ 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0 },
+	{ 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("Roaming Physical Ring")
+spell:words("###roaming_physical_ring")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()

--- a/data/scripts/spells/spells_monsters/skirmisher_wave.lua
+++ b/data/scripts/spells/spells_monsters/skirmisher_wave.lua
@@ -1,0 +1,27 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+
+local arr = {
+	{ 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },
+	{ 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("Skirmisher Wave")
+spell:words("###skirmisher_wave")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(true)
+spell:register()

--- a/data/scripts/spells/spells_monsters/wave_death_crypt.lua
+++ b/data/scripts/spells/spells_monsters/wave_death_crypt.lua
@@ -1,0 +1,36 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_DEATHDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MORTAREA)
+
+local arr = {
+	{ 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0 },
+	{ 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0 },
+	{ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+	{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 },
+	{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 },
+	{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 },
+	{ 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0 },
+	{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 },
+	{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 },
+	{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 },
+	{ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+	{ 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0 },
+	{ 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0 },
+}
+
+local area = createCombatArea(arr)
+combat:setArea(area)
+
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, var)
+	return combat:execute(creature, var)
+end
+
+spell:name("Wave Death Crypt")
+spell:words("###wave_death_crypt")
+spell:isAggressive(true)
+spell:blockWalls(true)
+spell:needLearn(true)
+spell:needDirection(false)
+spell:register()


### PR DESCRIPTION
Update for New Monsters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Adicionados 4 novos monstros e chefes ao jogo, incluindo Muglex Clan Chief, The Corruptor, Corrupted Ghost e Corrupted Skeleton, cada um com ataques, defesas, loot e comportamentos exclusivos configurados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->