### PR TITLE
feat: add getMonstersByBestiaryStars function to CustomBestiary

### DIFF
--- a/data/scripts/lib/custom_bestiary.lua
+++ b/data/scripts/lib/custom_bestiary.lua
@@ -315,3 +315,22 @@ function CustomBestiary.getLootTier(chance)
 	end
 	return 0
 end
+
+function CustomBestiary.getMonstersByStars(starFilter)
+	local result = {}
+	starFilter = tonumber(starFilter) or 0
+	for _, entry in pairs(CustomBestiary.monstersByRaceId) do
+		if entry.stars == starFilter then
+			result[#result + 1] = entry
+		end
+	end
+	table.sort(result, function(a, b) return a.name < b.name end)
+	return result
+end
+
+function Game.getMonstersByBestiaryStars(stars)
+	if not CustomBestiary then
+		return {}
+	end
+	return CustomBestiary.getMonstersByStars(stars)
+end

--- a/data/scripts/lib/custom_bestiary.lua
+++ b/data/scripts/lib/custom_bestiary.lua
@@ -1,5 +1,8 @@
 if not configManager.getBoolean(configKeys.BESTIARY_SYSTEM_ENABLED) then
 	CustomBestiary = nil
+	function Game.getMonstersByBestiaryStars(_stars)
+		return {}
+	end
 	return
 end
 
@@ -319,12 +322,12 @@ end
 function CustomBestiary.getMonstersByStars(starFilter)
 	local result = {}
 	starFilter = tonumber(starFilter) or 0
-	for _, entry in pairs(CustomBestiary.monstersByRaceId) do
+	for _, entry in pairs(CustomBestiary.monstersByRaceId or {}) do
 		if entry.stars == starFilter then
 			result[#result + 1] = entry
 		end
 	end
-	table.sort(result, function(a, b) return a.name < b.name end)
+	table.sort(result, function(a, b) return (a.name or ""):lower() < (b.name or ""):lower() end)
 	return result
 end
 


### PR DESCRIPTION
## Description

Adds the missing `getMonstersByBestiaryStars` function to the CustomBestiary system, mirroring the functionality necessary to manage monsters in task hunt `luaMonsterTypeGetMonstersByBestiaryStars`.

## Changes

- `CustomBestiary.getMonstersByStars(starFilter)` - Filters monsters by star count (1-5), returns sorted array of bestiary entries
- `Game.getMonstersByBestiaryStars(stars)` - Global accessor function for convenience

## Usage

```lua
-- Get all monsters with 3 stars
local monsters = Game.getMonstersByBestiaryStars(3)
for _, entry in ipairs(monsters) do
    print(entry.name .. ' - ' .. entry.stars .. ' stars')
end

-- Or directly via CustomBestiary
local monsters = CustomBestiary.getMonstersByStars(5)
```

## Related

Mirrors Crystalserver's implementation:
- `MonsterType:getMonstersByBestiaryStars(stars)`
- `Game.getMonstersByBestiaryStars(stars)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Permite filtrar monstros personalizados pela quantidade de estrelas, com resultados ordenados alfabeticamente.
  * Integração global para consulta por estrelas: quando o sistema de bestiário está desabilitado ou o bestiário personalizado não existe, as consultas retornam vazio; caso contrário, retornam os resultados filtrados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->