### PR TITLE
fix: atualiza setup-jenkins.sh para Jenkins 2.555.3

### DIFF
--- a/setup-jenkins.sh
+++ b/setup-jenkins.sh
@@ -9,12 +9,17 @@ NC='\033[0m'
 echo -e "${CYAN}=== Instalando Jenkins ===${NC}"
 
 sudo apt update
-sudo apt install -y fontconfig openjdk-17-jre
+sudo apt install -y fontconfig openjdk-21-jre
 
 sudo mkdir -p /etc/apt/keyrings
-wget -O- https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | \
-    sudo gpg --dearmor -o /etc/apt/keyrings/jenkins.gpg
+sudo rm -f /etc/apt/keyrings/jenkins.gpg
+
+sudo GNUPGHOME=/root/.gnupg gpg --no-default-keyring \
+    --keyring /etc/apt/keyrings/jenkins.gpg \
+    --keyserver keyserver.ubuntu.com --recv-keys 7198F4B714ABFC68
 sudo chmod a+r /etc/apt/keyrings/jenkins.gpg
+
+sudo rm -f /etc/apt/sources.list.d/jenkins.list
 echo "deb [signed-by=/etc/apt/keyrings/jenkins.gpg] https://pkg.jenkins.io/debian-stable binary/" | \
     sudo tee /etc/apt/sources.list.d/jenkins.list > /dev/null
 


### PR DESCRIPTION
- GPG key antiga expirou (2026-03-26) - busca via keyserver
- Jenkins 2.555.3 exige Java 21 (era Java 17)

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Refactor**
  * Script de configuração do Jenkins atualizado: agora utiliza Java 21 em substituição à versão anterior (Java 17), proporcionando melhor compatibilidade, segurança e desempenho. O método de configuração de repositório e importação de chaves de segurança foi otimizado para aumentar a confiabilidade e a eficiência durante todo o processo de instalação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->