### PR TITLE
Restrict Astra protocol packets to AstraClient

### DIFF
--- a/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
+++ b/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
@@ -108,7 +108,7 @@ event.onDropLoot = function(self, corpse)
 				local useColorized = configManager.getBoolean(configKeys.COLORIZED_LOOT_VALUE)
 				local party = player:getParty()
 				if useColorized then
-					-- Per-receiver message: colorized for OtClient, plain for others
+					-- Per-receiver message: colorized for AstraClient, plain for others
 					local colorizedText = ("Loot of %s: %s%s."):format(mType:getNameDescription(),
 					                                                   corpse:getContentDescription(true),
 					                                                   preyLootText)
@@ -119,15 +119,15 @@ event.onDropLoot = function(self, corpse)
 						local members = party:getMembers()
 						local leader = party:getLeader()
 						if leader then
-							local leaderText = (leader.isUsingOtClient and leader:isUsingOtClient()) and colorizedText or plainText
+							local leaderText = (leader.isUsingAstraClient and leader:isUsingAstraClient()) and colorizedText or plainText
 							sendLootMessage(leader, leaderText)
 						end
 						for _, member in ipairs(members) do
-							local memberText = (member.isUsingOtClient and member:isUsingOtClient()) and colorizedText or plainText
+							local memberText = (member.isUsingAstraClient and member:isUsingAstraClient()) and colorizedText or plainText
 							sendLootMessage(member, memberText)
 						end
 					else
-						local playerText = (player.isUsingOtClient and player:isUsingOtClient()) and colorizedText or plainText
+						local playerText = (player.isUsingAstraClient and player:isUsingAstraClient()) and colorizedText or plainText
 						sendLootMessage(player, playerText)
 					end
 				else

--- a/data/scripts/network/boss_cooldown/bosscooldown.lua
+++ b/data/scripts/network/boss_cooldown/bosscooldown.lua
@@ -4,8 +4,8 @@
 
 local OPCODE_BOSS_COOLDOWN = 0x2C
 
-local function isOTC(player)
-	return player and player:isUsingOtClient()
+local function supportsAstraClient(player)
+	return player and player.isUsingAstraClient and player:isUsingAstraClient()
 end
 
 local function getBossOutfit(lookType)
@@ -42,7 +42,7 @@ local function getBossList()
 end
 
 local function sendCooldowns(player)
-	if not player or not isOTC(player) then return false end
+	if not supportsAstraClient(player) then return false end
 
 	local kv = player:kv()
 	if not kv then return false end
@@ -91,7 +91,7 @@ end
 -- Login event
 local bossLogin = CreatureEvent("BossCooldownLogin")
 function bossLogin.onLogin(player)
-	if not isOTC(player) then return true end
+	if not supportsAstraClient(player) then return true end
 	addEvent(function(pid)
 		local p = Player(pid)
 		if p then sendCooldowns(p) end

--- a/data/scripts/network/quickloot.lua
+++ b/data/scripts/network/quickloot.lua
@@ -321,6 +321,10 @@ local function findDestinationContainer(player, category)
 end
 
 local function sendLootContainers(player)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
 	local pid = player:getId()
 
 	local msg = NetworkMessage(player)
@@ -330,8 +334,7 @@ local function sendLootContainers(player)
 
 	if not managedContainers[pid] then
 		msg:addByte(0)
-		msg:sendToPlayer(player)
-		return
+		return msg:sendToPlayer(player)
 	end
 
 	-- First section: loot containers (category + lootId, 3 bytes each)
@@ -366,17 +369,21 @@ local function sendLootContainers(player)
 		end
 	end
 
-	msg:sendToPlayer(player)
+	return msg:sendToPlayer(player)
 end
 
 local function sendLootStats(player, itemId, count)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
 	local msg = NetworkMessage(player)
 	msg:addByte(OPCODE_SEND_LOOT_STATS)
 	msg:addItemId(itemId)
 	msg:addByte(count)
 	local itemType = ItemType(itemId)
 	msg:addString(itemType and itemType:getName() or "")
-	msg:sendToPlayer(player)
+	return msg:sendToPlayer(player)
 end
 
 local function findDestinationContainerCached(player, category, cache)
@@ -591,6 +598,9 @@ end
 -- CreatureEvent: auto-loot on kill
 local killEvent = CreatureEvent("QuickLootKill")
 function killEvent.onKill(player, target)
+	if not supportsCustomNetwork(player) then
+		return true
+	end
 
 	local killerId = player:getId()
 	local targetPos = target:getPosition()
@@ -599,6 +609,9 @@ function killEvent.onKill(player, target)
 	addEvent(function()
 		local killer = Player(killerId)
 		if not killer then
+			return
+		end
+		if not supportsCustomNetwork(killer) then
 			return
 		end
 
@@ -616,7 +629,7 @@ function killEvent.onKill(player, target)
 		local party = killer:getParty()
 		if party then
 			local leader = party:getLeader()
-			if leader and leader ~= killer then
+			if leader and leader ~= killer and supportsCustomNetwork(leader) then
 				local leaderPos = leader:getPosition()
 				if leaderPos:getDistance(targetPos) <= 10 then
 					recipient = leader
@@ -862,6 +875,10 @@ blackWhitelistHandler:register()
 -- Login handler: restore state from KV and send loot container state
 local loginEvent = CreatureEvent("QuickLootLogin")
 function loginEvent.onLogin(player)
+	if not supportsCustomNetwork(player) then
+		return true
+	end
+
 	local pid = player:getId()
 	managedContainers[pid] = managedContainers[pid] or {}
 	quickLootState[pid] = quickLootState[pid] or {

--- a/src/luanetworkmessage.cpp
+++ b/src/luanetworkmessage.cpp
@@ -15,7 +15,6 @@ bool isOtcOnlyLuaOpcode(uint8_t opcode)
 	switch (opcode) {
 		case 0x29: // custom supply stash
 		case 0x2B: // custom party hunt analyzer
-		case 0x2C: // custom boss cooldown
 		case 0x2D: // custom charm activated
 		case 0x2F: // custom unjustified points
 		case 0x30: // custom imbuement activated
@@ -29,8 +28,6 @@ bool isOtcOnlyLuaOpcode(uint8_t opcode)
 		case 0xA7: // custom fight mode sync
 		case 0xBA: // native hunting task base data
 		case 0xBB: // native hunting task slot data
-		case 0xC6: // custom item values
-		case 0xC7: // custom item details
 		case 0xD1: // custom hunt analyzer
 		case 0xDB: // custom market
 		case 0xEB: // imbuing window
@@ -48,6 +45,22 @@ bool isOtcOnlyLuaOpcode(uint8_t opcode)
 	}
 }
 
+bool isAstraOnlyLuaOpcode(uint8_t opcode)
+{
+	switch (opcode) {
+		case 0x2C: // custom boss cooldown
+		case 0x9B: // blessing window
+		case 0x9C: // blessing status
+		case 0xC0: // managed quick-loot containers
+		case 0xC6: // custom item values
+		case 0xC7: // custom item details
+		case 0xCF: // quick-loot statistics
+			return true;
+		default:
+			return false;
+	}
+}
+
 bool canSendLuaNetworkMessageToPlayer(const NetworkMessage& message, const Player& player)
 {
 	if (message.getLength() == 0) {
@@ -55,6 +68,9 @@ bool canSendLuaNetworkMessageToPlayer(const NetworkMessage& message, const Playe
 	}
 
 	const uint8_t opcode = message.getBuffer()[NetworkMessage::INITIAL_BUFFER_POSITION];
+	if (isAstraOnlyLuaOpcode(opcode) && !player.isAstraClient()) {
+		return false;
+	}
 	return !isOtcOnlyLuaOpcode(opcode) || player.isOTC();
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -6685,48 +6685,58 @@ void Player::flushPendingLoot(const std::string& groupKey)
 		ss << ": ";
 	}
 
-	bool first = true;
-	const bool colorizedLootValue = ConfigManager::getBoolean(ConfigManager::COLORIZED_LOOT_VALUE);
-	for (auto& [itemId, count] : group->items) {
-		const ItemType& itemType = Item::items[itemId];
-		if (!first) {
-			ss << ", ";
-		}
-		first = false;
-		if (colorizedLootValue) {
-			const uint64_t itemValue = static_cast<uint64_t>(itemType.sellPrice > 0 ? itemType.sellPrice : itemType.buyPrice) * count;
-			ss << "{" << itemId << ":" << itemValue << "|";
-		}
-		if (count > 1) {
-			ss << count << " " << itemType.getPluralName();
-		} else {
-			if (itemType.article.empty() || itemType.stackable) {
-				ss << "1 " << itemType.name;
+	const std::string prefix = ss.str();
+	const auto buildLootText = [&](bool colorized) {
+		std::stringstream text;
+		text << prefix;
+		bool first = true;
+		for (auto& [itemId, count] : group->items) {
+			const ItemType& itemType = Item::items[itemId];
+			if (!first) {
+				text << ", ";
+			}
+			first = false;
+			if (colorized) {
+				const uint64_t itemValue =
+				    static_cast<uint64_t>(itemType.sellPrice > 0 ? itemType.sellPrice : itemType.buyPrice) * count;
+				text << "{" << itemId << ":" << itemValue << "|";
+			}
+			if (count > 1) {
+				text << count << " " << itemType.getPluralName();
+			} else if (itemType.article.empty() || itemType.stackable) {
+				text << "1 " << itemType.name;
 			} else {
-				ss << itemType.article << " " << itemType.name;
+				text << itemType.article << " " << itemType.name;
+			}
+			if (colorized) {
+				text << "}";
 			}
 		}
-		if (colorizedLootValue) {
-			ss << "}";
-		}
-	}
-	ss << ".";
+		text << ".";
+		return text.str();
+	};
 
-	std::string text = ss.str();
+	const bool colorizedLootEnabled = ConfigManager::getBoolean(ConfigManager::COLORIZED_LOOT_VALUE);
+	const std::string plainText = buildLootText(false);
+	const std::string colorizedText = colorizedLootEnabled ? buildLootText(true) : plainText;
+	const auto sendLootText = [&](Player& recipient) {
+		recipient.sendChannelMessage(
+		    "", colorizedLootEnabled && recipient.isAstraClient() ? colorizedText : plainText, TALKTYPE_CHANNEL_O, 10);
+	};
 
 	const auto& party = getParty();
 	if (party && party->isSharedExperienceEnabled()) {
 		const auto& leader = party->getLeader();
 		if (leader) {
-			leader->sendChannelMessage("", text, TALKTYPE_CHANNEL_O, 10);
+			sendLootText(*leader);
 		}
 		for (auto& member : party->getMembers()) {
 			if (auto memberPtr = member.lock()) {
-				memberPtr->sendChannelMessage("", text, TALKTYPE_CHANNEL_O, 10);
+				sendLootText(*memberPtr);
 			}
 		}
 	} else {
-		sendChannelMessage("", text, TALKTYPE_CHANNEL_O, 10);
+		sendLootText(*this);
 	}
 
 	m_pendingLootGroups.erase(it);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2438,6 +2438,7 @@ void ProtocolGame::sendLootContainers()
 	msg.addByte(0xC0);
 	msg.addByte(player->getQuickLootFallbackToMainContainer() ? 1 : 0);
 	msg.addByte(0); // managed loot containers
+	msg.addByte(0); // managed obtain containers
 	writeToOutputBuffer(msg);
 }
 


### PR DESCRIPTION
## What changed

- restrict boss cooldown opcode `0x2C` to authenticated AstraClient sessions
- prevent QuickLoot `0xC0` and `0xCF` packets and events from running for CIP, OTCv8 Classic, or Mehah clients
- add a central Lua network-message guard for Astra-only opcodes (`0x2C`, `0x9B`, `0x9C`, `0xC0`, `0xC6`, `0xC7`, and `0xCF`)
- send colorized loot markup only to AstraClient recipients
- keep the native `0xC0` response aligned with AstraClient's two-list parser format

## Root cause

The QuickLoot login event sent `0xC0` without checking the connected client, while the boss cooldown script checked only `isUsingOtClient()`. This allowed Astra-specific packets to reach OTCv8 Classic, Mehah, and official CIP 8.60 clients. Classic also consumes only the first `0xC0` container list, so the Astra-only second list was interpreted as subsequent opcodes, causing parser EOF and unhandled opcode errors.

## Impact

`enableQuickLoot`, `quickLootMaxCorpses`, and `enableColorizedLootValue` can remain enabled while non-Astra clients continue receiving the legacy-compatible protocol.

## Validation

- `git diff --cached --check`
- static checks for Astra guards on QuickLoot, boss cooldown, blessings, and Lua network messages
- compared AstraClient and OTCv8 Classic `0xC0` parsers

Compilation was intentionally not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrigido envio de mensagens de loot para diferentes tipos de cliente
  * Melhorado suporte e compatibilidade para clientes Astra
  * Ajustado comportamento do sistema de cooldown de boss
  * Refinado protocolo de rede para envio de containers de loot

* **Chores**
  * Otimizado sistema de agrupamento de loot
  * Atualizado mecanismo de detecção de cliente

<!-- end of auto-generated comment: release notes by coderabbit.ai -->