### PR TITLE
fix: Create player - account management

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -1781,7 +1781,7 @@ bool IOLoginData::createPlayer(uint32_t accountId, const std::string& name, uint
 	query << db.escapeString(name) << ", 1, " << accountId << ", " << level << ", " << vocationId << ", "
 		  << health << ", " << health << ", " << experience << ", 0, 0, 0, 0, " << lookType << ", 0, 2, " << magicLevel << ", "
 		  << mana << ", " << mana << ", 0, 0, " << townId << ", " << posX << ", " << posY << ", " << posZ
-		  << ", " << cap << ", " << static_cast<uint16_t>(sex) << ", 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 43200, -1, 2520, "
+		  << ", " << cap << ", " << static_cast<uint16_t>(sex) << ", 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43200, -1, 2520, "
 		  << "10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0)";
 
 	return db.executeQuery(query.str());


### PR DESCRIPTION
This change adds the missing default values for newly created players in the players table insert query.

**Problem**

The original insert statement did not include all columns expected by the current database schema, causing the values after sex to become misaligned when a new character was created.

**Change**

Expanded the default values section after the sex field:

**Before**

<< ", " << cap << ", " << static_cast<uint16_t>(sex)
<< ", 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 43200, -1, 2520, "

**After**

<< ", " << cap << ", " << static_cast<uint16_t>(sex)
<< ", 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43200, -1, 2520, "

**Result**

The insert query now matches the expected column count and ordering of the current database schema, preventing incorrect data assignment during character creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrigido ajuste no comando de criação de personagem para garantir a composição correta de dados do jogador.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->