### PR TITLE
fix: tabelas faltantes no schema.sql e GROUP BY do market_statistics

### DIFF
--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -1717,7 +1717,7 @@ local function refreshMarketStatistics()
 		"CASE WHEN SUM(`amount`) > 0 THEN FLOOR((SUM(`price` * `amount`) / SUM(`amount`)) * COUNT(*)) ELSE 0 END AS `total_price`, " ..
 		"MAX(`price`) AS `highest_price`, MIN(`price`) AS `lowest_price` FROM `market_history` " ..
 		"WHERE `state` = " .. MARKET_STATE_ACCEPTED .. " AND `inserted` >= " .. firstDay ..
-		" GROUP BY `itemtype`, `sale`, FLOOR(`inserted` / 86400)"
+		" GROUP BY `itemtype`, `sale`, FLOOR(`inserted` / 86400) * 86400"
 	)
 end
 

--- a/schema.sql
+++ b/schema.sql
@@ -447,6 +447,26 @@ CREATE TABLE IF NOT EXISTS player_bosstiary (
   PRIMARY KEY (player_id)
 );
 
+CREATE TABLE IF NOT EXISTS `player_rewarditems` (
+  `player_id` int NOT NULL,
+  `sid` int NOT NULL COMMENT 'range 0-100 will be reserved for adding items to player who are offline and all > 100 is for items saved from reward chest',
+  `pid` int NOT NULL DEFAULT '0',
+  `itemtype` smallint unsigned NOT NULL,
+  `count` smallint NOT NULL DEFAULT '0',
+  `attributes` blob NOT NULL,
+  UNIQUE KEY `player_id_2` (`player_id`, `sid`),
+  FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `player_save_async_pending` (
+  `guid` INT NOT NULL,
+  `query_index` INT UNSIGNED NOT NULL,
+  `query_text` LONGBLOB NOT NULL,
+  `created_at` BIGINT NOT NULL,
+  PRIMARY KEY (`guid`, `query_index`),
+  FOREIGN KEY (`guid`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
 CREATE TABLE IF NOT EXISTS player_bosstiary_tracker (
   player_id int NOT NULL,
   bossid int NOT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -467,6 +467,25 @@ CREATE TABLE IF NOT EXISTS `player_save_async_pending` (
   FOREIGN KEY (`guid`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
+CREATE TABLE IF NOT EXISTS `player_prey` (
+  `player_id` INT(11) NOT NULL,
+  `slot` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `state` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `monster_name` VARCHAR(255) NOT NULL DEFAULT '',
+  `bonus_type` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `bonus_value` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+  `time_left` INT UNSIGNED NOT NULL DEFAULT 0,
+  `list_monsters` VARCHAR(1024) NOT NULL DEFAULT '',
+  `reroll_at` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  `wildcards` INT UNSIGNED NOT NULL DEFAULT 0,
+  `list_reroll_used` TINYINT(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`player_id`, `slot`),
+  CONSTRAINT `fk_player_prey_player_id`
+    FOREIGN KEY (`player_id`)
+    REFERENCES `players` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS player_bosstiary_tracker (
   player_id int NOT NULL,
   bossid int NOT NULL,


### PR DESCRIPTION
1. schema.sql declara db_version=46, então um install novo só roda as migrations 46+ e nunca cria player_rewarditems (migration 30) — o reward chest quebra em bancos novos. Adiciona a tabela com a definição exata da migration 30 (UNIQUE KEY player_id_2 (player_id, sid)). Inclui também player_save_async_pending (migration 47) por completude do schema — idempotente via IF NOT EXISTS.

2. refreshMarketStatistics: o SELECT projeta FLOOR(`inserted`/86400)*86400 mas o GROUP BY usava só FLOOR(`inserted`/86400); com ONLY_FULL_GROUP_BY (default no MySQL moderno) a query falha com erro 1055. Igualar a expressão não muda o agrupamento (multiplicação por constante).

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper TFS Downgrades code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrigido cálculo de estatísticas diárias do mercado para garantir alinhamento consistente dos dados.

* **New Features**
  * Adicionado suporte a itens de recompensa para jogadores.
  * Implementado sistema de fila para gerenciamento de salvamento assíncrono de dados.
  * Adicionada funcionalidade de "prey" com configurações personalizáveis por slot, incluindo estado e opções de reroll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->