### PR TITLE
fix: party analyzer envia hasNames=0 mas sempre escreve o bloco de nomes

### DIFF
--- a/data/scripts/network/party_analyzer/partytracker.lua
+++ b/data/scripts/network/party_analyzer/partytracker.lua
@@ -99,7 +99,7 @@ local function sendPartyAnalyzer(player)
 		out:addU64(data.damage)
 		out:addU64(data.healing)
 	end
-	out:addByte(0) -- online flag
+	out:addByte(1) -- has names flag: o bloco de nomes é sempre escrito abaixo
 	out:addByte(math.min(onlineMemberCount, 255))
 	for id, m in pairs(onlineMembers) do
 		out:addU32(id)


### PR DESCRIPTION
sendPartyAnalyzer escreve addByte(0) no flag de nomes e em seguida escreve incondicionalmente o bloco (count + u32 id + string nome). Clients que honram o flag (semântica Canary, ex. OTClient Redemption) param de ler ali e o restante vira lixo no stream. O AstraClient ignora o valor do flag e sempre lê os nomes (modules/game_protocol/protocol.lua), então mandar 1 é correto para ambos.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
