### PR TITLE
Fix Battle Pass protocol and live gameplay updates

### DIFF
--- a/data/scripts/actions/systems/daily_reward_shrine.lua
+++ b/data/scripts/actions/systems/daily_reward_shrine.lua
@@ -1,0 +1,9 @@
+local dailyRewardShrine = Action()
+
+function dailyRewardShrine.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	DailyRewardSystem.openRewardWall(player, true)
+	return true
+end
+
+dailyRewardShrine:id(25802, 25803)
+dailyRewardShrine:register()

--- a/data/scripts/creaturescripts/others/custom_bestiary.lua
+++ b/data/scripts/creaturescripts/others/custom_bestiary.lua
@@ -171,6 +171,9 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		if CustomBestiary.invalidatePlayer then
 			CustomBestiary.invalidatePlayer(playerGuid)
 		end
+		if CustomBestiary.sendTracker then
+			CustomBestiary.sendTracker(player)
+		end
 		if oldKills < entry.toKill and newKills >= entry.toKill then
 			addPlayerCharmPoints(playerGuid, entry.charmPoints)
 		end

--- a/data/scripts/creaturescripts/others/extendedopcode.lua
+++ b/data/scripts/creaturescripts/others/extendedopcode.lua
@@ -1,6 +1,5 @@
 local OPCODE_LANGUAGE = 1
 local OPCODE_MEHAH_ID = 50
-local OPCODE_BATTLEPASS = 225
 local STORAGE_MEHAH_CLIENT = 99999 -- Storage key to mark Mehah clients
 
 local extendedOpcode = CreatureEvent("ExtendedOpcode")
@@ -10,10 +9,6 @@ function extendedOpcode.onExtendedOpcode(player, opcode, buffer)
     elseif opcode == OPCODE_MEHAH_ID then
         if buffer == "Mehah" then
             player:setStorageValue(STORAGE_MEHAH_CLIENT, 1)
-        end
-    elseif opcode == OPCODE_BATTLEPASS then
-        if BattlePassSystem and BattlePassSystem.onExtendedOpcode then
-            return BattlePassSystem.onExtendedOpcode(player, buffer)
         end
     end
     return true

--- a/data/scripts/eventcallbacks/player/default_onInventoryUpdate.lua
+++ b/data/scripts/eventcallbacks/player/default_onInventoryUpdate.lua
@@ -20,12 +20,12 @@ function ec.onUpdateInventory(player, item, slot, equip)
     if player.wheelSendSkillStats then
         player:wheelSendSkillStats()
     end
-    if equip and (slot == CONST_SLOT_LEFT or slot == CONST_SLOT_RIGHT) then
+    if slot == CONST_SLOT_LEFT or slot == CONST_SLOT_RIGHT then
         local playerId = player:getId()
         addEvent(function()
             local freshPlayer = Player(playerId)
-            if freshPlayer and WeaponProficiencySystem and WeaponProficiencySystem.sendEquippedExperience then
-                WeaponProficiencySystem.sendEquippedExperience(freshPlayer)
+            if freshPlayer and WeaponProficiencySystem and WeaponProficiencySystem.refreshEquippedPerks then
+                WeaponProficiencySystem.refreshEquippedPerks(freshPlayer)
             end
         end, 100)
     end

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -380,6 +380,56 @@ local function writeMissionList(out, missions)
 	end
 end
 
+local function writeThingValues(out, values)
+	values = type(values) == "table" and values or {}
+	local count = math.min(#values, 0xFFFF)
+	writeU16(out, count)
+	for index = 1, count do
+		local value = values[index] or {}
+		writeU16(out, value.thingId)
+		writeString(out, value.thingName)
+	end
+end
+
+local function writeOutfitGroups(out, groups)
+	groups = type(groups) == "table" and groups or {}
+	local groupIds = {}
+	for key, outfits in pairs(groups) do
+		local groupId = tonumber(key)
+		if groupId and groupId >= 0 and groupId <= 0xFF and type(outfits) == "table" and #outfits > 0 then
+			groupIds[#groupIds + 1] = groupId
+		end
+	end
+	table.sort(groupIds)
+
+	local groupCount = math.min(#groupIds, 0xFF)
+	out:addByte(groupCount)
+	for index = 1, groupCount do
+		local groupId = groupIds[index]
+		local outfits = groups[groupId] or groups[tostring(groupId)] or {}
+		local outfitCount = math.min(#outfits, 0xFF)
+		out:addByte(groupId)
+		out:addByte(outfitCount)
+		for outfitIndex = 1, outfitCount do
+			local outfit = outfits[outfitIndex] or {}
+			writeU16(out, outfit.looktype or outfit.thingId or outfit.type)
+			writeString(out, outfit.name or outfit.thingName)
+		end
+	end
+end
+
+local function writeRewardItems(out, items)
+	items = type(items) == "table" and items or {}
+	local count = math.min(#items, 0xFFFF)
+	writeU16(out, count)
+	for index = 1, count do
+		local item = items[index] or {}
+		writeU16(out, item.itemId)
+		writeU16(out, item.count)
+		writeBool(out, item.stuck)
+	end
+end
+
 local function sendBattlePassMessage(player, response, writer)
 	if not supportsCustomNetwork(player) then
 		return false
@@ -522,6 +572,13 @@ function BattlePassSystem.sendRewards(player)
 					writeU16(out, reward.charges)
 					writeBool(out, reward.stuck)
 					writeBool(out, reward.hasClaimedReward or reward.hasClamedReward)
+					writeU32(out, reward.durationTime)
+					out:addByte(clamp(reward.addons, 0, 0xFF))
+					writeThingValues(out, reward.randomValues)
+					writeThingValues(out, reward.choosableValues)
+					writeOutfitGroups(out, reward.maleOutfit)
+					writeOutfitGroups(out, reward.femaleOutfit)
+					writeRewardItems(out, reward.items)
 				end
 			end
 		end) or sent

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -1,14 +1,24 @@
 BattlePassSystem = BattlePassSystem or {}
 
-local BATTLEPASS_OPCODE = 225
+local BATTLEPASS_REQUEST_OPCODE = 0x36
+local BATTLEPASS_SEND_OPCODE = 0x37
 local RESOURCE_BALANCE_OPCODE = 0xEE
 local RESOURCE_BANK = 0
 local RESOURCE_INVENTORY = 1
-local EXTENDED_OPCODE_MAX_STRING_LENGTH = 8192
 local REWARD_STEPS_PER_CHUNK = 20
 
+local REQUEST_GET_MISSIONS = 1
+local REQUEST_GET_REWARDS = 2
+local REQUEST_REROLL = 3
+local REQUEST_REDEEM = 4
+local REQUEST_BUY_PREMIUM = 5
+
+local RESPONSE_MISSIONS = 1
+local RESPONSE_REWARDS = 2
+local RESPONSE_ERROR = 3
+
 local function supportsCustomNetwork(player)
-	return player and player.isUsingOtClient and player:isUsingOtClient()
+	return player and player.isUsingAstraClient and player:isUsingAstraClient()
 end
 
 local DAY_SECONDS = 24 * 60 * 60
@@ -315,27 +325,6 @@ local function buildMissionsPayload(player, state, season, daily)
 	}
 end
 
-local function sendOpcode(player, action, data)
-	if not player or not player.sendExtendedOpcode then
-		return false
-	end
-
-	local ok, buffer = pcall(json.encode, {
-		action = action,
-		data = data or {},
-	})
-	if not ok or type(buffer) ~= "string" then
-		return false
-	end
-
-	if #buffer > EXTENDED_OPCODE_MAX_STRING_LENGTH then
-		print(string.format("[Battle Pass] Refusing oversized extended opcode payload (%s, %d bytes).", action, #buffer))
-		return false
-	end
-
-	return player:sendExtendedOpcode(BATTLEPASS_OPCODE, buffer)
-end
-
 local function sendResourceBalance(player, resourceType, value)
 	if not supportsCustomNetwork(player) then
 		return false
@@ -348,6 +337,69 @@ local function sendResourceBalance(player, resourceType, value)
 	return msg:sendToPlayer(player)
 end
 
+local function writeString(out, value)
+	out:addString(tostring(value or ""))
+end
+
+local function writeBool(out, value)
+	out:addByte(value and 1 or 0)
+end
+
+local function writeU16(out, value)
+	out:addU16(clamp(value, 0, 0xFFFF))
+end
+
+local function writeU32(out, value)
+	out:addU32(clamp(value, 0, 0xFFFFFFFF))
+end
+
+local function writeOutfit(out, outfit)
+	outfit = outfit or {}
+	writeU16(out, outfit.type)
+	out:addByte(clamp(outfit.head, 0, 0xFF))
+	out:addByte(clamp(outfit.body, 0, 0xFF))
+	out:addByte(clamp(outfit.legs, 0, 0xFF))
+	out:addByte(clamp(outfit.feet, 0, 0xFF))
+	out:addByte(clamp(outfit.addons, 0, 0xFF))
+end
+
+local function writeMission(out, mission)
+	writeString(out, mission.missionId)
+	writeString(out, mission.missionName)
+	writeString(out, mission.missionDescription)
+	writeU32(out, mission.currentProgress)
+	writeU32(out, mission.maxProgress)
+	writeU16(out, mission.rewardPoints)
+end
+
+local function writeMissionList(out, missions)
+	missions = type(missions) == "table" and missions or {}
+	writeU16(out, #missions)
+	for index = 1, math.min(#missions, 0xFFFF) do
+		writeMission(out, missions[index])
+	end
+end
+
+local function sendBattlePassMessage(player, response, writer)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
+	local out = NetworkMessage(player)
+	out:addByte(BATTLEPASS_SEND_OPCODE)
+	out:addByte(response)
+	if writer then
+		writer(out)
+	end
+	return out:sendToPlayer(player)
+end
+
+local function sendBattlePassError(player, message)
+	return sendBattlePassMessage(player, RESPONSE_ERROR, function(out)
+		writeString(out, message)
+	end)
+end
+
 local function sendMoneyResources(player)
 	local bankSent = sendResourceBalance(player, RESOURCE_BANK, player:getBankBalance())
 	local inventorySent = sendResourceBalance(player, RESOURCE_INVENTORY, player:getMoney())
@@ -357,7 +409,21 @@ end
 local function sendMissionState(player, state, season, daily)
 	local payload = buildMissionsPayload(player, state, season, daily)
 	sendMoneyResources(player)
-	return sendOpcode(player, "missions", payload)
+	return sendBattlePassMessage(player, RESPONSE_MISSIONS, function(out)
+		writeOutfit(out, payload.playerOutfit)
+		writeU32(out, payload.beginTime)
+		writeU32(out, payload.endTime)
+		writeU32(out, payload.points)
+		writeU32(out, payload.rerollPrice)
+		writeU32(out, payload.deluxePrice)
+		writeBool(out, payload.battlePassActive)
+		writeU16(out, payload.currentRewardStep)
+		writeU32(out, payload.nextStepPoints)
+		writeU32(out, payload.dailyBeginTime)
+		writeU32(out, payload.dailyEndTime)
+		writeMissionList(out, payload.dailyMissions)
+		writeMissionList(out, payload.generalMissions)
+	end)
 end
 
 function BattlePassSystem.sendMissions(player)
@@ -423,7 +489,12 @@ function BattlePassSystem.sendRewards(player)
 	saveState(store, state)
 
 	if #rewards == 0 then
-		return sendOpcode(player, "rewards", rewards)
+		return sendBattlePassMessage(player, RESPONSE_REWARDS, function(out)
+			writeBool(out, false)
+			writeU16(out, 1)
+			writeU16(out, 0)
+			writeU16(out, 0)
+		end)
 	end
 
 	local sent = false
@@ -433,12 +504,27 @@ function BattlePassSystem.sendRewards(player)
 			table.insert(steps, rewards[index])
 		end
 
-		sent = sendOpcode(player, "rewards", {
-			chunk = true,
-			first = first,
-			total = #rewards,
-			steps = steps,
-		}) or sent
+		sent = sendBattlePassMessage(player, RESPONSE_REWARDS, function(out)
+			writeBool(out, true)
+			writeU16(out, first)
+			writeU16(out, #rewards)
+			writeU16(out, #steps)
+			for _, step in ipairs(steps) do
+				writeU16(out, step.stepId)
+				out:addByte(math.min(#step.rewards, 0xFF))
+				for index = 1, math.min(#step.rewards, 0xFF) do
+					local reward = step.rewards[index]
+					writeU32(out, reward.rewardId)
+					out:addByte(clamp(reward.rewardType, 0, 0xFF))
+					writeBool(out, reward.freeReward)
+					writeU16(out, reward.itemId)
+					writeU16(out, reward.count)
+					writeU16(out, reward.charges)
+					writeBool(out, reward.stuck)
+					writeBool(out, reward.hasClaimedReward or reward.hasClamedReward)
+				end
+			end
+		end) or sent
 	end
 	return sent
 end
@@ -670,14 +756,7 @@ local function isRateLimited(player, action)
 	return false
 end
 
-function BattlePassSystem.onExtendedOpcode(player, buffer)
-	local ok, payload = pcall(json.decode, buffer)
-	if not ok or type(payload) ~= "table" then
-		return true
-	end
-
-	local action = payload.action
-	local data = type(payload.data) == "table" and payload.data or {}
+local function handleBattlePassRequest(player, action, data)
 	if isRateLimited(player, action) then
 		return true
 	end
@@ -694,11 +773,59 @@ function BattlePassSystem.onExtendedOpcode(player, buffer)
 		local errorMessage = BattlePassSystem.purchasePremium(player)
 		if errorMessage then
 			player:sendCancelMessage("[Battle Pass] " .. errorMessage)
+			sendBattlePassError(player, errorMessage)
 			BattlePassSystem.sendMissions(player)
 		end
 	end
 	return true
 end
+
+local battlePassHandler = PacketHandler(BATTLEPASS_REQUEST_OPCODE)
+function battlePassHandler.onReceive(player, msg)
+	if not supportsCustomNetwork(player) then
+		return true
+	end
+
+	local request = NetworkGuard.readByte(msg)
+	if not request then
+		return true
+	end
+
+	if request == REQUEST_GET_MISSIONS then
+		return handleBattlePassRequest(player, "getMissions", {})
+	elseif request == REQUEST_GET_REWARDS then
+		return handleBattlePassRequest(player, "getRewards", {})
+	elseif request == REQUEST_REROLL then
+		local missionId = NetworkGuard.readString(msg, 128)
+		if not missionId then
+			sendBattlePassError(player, "Invalid mission.")
+			return true
+		end
+		return handleBattlePassRequest(player, "reroll", { missionId = missionId })
+	elseif request == REQUEST_REDEEM then
+		local index = NetworkGuard.readU16(msg)
+		local rewardId = NetworkGuard.readU32(msg)
+		local objectId = NetworkGuard.readU32(msg)
+		if not index or not rewardId or not objectId then
+			sendBattlePassError(player, "Invalid reward.")
+			return true
+		end
+		if objectId == 0 then
+			objectId = -1
+		end
+		return handleBattlePassRequest(player, "redeem", {
+			index = index,
+			rewardId = rewardId,
+			objectId = objectId,
+		})
+	elseif request == REQUEST_BUY_PREMIUM then
+		return handleBattlePassRequest(player, "buyPremium", {})
+	end
+
+	sendBattlePassError(player, "Unknown request.")
+	return true
+end
+battlePassHandler:register()
 
 local killEvent = CreatureEvent("BattlePassKill")
 function killEvent.onKill(player, target)

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -501,6 +501,14 @@ local function makeReward(step, freeReward)
 		count = count,
 		charges = 0,
 		stuck = false,
+		hasClaimedReward = false,
+		durationTime = 0,
+		addons = 0,
+		randomValues = {},
+		choosableValues = {},
+		maleOutfit = {},
+		femaleOutfit = {},
+		items = {},
 	}
 end
 

--- a/data/scripts/network/daily_reward.lua
+++ b/data/scripts/network/daily_reward.lua
@@ -233,14 +233,20 @@ local function sendOpenRewardWall(player, fromShrine)
 	return out:sendToPlayer(player)
 end
 
-local function openRewardWall(player)
+DailyRewardSystem = DailyRewardSystem or {}
+
+function DailyRewardSystem.openRewardWall(player, fromShrine)
 	if not supportsCustomNetwork(player) then
 		return false
 	end
 
 	ensureDailyRewardSchema()
 	sendDailyReward(player)
-	return sendOpenRewardWall(player, true)
+	return sendOpenRewardWall(player, fromShrine ~= false)
+end
+
+local function openRewardWall(player)
+	return DailyRewardSystem.openRewardWall(player, true)
 end
 
 local function sendRewardHistory(player)

--- a/data/scripts/network/gamestore/gamestore.lua
+++ b/data/scripts/network/gamestore/gamestore.lua
@@ -20,6 +20,10 @@ local MAX_CHARACTER_NAME_LENGTH = 20
 local MAX_CHARACTER_NAME_WORDS = 5
 local CHANGE_NAME_KICK_DELAY = 3000
 local CHANGE_NAME_SUCCESS_MESSAGE = "Your character name has been changed. You will be disconnected in 3 seconds. Please log in again to use your new name."
+local STORE_HOME_BANNER_DELAY = 10
+local STORE_HOME_BANNERS = {
+	{image = "/images/store/home/banner_exercisedummies", action = 0, target = 0}
+}
 
 local storeCategories = {}
 local storeItemsById = {}
@@ -369,6 +373,14 @@ local function sendStoreCatalog(player)
 		end
 	end
 
+	out:addByte(#STORE_HOME_BANNERS)
+	for _, banner in ipairs(STORE_HOME_BANNERS) do
+		out:addString(banner.image)
+		out:addByte(banner.action)
+		out:addU32(banner.target)
+	end
+	out:addByte(STORE_HOME_BANNER_DELAY)
+
 	return out:sendToPlayer(player)
 end
 
@@ -441,7 +453,7 @@ local function deliverOffer(player, offer, extra)
 	end
 
 	if offer.oftype == "mount" then
-		if player:hasMount(offer.value) then
+		if player:ownsMount(offer.value) then
 			return "You already have this mount."
 		end
 
@@ -535,7 +547,6 @@ local openHandler = PacketHandler(OPCODE_STORE_OPEN)
 
 function openHandler.onReceive(player, msg)
 	sendStoreCatalog(player)
-	sendStoreHistory(player)
 end
 
 openHandler:register()

--- a/data/scripts/network/gamestore/gamestore.lua
+++ b/data/scripts/network/gamestore/gamestore.lua
@@ -477,10 +477,21 @@ local function deliverOffer(player, offer, extra)
 	end
 
 	if offer.oftype == "item" and offer.itemid > 0 then
-		local added = player:addItem(offer.itemid, offer.count, true)
-		if not added then
-			return "Failed to deliver item. Check your inventory."
+		local inbox = player:getStoreInbox()
+		if not inbox then
+			return "Your store inbox is not available."
 		end
+
+		local item = Game.createItem(offer.itemid, offer.count)
+		if not item then
+			return "Failed to create item."
+		end
+
+		if inbox:addItemEx(item) ~= RETURNVALUE_NOERROR then
+			item:remove()
+			return "Your store inbox is full."
+		end
+		player:sendTextMessage(MESSAGE_STATUS_SMALL, "Your item was sent to your store inbox.")
 		return nil
 	end
 

--- a/data/scripts/network/item_values.lua
+++ b/data/scripts/network/item_values.lua
@@ -316,6 +316,15 @@ end
 
 loginEvent:register()
 
+local reconnectEvent = CreatureEvent("ItemValuesReconnect")
+
+function reconnectEvent.onReconnect(player)
+	addEvent(sendItemValues, 250, player:getId(), 1)
+	return true
+end
+
+reconnectEvent:register()
+
 local itemDetailsHandler = PacketHandler(OPCODE_ITEM_DETAILS)
 
 function itemDetailsHandler.onReceive(player, msg)

--- a/data/scripts/network/prey_system/prey_system.lua
+++ b/data/scripts/network/prey_system/prey_system.lua
@@ -32,9 +32,11 @@ local PREY_STATE_BONUS_SELECTION = 2
 local PREY_STATE_ACTIVE = 3
 local PREY_STATE_INACTIVE = 4
 
+local PREY_NATIVE_STATE_LOCKED = 0
 local PREY_NATIVE_STATE_INACTIVE = 1
 local PREY_NATIVE_STATE_ACTIVE = 2
 local PREY_NATIVE_STATE_SELECTION = 3
+local PREY_NATIVE_UNLOCK_STORE = 1
 
 local PREY_BONUS_NONE = 0
 local PREY_BONUS_DMG_BOOST = 1
@@ -50,6 +52,9 @@ local PREY_LIST_REROLL_COST_PER_LEVEL = 150
 local PREY_TICK_INTERVAL = 1000
 local PREY_STORAGE_AUTO_BONUS_BASE = 780000
 local PREY_STORAGE_LOCK_BASE = 780100
+local PREY_STORAGE_PERMANENT_SLOT = 780200
+local PREY_PERMANENT_SLOT = 2
+local PREY_PERMANENT_SLOT_COST = 900
 local PREY_AUTO_BONUS_COST = 1
 local PREY_LOCK_COST = 5
 local RESOURCE_BANK = 0
@@ -61,6 +66,11 @@ local preySchemaChecked = false
 
 local function supportsCustomNetwork(player)
 	return player and player.isUsingOtClient and player:isUsingOtClient()
+end
+
+local function isPreySlotUnlocked(player, slot)
+	return slot ~= PREY_PERMANENT_SLOT
+		or player:getStorageValue(PREY_STORAGE_PERMANENT_SLOT) == 1
 end
 
 local function ensurePreySchema()
@@ -304,7 +314,8 @@ local function syncPreyCombatBonuses(player, prey)
 	player:clearPreyCombatBonuses()
 	for slot = 0, PREY_SLOTS - 1 do
 		local slotData = prey.slots[slot]
-		local isActiveCombatPrey = slotData
+		local isActiveCombatPrey = isPreySlotUnlocked(player, slot)
+			and slotData
 			and slotData.state == PREY_STATE_ACTIVE
 			and slotData.time_left > 0
 			and (slotData.monster_name or "") ~= ""
@@ -417,6 +428,14 @@ local function sendError(player, message)
 	return false
 end
 
+local function requirePreySlotUnlocked(player, slot)
+	if isPreySlotUnlocked(player, slot) then
+		return true
+	end
+
+	return sendError(player, "This Prey slot is locked.")
+end
+
 local function getMonsterOutfit(name)
 	local monsterType = name and name ~= "" and MonsterType(name)
 	if not monsterType then
@@ -520,14 +539,22 @@ local function ensureSelectionList(player, slot, slotData)
 	end
 
 	local prey = getPlayerPrey(player)
-	slotData.list_monsters = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(prey, slot))
+	slotData.list_monsters = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(player, prey, slot))
 	return true
 end
 
 local function writeSlot(out, player, slot, slotData)
+	out:addByte(slot)
+	if not isPreySlotUnlocked(player, slot) then
+		out:addByte(PREY_NATIVE_STATE_LOCKED)
+		out:addByte(PREY_NATIVE_UNLOCK_STORE)
+		out:addU16(0)
+		out:addU32(PREY_PERMANENT_SLOT_COST)
+		return
+	end
+
 	normalizeSlot(slotData)
 	ensureSelectionList(player, slot, slotData)
-	out:addByte(slot)
 	if slotData.state == PREY_STATE_LIST_SELECTION then
 		out:addByte(PREY_NATIVE_STATE_SELECTION)
 		local list = slotData.list_monsters or {}
@@ -590,10 +617,10 @@ local function sendSlotUpdate(player, slot)
 	return sent
 end
 
-getOtherSlotMonsters = function(prey, excludedSlot)
+getOtherSlotMonsters = function(player, prey, excludedSlot)
 	local names = {}
 	for slot = 0, PREY_SLOTS - 1 do
-		if slot ~= excludedSlot then
+		if slot ~= excludedSlot and isPreySlotUnlocked(player, slot) then
 			local slotData = prey.slots[slot]
 			if slotData.monster_name and slotData.monster_name ~= "" then
 				table.insert(names, slotData.monster_name)
@@ -607,6 +634,10 @@ getOtherSlotMonsters = function(prey, excludedSlot)
 end
 
 local function initializeSlot(player, slot)
+	if not isPreySlotUnlocked(player, slot) then
+		return false
+	end
+
 	local prey = getPlayerPrey(player)
 	local slotData = prey.slots[slot]
 	if slotData.state ~= PREY_STATE_EMPTY then
@@ -618,7 +649,7 @@ local function initializeSlot(player, slot)
 	slotData.bonus_type = PREY_BONUS_NONE
 	slotData.bonus_value = 0
 	slotData.time_left = 0
-	slotData.list_monsters = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(prey, slot))
+	slotData.list_monsters = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(player, prey, slot))
 	slotData.reroll_at = 0
 	slotData.list_reroll_used = false
 	return true
@@ -628,7 +659,7 @@ local function initializeEmptySlots(player)
 	local changed = false
 	local prey = getPlayerPrey(player)
 	for slot = 0, PREY_SLOTS - 1 do
-		if initializeSlot(player, slot) then
+		if isPreySlotUnlocked(player, slot) and initializeSlot(player, slot) then
 			saveSlotToDB(player:getGuid(), slot, prey.slots[slot], prey.wildcards)
 			changed = true
 		end
@@ -654,6 +685,9 @@ function selectHandler.onReceive(player, msg)
 	local listIndex = msg:getByte()
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
+	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
 	end
 
 	local prey = getPlayerPrey(player)
@@ -704,6 +738,9 @@ function listRerollHandler.onReceive(player, msg)
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
 	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
+	end
 
 	local prey = getPlayerPrey(player)
 	local slotData = prey.slots[slot]
@@ -728,7 +765,7 @@ function listRerollHandler.onReceive(player, msg)
 		end
 	end
 
-	local newList = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(prey, slot))
+	local newList = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(player, prey, slot))
 	if #newList < 1 then
 		return sendError(player, "Could not generate a monster list.")
 	end
@@ -764,6 +801,9 @@ function clearHandler.onReceive(player, msg)
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
 	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
+	end
 
 	local prey = getPlayerPrey(player)
 	prey.slots[slot] = defaultSlot()
@@ -781,6 +821,9 @@ function autoBonusHandler.onReceive(player, msg)
 	local enabled = msg:getByte() ~= 0
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
+	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
 	end
 
 	setStorageFlag(player, PREY_STORAGE_AUTO_BONUS_BASE, slot, enabled)
@@ -801,6 +844,9 @@ function lockPreyHandler.onReceive(player, msg)
 	local enabled = msg:getByte() ~= 0
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
+	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
 	end
 
 	setStorageFlag(player, PREY_STORAGE_LOCK_BASE, slot, enabled)
@@ -832,7 +878,7 @@ local function preyTick()
 				local changed = false
 				for slot = 0, PREY_SLOTS - 1 do
 					local slotData = prey.slots[slot]
-					if slotData.state == PREY_STATE_ACTIVE and slotData.time_left > 0 then
+					if isPreySlotUnlocked(player, slot) and slotData.state == PREY_STATE_ACTIVE and slotData.time_left > 0 then
 						slotData.time_left = math.max(slotData.time_left - 1, 0)
 						changed = true
 						if slotData.time_left == 0 then
@@ -922,7 +968,7 @@ function PreySystem.getBonus(player, monsterName)
 	local targetName = monsterName:lower()
 	for slot = 0, PREY_SLOTS - 1 do
 		local slotData = prey.slots[slot]
-		if slotData.state == PREY_STATE_ACTIVE and slotData.time_left > 0 and (slotData.monster_name or ""):lower() == targetName then
+		if isPreySlotUnlocked(player, slot) and slotData.state == PREY_STATE_ACTIVE and slotData.time_left > 0 and (slotData.monster_name or ""):lower() == targetName then
 			return slotData.bonus_type, slotData.bonus_value
 		end
 	end
@@ -946,6 +992,9 @@ function PreySystem.initSlot(player, slot)
 	if slot < 0 or slot >= PREY_SLOTS then
 		return false
 	end
+	if not isPreySlotUnlocked(player, slot) then
+		return false
+	end
 
 	if initializeSlot(player, slot) then
 		sendSlotUpdate(player, slot)
@@ -955,6 +1004,10 @@ function PreySystem.initSlot(player, slot)
 end
 
 local function nativeSelectMonster(player, slot, listIndex)
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
+	end
+
 	local prey = getPlayerPrey(player)
 	local slotData = prey.slots[slot]
 	if not slotData or slotData.state ~= PREY_STATE_LIST_SELECTION then
@@ -990,6 +1043,10 @@ local function nativeSelectMonster(player, slot, listIndex)
 end
 
 local function nativeListReroll(player, slot)
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
+	end
+
 	local prey = getPlayerPrey(player)
 	local slotData = prey.slots[slot]
 	local now = os.time()
@@ -1009,7 +1066,7 @@ local function nativeListReroll(player, slot)
 	slotData.bonus_type = PREY_BONUS_NONE
 	slotData.bonus_value = 0
 	slotData.time_left = 0
-	slotData.list_monsters = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(prey, slot))
+	slotData.list_monsters = PreyMonsters.generateList(player:getLevel(), getOtherSlotMonsters(player, prey, slot))
 	sendSlotUpdate(player, slot)
 	sendPreyBalances(player)
 end
@@ -1017,6 +1074,9 @@ end
 local function nativeBonusReroll(player, slot)
 	if slot < 0 or slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
+	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
 	end
 
 	local prey = getPlayerPrey(player)
@@ -1047,6 +1107,42 @@ function nativeRequestHandler.onReceive(player, msg)
 end
 nativeRequestHandler:register()
 
+local function unlockPermanentPreySlot(player, slot)
+	if slot ~= PREY_PERMANENT_SLOT then
+		return sendError(player, "This slot cannot be purchased.")
+	end
+	if isPreySlotUnlocked(player, slot) then
+		sendFullPrey(player)
+		return sendError(player, "This Prey slot is already unlocked.")
+	end
+	if player:getTibiaCoins() < PREY_PERMANENT_SLOT_COST then
+		return sendError(player, string.format(
+			"You need %d Tibia Coins to unlock this Prey slot permanently.",
+			PREY_PERMANENT_SLOT_COST
+		))
+	end
+	if not player:removeTibiaCoins(PREY_PERMANENT_SLOT_COST) then
+		return sendError(player, "Failed to remove Tibia Coins.")
+	end
+
+	local saved = db.query(string.format(
+		"INSERT INTO `player_storage` (`player_id`, `key`, `value`) VALUES (%d, %d, 1) "
+			.. "ON DUPLICATE KEY UPDATE `value` = 1",
+		player:getGuid(),
+		PREY_STORAGE_PERMANENT_SLOT
+	))
+	if not saved then
+		player:addTibiaCoins(PREY_PERMANENT_SLOT_COST)
+		return sendError(player, "The Prey slot could not be unlocked. Your Tibia Coins were refunded.")
+	end
+
+	player:setStorageValue(PREY_STORAGE_PERMANENT_SLOT, 1)
+	initializeSlot(player, slot)
+	sendFullPrey(player)
+	player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "Your third Prey slot is now permanently unlocked.")
+	return true
+end
+
 local nativeActionHandler = PacketHandler(PREY_NATIVE_OPCODE_ACTION)
 function nativeActionHandler.onReceive(player, msg)
 	local remaining = msg:len() - msg:tell()
@@ -1061,6 +1157,12 @@ function nativeActionHandler.onReceive(player, msg)
 	local action = msg:getByte()
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
+	end
+	if action == 6 then
+		return unlockPermanentPreySlot(player, slot)
+	end
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
 	end
 
 	if action == 0 then

--- a/data/scripts/network/proficiency/proficiency.lua
+++ b/data/scripts/network/proficiency/proficiency.lua
@@ -605,9 +605,9 @@ local function sendAllInfo(player, itemIds)
 	return out:sendToPlayer(player)
 end
 
-local function sendAll(player)
+local function sendAll(player, forceCatalog)
 	local profile = loadProfile(player)
-	if profile.catalogSent ~= true and sendCatalog(player) then
+	if (forceCatalog or profile.catalogSent ~= true) and sendCatalog(player) then
 		profile.catalogSent = true
 	end
 
@@ -710,6 +710,15 @@ function System.sendEquippedExperience(player)
 	end
 end
 
+function System.refreshEquippedPerks(player)
+	if not player then
+		return
+	end
+
+	refreshProfileSpellAugments(player)
+	System.sendEquippedExperience(player)
+end
+
 function System.clearPlayerCache(player)
 	if player then
 		local guid = player:getGuid()
@@ -743,7 +752,7 @@ function requestHandler.onReceive(player, msg)
 			return
 		end
 		profile.lastListInfoAt = now
-		sendAll(player)
+		sendAll(player, true)
 		return
 	end
 

--- a/data/scripts/network/proficiency/proficiency.lua
+++ b/data/scripts/network/proficiency/proficiency.lua
@@ -710,6 +710,8 @@ function System.sendEquippedExperience(player)
 	end
 end
 
+-- Validates the player, then synchronizes equipped spell augments and experience/perks
+-- through refreshProfileSpellAugments and System.sendEquippedExperience.
 function System.refreshEquippedPerks(player)
 	if not player then
 		return

--- a/src/luanetworkmessage.cpp
+++ b/src/luanetworkmessage.cpp
@@ -49,6 +49,7 @@ bool isAstraOnlyLuaOpcode(uint8_t opcode)
 {
 	switch (opcode) {
 		case 0x2C: // custom boss cooldown
+		case 0x37: // custom battle pass
 		case 0x9B: // blessing window
 		case 0x9C: // blessing status
 		case 0xC0: // managed quick-loot containers

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -2229,6 +2229,30 @@ int luaPlayerHasMount(lua_State* L)
 	return 1;
 }
 
+int luaPlayerOwnsMount(lua_State* L)
+{
+	// player:ownsMount(mountId or mountName)
+	const Player* player = getUserdata<const Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	Mount* mount = nullptr;
+	if (isInteger(L, 2)) {
+		mount = g_game.mounts.getMountByID(getInteger<uint16_t>(L, 2));
+	} else {
+		mount = g_game.mounts.getMountByName(getString(L, 2));
+	}
+
+	if (mount) {
+		pushBoolean(L, player->ownsMount(mount));
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int luaPlayerToggleMount(lua_State* L)
 {
 	// player:toggleMount(mount)
@@ -4353,6 +4377,7 @@ void LuaScriptInterface::registerPlayer()
 	registerMethod("Player", "addMount", luaPlayerAddMount);
 	registerMethod("Player", "removeMount", luaPlayerRemoveMount);
 	registerMethod("Player", "hasMount", luaPlayerHasMount);
+	registerMethod("Player", "ownsMount", luaPlayerOwnsMount);
 	registerMethod("Player", "toggleMount", luaPlayerToggleMount);
 
 	registerMethod("Player", "getPremiumEndsAt", luaPlayerGetPremiumEndsAt);

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -2218,7 +2218,7 @@ int luaPlayerHasMount(lua_State* L)
 	if (isInteger(L, 2)) {
 		mount = g_game.mounts.getMountByID(getInteger<uint16_t>(L, 2));
 	} else {
-		mount = g_game.mounts.getMountByName(getString(L, 2));
+		mount = g_game.mounts.getMountByName(getStringView(L, 2));
 	}
 
 	if (mount) {
@@ -2242,7 +2242,7 @@ int luaPlayerOwnsMount(lua_State* L)
 	if (isInteger(L, 2)) {
 		mount = g_game.mounts.getMountByID(getInteger<uint16_t>(L, 2));
 	} else {
-		mount = g_game.mounts.getMountByName(getString(L, 2));
+		mount = g_game.mounts.getMountByName(getStringView(L, 2));
 	}
 
 	if (mount) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -703,13 +703,21 @@ void Player::sendMonkData()
 void Player::addBlessing(uint8_t blessing, uint8_t count)
 {
 	if (blessing < 1 || blessing > PLAYER_MAX_BLESSINGS || blessings[blessing] == 255) return;
+	const uint8_t oldCount = blessings[blessing];
 	blessings[blessing] = static_cast<uint8_t>(std::min(255, blessings[blessing] + count));
+	if (blessings[blessing] != oldCount) {
+		sendBlessStatus();
+	}
 }
 
 void Player::removeBlessing(uint8_t blessing, uint8_t count)
 {
 	if (blessing < 1 || blessing > PLAYER_MAX_BLESSINGS) return;
+	const uint8_t oldCount = blessings[blessing];
 	blessings[blessing] = static_cast<uint8_t>(std::max(0, blessings[blessing] - count));
+	if (blessings[blessing] != oldCount) {
+		sendBlessStatus();
+	}
 }
 
 bool Player::hasBlessing(uint8_t blessing) const

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -5936,7 +5936,7 @@ bool Player::toggleMount(bool mount)
 bool Player::tameMount(uint16_t mountId)
 {
 	Mount* mount = g_game.mounts.getMountByID(mountId);
-	if (!mount || hasMount(mount)) {
+	if (!mount || ownsMount(mount)) {
 		return false;
 	}
 
@@ -5947,7 +5947,7 @@ bool Player::tameMount(uint16_t mountId)
 bool Player::untameMount(uint16_t mountId)
 {
 	Mount* mount = g_game.mounts.getMountByID(mountId);
-	if (!mount || hasMount(mount)) {
+	if (!mount || !ownsMount(mount)) {
 		return false;
 	}
 
@@ -5965,6 +5965,11 @@ bool Player::untameMount(uint16_t mountId)
 	return true;
 }
 
+bool Player::ownsMount(const Mount* mount) const
+{
+	return mount && mounts.contains(mount->id);
+}
+
 bool Player::hasMount(const Mount* mount) const
 {
 	if (isAccessPlayer()) {
@@ -5975,7 +5980,7 @@ bool Player::hasMount(const Mount* mount) const
 		return false;
 	}
 
-	return mounts.contains(mount->id);
+	return ownsMount(mount);
 }
 
 bool Player::hasMounts() const

--- a/src/player.h
+++ b/src/player.h
@@ -183,6 +183,7 @@ public:
 	bool changeMount(uint16_t mountId, bool checkList = true);
 	bool tameMount(uint16_t mountId);
 	bool untameMount(uint16_t mountId);
+	bool ownsMount(const Mount* mount) const;
 	bool hasMount(const Mount* mount) const;
 	bool hasMounts() const;
 	void dismount();


### PR DESCRIPTION
## Summary
- replace the Battle Pass extended-opcode JSON flow with the Astra-only `0x36`/`0x37` byte protocol
- recalculate weapon Proficiency bonuses after both equip and unequip
- push Bestiary Tracker progress immediately after a kill
- send blessing visual status immediately when blessings change
- resend item-value data after reconnect so rarity frames refresh correctly
- lock the third Prey slot until a per-character permanent purchase, persist the unlock for 900 Tibia Coins, and block hidden slot actions/bonuses before purchase

## Validation
- `git diff --check`
- Lua syntax parsing for every changed Lua file
- not compiled, as requested

The unrelated local change in `data/raids/dragonsMountainSpawn.xml` is not included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Daily Reward Shrine for accessing rewards
  * Introduced purchasable permanent Prey slot
  * GameStore now displays promotional banners

* **Bug Fixes**
  * Fixed blessing count updates to only trigger on actual changes
  * Improved mount ownership validation

* **Chores**
  * Enhanced proficiency perk system refresh functionality
  * Optimized reconnect event handling for item synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->