### PR TITLE
fix: não vaza tier byte e catálogo de proficiency para clients sem o …

### DIFF
--- a/data/scripts/network/proficiency/proficiency.lua
+++ b/data/scripts/network/proficiency/proficiency.lua
@@ -127,7 +127,10 @@ local function ensureTables()
 end
 
 local function supportsCustomNetwork(player)
-	return player and player.isUsingOtClient and player:isUsingOtClient()
+	-- Os opcodes 0x5A/0x5B/0x5C/0xC4 são dialeto do AstraClient; outros
+	-- clients OTC (ex.: Redemption) não os parseiam e descartam mensagens
+	-- de até 14KB de catálogo no login (mesma razão do gate do #89).
+	return player and player.isUsingAstraClient and player:isUsingAstraClient()
 end
 
 local function getItemType(itemId)

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -121,8 +121,12 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 		addByte(0);
 	}
 
-	if (sendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
-	    (alwaysSendTier || (ConfigManager::getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) && it.classification > 0))) {
+	// O tier byte só é parseável por quem negociou o dialeto (marker
+	// OTCv8TierByte -> alwaysSendTier). O ramo por classification pressupunha
+	// um client 13.x+ que conhece classification pelo .dat — impossível num
+	// servidor 860-only; para os demais clients OTC o byte extra dessincroniza
+	// o stream (ex.: 0x6E de containers no OTClient Redemption).
+	if (sendTier && alwaysSendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY)) {
 		addByte(static_cast<uint8_t>(it.tier));
 	}
 }
@@ -146,8 +150,8 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 		addByte(0);
 	}
 
-	if (sendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
-	    (alwaysSendTier || (ConfigManager::getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) && it.classification > 0))) {
+	// Ver comentário no overload acima: tier byte apenas com dialeto negociado.
+	if (sendTier && alwaysSendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY)) {
 		addByte(item->getTier());
 	}
 }


### PR DESCRIPTION
…dialeto

Dois vazamentos do dialeto Astra para clients OTC genéricos (ex.: OTClient Redemption a 860), expostos ao ligar enableItemTierDisplay/ enableItemUpgradeClassification e weaponProficiencySystemEnabled:

1. NetworkMessage::addItem: o ramo "classification > 0" mandava o tier byte para qualquer isOTC. Só quem negociou o dialeto (marker OTCv8TierByte -> useItemTierByte/alwaysSendTier, anunciado no 0x43) sabe ler o byte; clients 8.60 não têm classification no .dat e o byte extra dessincroniza o stream (0x6E de containers, p. ex.). O tier byte agora exige alwaysSendTier.

2. proficiency.lua: catálogo 0x5A (14KB) e 0x5B/0x5C/0xC4 eram enviados a qualquer isUsingOtClient; restringido a isUsingAstraClient, no mesmo padrão do #89.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper TFS Downgrades code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
