### PR TITLE
Fix duplicate definition when building with Visual Studio 2026

### DIFF
--- a/src/weapon_proficiency.cpp
+++ b/src/weapon_proficiency.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-int32_t saturatingAdd(int32_t value, int64_t increase)
+int32_t saturatingAddWeapon(int32_t value, int64_t increase)
 {
 	return static_cast<int32_t>(std::clamp<int64_t>(static_cast<int64_t>(value) + increase,
 	                                               std::numeric_limits<int32_t>::min(),
@@ -379,9 +379,9 @@ void WeaponProficiency::applyAutoAttackCritical(CombatDamage& damage) const
 	}
 
 	if (damage.origin == ORIGIN_MELEE || damage.origin == ORIGIN_RANGED) {
-		damage.criticalChance = saturatingAdd(damage.criticalChance,
+		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
 		                                      static_cast<int64_t>(std::llround(m_autoAttackCritical.chance * 10000.0)));
-		damage.criticalDamage = saturatingAdd(damage.criticalDamage,
+		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
 		                                      static_cast<int64_t>(std::llround(m_autoAttackCritical.damage * 10000.0)));
 	}
 }
@@ -389,9 +389,9 @@ void WeaponProficiency::applyAutoAttackCritical(CombatDamage& damage) const
 void WeaponProficiency::applyGeneralCritical(CombatDamage& damage) const
 {
 	if (m_generalCritical.chance > 0 || m_generalCritical.damage > 0) {
-		damage.criticalChance = saturatingAdd(damage.criticalChance,
+		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
 		                                      static_cast<int64_t>(std::llround(m_generalCritical.chance * 10000.0)));
-		damage.criticalDamage = saturatingAdd(damage.criticalDamage,
+		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
 		                                      static_cast<int64_t>(std::llround(m_generalCritical.damage * 10000.0)));
 	}
 }
@@ -403,9 +403,9 @@ void WeaponProficiency::applyRunesCritical(CombatDamage& damage, bool aggressive
 	}
 
 	if (!damage.instantSpellName.empty() && damage.origin == ORIGIN_SPELL) {
-		damage.criticalChance = saturatingAdd(damage.criticalChance,
+		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
 		                                      static_cast<int64_t>(std::llround(m_runesCritical.chance * 10000.0)));
-		damage.criticalDamage = saturatingAdd(damage.criticalDamage,
+		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
 		                                      static_cast<int64_t>(std::llround(m_runesCritical.damage * 10000.0)));
 	}
 }
@@ -415,9 +415,9 @@ void WeaponProficiency::applyElementCritical(CombatDamage& damage) const
 	const size_t index = combatTypeToIndex(damage.primary.type);
 	if (index < m_elementCritical.size()) {
 		const auto& ec = m_elementCritical[index];
-		damage.criticalChance = saturatingAdd(damage.criticalChance,
+		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
 		                                      static_cast<int64_t>(std::llround(ec.chance * 10000.0)));
-		damage.criticalDamage = saturatingAdd(damage.criticalDamage,
+		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
 		                                      static_cast<int64_t>(std::llround(ec.damage * 10000.0)));
 	}
 }


### PR DESCRIPTION
**Summary**

This change renames the helper function saturatingAdd in weapon_proficiency.cpp to saturatingAddWeapon and updates all corresponding invocations.

**Reason**

When compiling on Windows using Visual Studio 2026, the build fails with the following error:

`error C2084: function 'int32_t anonymous-namespace::saturatingAdd(int32_t,int64_t)' already has a body`

The issue occurs because both weapon_proficiency.cpp and spells.cpp define a helper function named saturatingAdd inside an anonymous namespace. Under the Unity Build configuration, multiple source files are combined into a single translation unit, causing the duplicate definition error and preventing the project from linking successfully.

**Changes**
Renamed:

- saturatingAdd(...) → saturatingAddWeapon(...)
- Updated all usages within weapon_proficiency.cpp.

**Result**

The project now compiles successfully with Visual Studio 2026 and Unity Build enabled, while preserving the original functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refatoração interna dos mecanismos de cálculo de crítico de armas para melhor organização e manutenibilidade do código, sem alterações de comportamento visível ao usuário.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->