### PR TITLE
ci: add sccache to Windows build (compiler cache)

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -41,6 +41,8 @@ jobs:
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed/x64-windows-static-release
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg_cache
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
+      # sccache uses the built-in GitHub Actions cache backend; it manages its own entries
+      SCCACHE_GHA_ENABLED: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -72,12 +74,15 @@ jobs:
         with:
           vcpkgJsonGlob: 'vcpkg.json'
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@676c0e67b665684f17941acf5cc3af83bcf10228 # v0.0.6
+
       - name: Build with CMake
         uses: lukka/run-cmake@v10.9
         with:
           configurePreset: vcpkg
           buildPreset: vcpkg
-          configurePresetAdditionalArgs: "['-GNinja', '-DCMAKE_BUILD_TYPE=Release', '-DCMAKE_C_COMPILER=cl', '-DCMAKE_CXX_COMPILER=cl', '-DVCPKG_TARGET_TRIPLET=x64-windows-static', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']"
+          configurePresetAdditionalArgs: "['-GNinja', '-DCMAKE_BUILD_TYPE=Release', '-DCMAKE_C_COMPILER=cl', '-DCMAKE_CXX_COMPILER=cl', '-DCMAKE_C_COMPILER_LAUNCHER=sccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache', '-DVCPKG_TARGET_TRIPLET=x64-windows-static', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']"
 
       - name: Upload build logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Layer a compiler cache (sccache) on top of the existing vcpkg binary cache in the Windows vcpkg build. The vcpkg cache already skips rebuilding the dependencies; sccache additionally skips recompiling unchanged objects between runs, so only changed translation units are rebuilt.

Mirrors the sccache setup already present in Mateuzkl/AstraClient's build-vcpkg.yml. Cache is restored/saved with if: always() so a partial build still seeds the next run.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper TFS Downgrades code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Otimizações de cache foram adicionadas ao fluxo de compilação no Windows para acelerar builds com cache persistente.
  * O build agora configura e utiliza automaticamente o sccache como *compiler launcher* para compiladores C e C++, mantendo as demais opções do CMake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->