### PR TITLE
Implements persistent corpse loot highlighting.

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -943,8 +943,9 @@ enum class GameFeature : uint8_t {
 	ItemTierByte = 131,
 	AstraCreatureIcons = 133,
 	PlayerFamiliars = 138,
+	ItemLootHighlight = 139,
 
-	Last = 138
+	Last = 139
 };
 
 inline constexpr int32_t CHANNEL_GUILD = 0x00;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -317,6 +317,10 @@ QuickLootResult collectQuickLootContainer(Game& game, Player* player, Container*
 		}
 	}
 
+	if (result.movedItems > 0) {
+		game.stopLootHighlight(container);
+	}
+
 	return result;
 }
 
@@ -2167,8 +2171,18 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
+		if (item->hasLootHighlight()) {
+			item->setLootHighlight(false);
+		}
+
 		// remove the item
 		cylinder->removeThing(item, count);
+
+		if (Container* parentContainer = dynamic_cast<Container*>(cylinder)) {
+			if (parentContainer->hasLootHighlight() && parentContainer->empty()) {
+				stopLootHighlight(parentContainer);
+			}
+		}
 
 		if (item->isRemoved()) {
 			item->onRemoved();
@@ -2388,6 +2402,10 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 	}
 
 	const ItemType& curType = Item::items[item->getID()];
+	if (item->hasLootHighlight()) {
+		item->setLootHighlight(false);
+	}
+
 	if (curType.alwaysOnTop != newType.alwaysOnTop) {
 		// This only occurs when you transform items on tiles from a downItem to a topItem (or vice versa)
 		// Remove the old, and add the new
@@ -3044,7 +3062,7 @@ void Game::playerUseItem(uint32_t playerId, const Position& pos, uint8_t stackPo
 		return;
 	}
 
-	if (!item->isUseable()) {
+	if (item->isUseable()) {
 		player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
 		return;
 	}
@@ -6533,37 +6551,97 @@ void Game::internalDecayItem(std::shared_ptr<Item> item)
 // Loot Highlight System
 // ============================================================
 
+namespace {
+
+void notifyAstraLootHighlightChange(Game& game, Container* corpse)
+{
+	if (!corpse) {
+		return;
+	}
+
+	Tile* tile = corpse->getTile();
+	if (!tile || corpse->isRemoved()) {
+		return;
+	}
+
+	const Position& pos = corpse->getPosition();
+	SpectatorVec spectators;
+	game.map.getSpectators(spectators, pos, true);
+	for (const auto& spectator : spectators.players()) {
+		Player* player = static_cast<Player*>(spectator.get());
+		if (!player->isAstraClient()) {
+			continue;
+		}
+
+		if (InstanceUtils::canSeeItemInInstance(player->getInstanceID(), corpse)) {
+			player->sendUpdateTileItem(tile, pos, corpse);
+		}
+	}
+}
+
+void sendLegacyLootHighlightToPlayer(Player* player, Container* corpse, const Position& pos)
+{
+	if (!player || player->isAstraClient()) {
+		return;
+	}
+
+	if (!InstanceUtils::isPlayerInSameInstance(player, corpse->getInstanceID())) {
+		return;
+	}
+
+	player->sendMagicEffect(pos, CONST_ME_LOOT_HIGHLIGHT);
+}
+
+void sendLegacyLootHighlightToOwnerParty(Game& game, Container* corpse, uint32_t ownerPlayerId, const Position& pos)
+{
+	auto ownerRef = game.getPlayerByID(ownerPlayerId);
+	Player* owner = ownerRef.get();
+	if (!owner) {
+		return;
+	}
+
+	sendLegacyLootHighlightToPlayer(owner, corpse, pos);
+	if (Party* party = owner->getParty()) {
+		if (auto leader = party->getLeader()) {
+			if (leader.get() != owner) {
+				sendLegacyLootHighlightToPlayer(leader.get(), corpse, pos);
+			}
+		}
+		for (const auto& memberRef : party->getMembers()) {
+			if (auto member = memberRef.lock()) {
+				if (member.get() != owner) {
+					sendLegacyLootHighlightToPlayer(member.get(), corpse, pos);
+				}
+			}
+		}
+	}
+}
+
+void sendLegacyLootHighlightToSpectators(Game& game, Container* corpse, const Position& pos)
+{
+	SpectatorVec spectators;
+	game.map.getSpectators(spectators, pos, false, true);
+	for (const auto& spectator : spectators.players()) {
+		sendLegacyLootHighlightToPlayer(static_cast<Player*>(spectator.get()), corpse, pos);
+	}
+}
+
+} // namespace
+
 // Called once after loot is dropped into a corpse container.
-// ownerPlayerId: the player who has exclusive rights to open the corpse.
-// The highlight pulses every 2 seconds.
-// Phase 1 (0-10s): effect visible only to owner.
-// Phase 2 (10s+):  effect visible to everyone until corpse is opened/decayed.
 void Game::startLootHighlight(Container* corpse, uint32_t ownerPlayerId)
 {
 	if (!corpse || corpse->empty()) {
 		return;
 	}
 
-	// Send the first effect immediately to owner and party
-	auto ownerRef = getPlayerByID(ownerPlayerId);
-	Player* owner = ownerRef.get();
-	if (owner && InstanceUtils::isPlayerInSameInstance(owner, corpse->getInstanceID())) {
-		owner->sendMagicEffect(corpse->getPosition(), CONST_ME_LOOT_HIGHLIGHT);
-		if (Party* party = owner->getParty()) {
-			if (auto leader = party->getLeader()) {
-				if (leader.get() != owner && InstanceUtils::isPlayerInSameInstance(leader.get(), corpse->getInstanceID())) {
-					leader->sendMagicEffect(corpse->getPosition(), CONST_ME_LOOT_HIGHLIGHT);
-				}
-			}
-			for (const auto& memberRef : party->getMembers()) {
-				if (auto member = memberRef.lock()) {
-					if (member.get() != owner && InstanceUtils::isPlayerInSameInstance(member.get(), corpse->getInstanceID())) {
-						member->sendMagicEffect(corpse->getPosition(), CONST_ME_LOOT_HIGHLIGHT);
-					}
-				}
-			}
-		}
+	if (!corpse->hasLootHighlight()) {
+		corpse->setLootHighlight(true);
+		notifyAstraLootHighlightChange(*this, corpse);
 	}
+
+	const Position& pos = corpse->getPosition();
+	sendLegacyLootHighlightToOwnerParty(*this, corpse, ownerPlayerId, pos);
 
 	auto corpseItem = corpse->weak_from_this().lock();
 	if (!corpseItem) {
@@ -6574,7 +6652,6 @@ void Game::startLootHighlight(Container* corpse, uint32_t ownerPlayerId)
 	auto scheduledEventId = std::make_shared<uint32_t>(0);
 	cleanupExpiredLootHighlightEvents();
 
-	// Schedule the first repeating tick
 	uint32_t eventId = g_scheduler.addEvent(createSchedulerTask(
 	    LOOT_HIGHLIGHT_PULSE_MS,
 	    ([this, weakCorpse, scheduledEventId, ownerPlayerId,
@@ -6606,59 +6683,24 @@ void Game::checkLootHighlight(std::shared_ptr<Item> corpseItem, uint32_t ownerPl
 	}
 
 	std::weak_ptr<Item> weakCorpse = corpseItem;
-
-	// Remove entry first
 	auto it = lootHighlightEvents.find(weakCorpse);
 	if (it == lootHighlightEvents.end() || it->second != eventId) {
 		return;
 	}
 	lootHighlightEvents.erase(it);
 
-	// Validate stop conditions
 	Tile* tile = corpse->getTile();
 	if (!tile || corpse->isRemoved() || corpse->empty() || totalTicksLeft < 0) {
-		return; // Stop permanently
+		return;
 	}
 
 	const Position& pos = corpse->getPosition();
-
 	if (ownerTicksLeft > 0) {
-		// Phase 1 — Owner and Party
-		auto ownerRef = getPlayerByID(ownerPlayerId);
-		Player* owner = ownerRef.get();
-		if (owner && InstanceUtils::isPlayerInSameInstance(owner, corpse->getInstanceID())) {
-			owner->sendMagicEffect(pos, CONST_ME_LOOT_HIGHLIGHT);
-			if (Party* party = owner->getParty()) {
-				if (auto leader = party->getLeader()) {
-					if (leader.get() != owner && InstanceUtils::isPlayerInSameInstance(leader.get(), corpse->getInstanceID())) {
-						leader->sendMagicEffect(pos, CONST_ME_LOOT_HIGHLIGHT);
-					}
-				}
-				for (const auto& memberRef : party->getMembers()) {
-					if (auto member = memberRef.lock()) {
-						if (member.get() != owner && InstanceUtils::isPlayerInSameInstance(member.get(), corpse->getInstanceID())) {
-							member->sendMagicEffect(pos, CONST_ME_LOOT_HIGHLIGHT);
-						}
-					}
-				}
-			}
-		}
+		sendLegacyLootHighlightToOwnerParty(*this, corpse, ownerPlayerId, pos);
 	} else {
-		// Phase 2 — Public
-		SpectatorVec spectators;
-		map.getSpectators(spectators, pos, false, true);
-		for (const auto& spec : spectators) {
-			if (Player* p = spec->getPlayer()) {
-				if (!InstanceUtils::isPlayerInSameInstance(p, corpse->getInstanceID())) {
-					continue;
-				}
-
-				p->sendMagicEffect(pos, CONST_ME_LOOT_HIGHLIGHT);
-			}
-		}
+		sendLegacyLootHighlightToSpectators(*this, corpse, pos);
 	}
 
-	// Reschedule with decreased timers
 	auto scheduledEventId = std::make_shared<uint32_t>(0);
 	uint32_t newEventId = g_scheduler.addEvent(createSchedulerTask(
 	    LOOT_HIGHLIGHT_PULSE_MS,
@@ -6684,6 +6726,12 @@ void Game::stopLootHighlight(Container* corpse)
 		return;
 	}
 
+	const bool hadAstraHighlight = corpse->hasLootHighlight();
+	if (hadAstraHighlight) {
+		corpse->setLootHighlight(false);
+		notifyAstraLootHighlightChange(*this, corpse);
+	}
+
 	auto corpseItem = corpse->weak_from_this().lock();
 	if (!corpseItem) {
 		return;
@@ -6692,7 +6740,7 @@ void Game::stopLootHighlight(Container* corpse)
 	std::weak_ptr<Item> weakCorpse = corpseItem;
 	auto it = lootHighlightEvents.find(weakCorpse);
 	if (it == lootHighlightEvents.end()) {
-		return; // No highlight active for this corpse
+		return;
 	}
 
 	g_scheduler.stopEvent(it->second);

--- a/src/game.h
+++ b/src/game.h
@@ -728,7 +728,7 @@ private:
 
 	std::unordered_set<Position, PositionHasher> tilesToClean;
 
-	// Loot Highlight: maps corpse item lifetime to scheduler event ID
+	// Loot Highlight: maps corpse item lifetime to scheduler event ID for non-Astra clients.
 	LootHighlightEventMap lootHighlightEvents;
 
 	ModalWindow offlineTrainingWindow{std::numeric_limits<uint32_t>::max(), "Train while you sleep",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -202,7 +202,8 @@ Item::Item(const uint16_t type, uint16_t count /*= 0*/) : id(type)
 	setDefaultDuration();
 }
 
-Item::Item(const Item& i) : Thing(), std::enable_shared_from_this<Item>(), id(i.id), count(i.count), loadedFromMap(i.loadedFromMap)
+Item::Item(const Item& i) : Thing(), std::enable_shared_from_this<Item>(), id(i.id), count(i.count), loadedFromMap(i.loadedFromMap),
+                            lootHighlight(i.lootHighlight)
 {
 	if (g_validItems) g_validItems->insert(this);
 	if (i.attributes) {

--- a/src/item.h
+++ b/src/item.h
@@ -524,6 +524,8 @@ public:
 	}
 	void setIntAttr(itemAttrTypes type, int64_t value) { getAttributes()->setIntAttr(type, value); }
 	void increaseIntAttr(itemAttrTypes type, int64_t value) { getAttributes()->increaseIntAttr(type, value); }
+	void setLootHighlight(bool value) { lootHighlight = value; }
+	bool hasLootHighlight() const { return lootHighlight; }
 
 	void removeAttribute(itemAttrTypes type)
 	{
@@ -1059,7 +1061,9 @@ private:
 
 	bool loadedFromMap = false;
 
-	// Don't add variables here, use the ItemAttribute class.
+	bool lootHighlight = false;
+
+	// Don't add persistent variables here, use the ItemAttribute class.
 	friend class Decay;
 };
 

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -106,7 +106,8 @@ void NetworkMessage::addItemId(uint16_t itemId)
 	add<uint16_t>(clientId);
 }
 
-void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alwaysSendTier, bool sendQuickLootFlags)
+void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alwaysSendTier, bool sendQuickLootFlags,
+                             bool sendLootHighlight)
 {
 	addItemId(id);
 
@@ -120,6 +121,9 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 	if (sendQuickLootFlags && it.isContainer()) {
 		addByte(0);
 	}
+	if (sendLootHighlight && it.isContainer()) {
+		addByte(0);
+	}
 
 	if (sendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
 	    (alwaysSendTier || (ConfigManager::getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) && it.classification > 0))) {
@@ -128,7 +132,7 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 }
 
 void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTier, bool sendQuiverCount,
-                             bool sendQuickLootFlags)
+                             bool sendQuickLootFlags, bool sendLootHighlight)
 {
 	addItemId(item->getID());
 
@@ -144,6 +148,9 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 
 	if (sendQuickLootFlags && it.isContainer()) {
 		addByte(0);
+	}
+	if (sendLootHighlight && it.isContainer()) {
+		addByte(item->hasLootHighlight() ? 1 : 0);
 	}
 
 	if (sendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -123,9 +123,9 @@ public:
 	void addPosition(const Position& pos);
 	void addItemId(uint16_t itemId);
 	void addItem(uint16_t id, uint8_t count, bool sendTier = false, bool alwaysSendTier = false,
-	             bool sendQuickLootFlags = false);
+	             bool sendQuickLootFlags = false, bool sendLootHighlight = false);
 	void addItem(const Item* item, bool sendTier = false, bool alwaysSendTier = false, bool sendQuiverCount = false,
-	             bool sendQuickLootFlags = false);
+	             bool sendQuickLootFlags = false, bool sendLootHighlight = false);
 
 	MsgSize_t getLength() const { return info.length; }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -378,6 +378,11 @@ bool ProtocolGame::shouldSendQuickLootFlags() const
 	return isAstraClient && getBoolean(ConfigManager::QUICK_LOOT_ENABLED);
 }
 
+bool ProtocolGame::shouldSendItemLootHighlight() const
+{
+	return isAstraClient;
+}
+
 bool ProtocolGame::shouldSendItemTierByte() const
 {
 	return useItemTierByte && getBoolean(ConfigManager::ITEM_TIER_DISPLAY);
@@ -1382,7 +1387,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 	int32_t count;
 	Item* ground = tile->getGround();
 	if (ground) {
-		msg.addItem(ground, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+		msg.addItem(ground, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 		count = 1;
 	} else {
 		count = 0;
@@ -1394,7 +1399,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 			if (!InstanceUtils::canSeeItemInInstance(playerInstanceId, it->get())) {
 				continue;
 			}
-			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 			count++;
 			if (count == 9 && tile->getPosition() == player->getPosition()) {
 				break;
@@ -1439,7 +1444,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 			if (!InstanceUtils::canSeeItemInInstance(playerInstanceId, it->get())) {
 				continue;
 			}
-			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 			if (++count == MAX_STACKPOS_THINGS) {
 				return;
 			}
@@ -2594,7 +2599,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const bool sendQuickLootFlags = shouldSendQuickLootFlags();
 	const bool sendItemTierByte = shouldSendItemTierByte();
 	const bool sendItemTierData = shouldSendItemTierData();
-	msg.addItem(container, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+	msg.addItem(container, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 	msg.addString(container->getName());
 
 	msg.addByte(static_cast<uint8_t>(container->capacity()));
@@ -2607,7 +2612,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const ItemDeque& itemList = container->getItemList();
 	for (ItemDeque::const_iterator cit = itemList.begin() + firstIndex, end = itemList.end(); i < 0xFF && cit != end;
 	     ++cit, ++i) {
-		msg.addItem(cit->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+		msg.addItem(cit->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 	}
 	writeToOutputBuffer(msg);
 }
@@ -2781,11 +2786,11 @@ void ProtocolGame::sendTradeItemRequest(std::string_view traderName, const Item*
 
 		msg.addByte(itemList.size());
 		for (const Item* listItem : itemList) {
-			msg.addItem(listItem, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+			msg.addItem(listItem, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 		}
 	} else {
 		msg.addByte(0x01);
-		msg.addItem(item, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+		msg.addItem(item, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, shouldSendItemLootHighlight());
 	}
 	writeToOutputBuffer(msg);
 }
@@ -3125,7 +3130,7 @@ void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const
 	msg.addByte(0x6A);
 	msg.addPosition(pos);
 	msg.addByte(static_cast<uint8_t>(stackpos));
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	writeToOutputBuffer(msg);
 }
 
@@ -3143,7 +3148,7 @@ void ProtocolGame::sendUpdateTileItem(const Position& pos, uint32_t stackpos, co
 	msg.addByte(0x6B);
 	msg.addPosition(pos);
 	msg.addByte(static_cast<uint8_t>(stackpos));
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	writeToOutputBuffer(msg);
 }
 
@@ -3428,7 +3433,7 @@ void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
 	if (item) {
 		msg.addByte(0x78);
 		msg.addByte(slot);
-		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	} else {
 		msg.addByte(0x79);
 		msg.addByte(slot);
@@ -3477,7 +3482,7 @@ void ProtocolGame::sendAddContainerItem(uint8_t cid, const Item* item)
 	NetworkMessage msg;
 	msg.addByte(0x70);
 	msg.addByte(cid);
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	writeToOutputBuffer(msg);
 }
 
@@ -3487,7 +3492,7 @@ void ProtocolGame::sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Ite
 	msg.addByte(0x71);
 	msg.addByte(cid);
 	msg.addByte(slot);
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	writeToOutputBuffer(msg);
 }
 
@@ -3710,10 +3715,10 @@ void ProtocolGame::sendItemInspection(std::shared_ptr<Item> item, uint16_t itemI
 	msg.addByte(1);
 	msg.addString(item ? item->getName() : std::string_view(itemType.name));
 	if (item) {
-		msg.addItem(item.get(), shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+		msg.addItem(item.get(), shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	} else {
 		msg.addItem(itemId, itemCount, shouldSendItemTierData(), shouldSendItemTierByte(),
-		            shouldSendQuickLootFlags());
+		            shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 	}
 	msg.addByte(0);
 
@@ -4345,6 +4350,7 @@ void ProtocolGame::sendFeatures()
 		features[GameFeature::PlayerFamiliars] = true;
 	}
 	features[GameFeature::QuickLootFlags] = shouldSendQuickLootFlags();
+	features[GameFeature::ItemLootHighlight] = shouldSendItemLootHighlight();
 	features[GameFeature::ThingUpgradeClassification] = false;
 	features[GameFeature::ItemTierByte] = shouldSendItemTierByte();
 
@@ -4633,7 +4639,7 @@ void ProtocolGame::sendImbuementDurations(slots_t updatedSlot, const Item* updat
 		const Item* item = p.second;
 
 		msg.addByte(static_cast<uint8_t>(slot));
-		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(), shouldSendItemLootHighlight());
 
 		uint16_t totalSlots = item->getImbuementSlots();
 		msg.addByte(static_cast<uint8_t>(totalSlots));

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -297,6 +297,7 @@ private:
 	// OTCv8
 	void sendFeatures();
 	bool shouldSendQuickLootFlags() const;
+	bool shouldSendItemLootHighlight() const;
 	bool shouldSendItemTierByte() const;
 	bool shouldSendThingUpgradeClassification() const;
 	bool shouldSendItemTierData() const;


### PR DESCRIPTION
AstraClient using item state synchronization, while preserving the legacy timed magic effect highlight for non-Astra clients.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado suporte a destaque visual para itens de loot, disponível para clientes Astra

* **Melhorias**
  * Refatoração abrangente do sistema de destaque de loot com melhor consistência de estado
  * Aprimoramento na sincronização de destaque durante movimentação, transformação e remoção de itens
  * Melhor preservação do estado de destaque em operações do game

<!-- end of auto-generated comment: release notes by coderabbit.ai -->