### PR TITLE
[codex] Import inventory protocol changes

### DIFF
--- a/docs/astra-hotkey-equip-client-contract.md
+++ b/docs/astra-hotkey-equip-client-contract.md
@@ -1,0 +1,14 @@
+# Astra hotkey equip client contract
+
+The server handles hotkey equip through opcode `0x77` only for authenticated Astra clients.
+
+Payload:
+
+```text
+uint16 itemId
+uint8 tier   # only when the server advertises item tier support for this item
+```
+
+Do not send item subtype/count in this opcode. If a client currently sends `itemId + subtype`, update it to omit `subtype`; otherwise, when tier support is enabled, the server can interpret that byte as `tier` and search for the wrong item.
+
+Clients that need stack count, charges, duration, or other item state should use the existing item serialization/state features, not opcode `0x77`.

--- a/src/const.h
+++ b/src/const.h
@@ -939,12 +939,15 @@ enum class GameFeature : uint8_t {
 	PacketCompression = 111,
 
 	QuickLootFlags = 123,
+	DisplayItemDuration = 129,
 	ThingUpgradeClassification = 130,
 	ItemTierByte = 131,
 	AstraCreatureIcons = 133,
 	PlayerFamiliars = 138,
+	DisplayItemCharges = 139,
+	PackedPlayerInventory = 140,
 
-	Last = 138
+	Last = 140
 };
 
 inline constexpr int32_t CHANNEL_GUILD = 0x00;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2581,10 +2581,14 @@ ReturnValue Game::internalTeleport(Thing* thing, const Position& newPos, bool pu
 	return RETURNVALUE_NOTPOSSIBLE;
 }
 
-Item* searchForItem(Container* container, uint16_t itemId)
+Item* searchForItem(Container* container, uint16_t itemId, bool hasTier = false, uint8_t tier = 0)
 {
+	if (!container) {
+		return nullptr;
+	}
+
 	for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-		if ((*it)->getID() == itemId) {
+		if ((*it)->getID() == itemId && (!hasTier || (*it)->getTier() == tier)) {
 			return *it;
 		}
 	}
@@ -2620,7 +2624,105 @@ slots_t getSlotType(const ItemType& it)
 	return slot;
 }
 
+bool isHotkeyEquippedItem(const Item* slotItem, uint16_t itemId, bool hasTier, uint8_t tier)
+{
+	if (!slotItem || (hasTier && slotItem->getTier() != tier)) {
+		return false;
+	}
+
+	if (slotItem->getID() == itemId) {
+		return true;
+	}
+
+	const ItemType& hotkeyType = Item::items[itemId];
+	const ItemType& equippedType = Item::items[slotItem->getID()];
+	return hotkeyType.transformEquipTo == slotItem->getID() || equippedType.transformDeEquipTo == itemId;
+}
+
 // Implementation of player invoked events
+void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= false*/, uint8_t tier /*= 0*/)
+{
+	auto playerRef = getPlayerByID(playerId);
+	Player* player = playerRef.get();
+	if (!player) {
+		return;
+	}
+
+	const ItemType& it = Item::items[itemId];
+	slots_t slot = getSlotType(it);
+
+	if (!player->canDoAction()) {
+		const uint32_t delay = player->getNextActionTime();
+		auto task = createSchedulerTask(delay, ([this, playerId, itemId, hasTier, tier]() {
+			playerEquipItem(playerId, itemId, hasTier, tier);
+		}));
+		player->setNextActionTask(std::move(task));
+		return;
+	}
+
+	if (player->hasCondition(CONDITION_FEARED)) {
+		player->sendTextMessage(MESSAGE_STATUS_SMALL, "You are feared.");
+		return;
+	}
+
+	Item* backpackItem = player->getInventoryItem(CONST_SLOT_BACKPACK);
+	Container* backpack = backpackItem ? backpackItem->getContainer() : nullptr;
+	Item* slotItem = player->getInventoryItem(slot);
+	Item* equipItem = searchForItem(backpack, itemId, hasTier, tier);
+
+	ReturnValue ret = RETURNVALUE_NOERROR;
+	if (isHotkeyEquippedItem(slotItem, itemId, hasTier, tier)) {
+		if (!backpack) {
+			player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+			return;
+		}
+		ret = internalMoveItem(slotItem->getParent(), backpack, INDEX_WHEREEVER, slotItem, slotItem->getItemCount(), nullptr, 0, player);
+	} else if (equipItem) {
+		Item* rightItem = player->getInventoryItem(CONST_SLOT_RIGHT);
+		if (it.weaponType == WEAPON_AMMO) {
+			if (rightItem && rightItem->getWeaponType() == WEAPON_QUIVER) {
+				ret = internalMoveItem(equipItem->getParent(), rightItem->getContainer(), INDEX_WHEREEVER, equipItem, equipItem->getItemCount(), nullptr, 0, player);
+			}
+		} else {
+			Item* leftItem = player->getInventoryItem(CONST_SLOT_LEFT);
+			const int32_t slotPosition = equipItem->getSlotPosition();
+			if ((slotPosition & SLOTP_LEFT) && (slotPosition & SLOTP_TWO_HAND) && rightItem && rightItem->getWeaponType() != WEAPON_QUIVER) {
+				if (!backpack) {
+					player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+					return;
+				}
+				ret = internalMoveItem(rightItem->getParent(), backpack, INDEX_WHEREEVER, rightItem, rightItem->getItemCount(), nullptr, 0, player);
+				if (ret != RETURNVALUE_NOERROR) {
+					player->sendCancelMessage(ret);
+					return;
+				}
+			}
+
+			if (slot == CONST_SLOT_RIGHT && it.weaponType != WEAPON_QUIVER && leftItem && leftItem->getSlotPosition() & SLOTP_TWO_HAND) {
+				if (!backpack) {
+					player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+					return;
+				}
+				ret = internalMoveItem(leftItem->getParent(), backpack, INDEX_WHEREEVER, leftItem, leftItem->getItemCount(), nullptr, 0, player);
+				if (ret != RETURNVALUE_NOERROR) {
+					player->sendCancelMessage(ret);
+					return;
+				}
+			}
+
+			ret = internalMoveItem(equipItem->getParent(), player, slot, equipItem, equipItem->getItemCount(), nullptr, 0, player);
+		}
+	}
+
+	if (ret != RETURNVALUE_NOERROR) {
+		player->sendCancelMessage(ret);
+		return;
+	}
+
+	player->setNextAction(OTSYS_TIME() + getMoveItemExhaustionDelay(Position(0xFFFF, slot, 0)));
+	player->sendAstraPlayerInventorySnapshot();
+}
+
 void Game::playerMove(uint32_t playerId, Direction direction)
 {
 	auto playerRef = getPlayerByID(playerId);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2751,6 +2751,9 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 
 			ret = internalMoveItem(equipItem->getParent(), player, slot, equipItem, equipItem->getItemCount(), nullptr, 0, player);
 		}
+	} else {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
 	}
 
 	if (ret != RETURNVALUE_NOERROR) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2653,10 +2653,6 @@ ReturnValue validateHotkeyEquip(Player* player, Item* item, slots_t slot)
 		return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
 	}
 
-	if (!player->hasCapacity(item, item->getItemCount())) {
-		return RETURNVALUE_NOTENOUGHCAPACITY;
-	}
-
 	return g_moveEvents->onPlayerEquip(player, item, slot, true);
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2639,12 +2639,37 @@ bool isHotkeyEquippedItem(const Item* slotItem, uint16_t itemId, bool hasTier, u
 	return hotkeyType.transformEquipTo == slotItem->getID() || equippedType.transformDeEquipTo == itemId;
 }
 
+ReturnValue validateHotkeyEquip(Player* player, Item* item, slots_t slot)
+{
+	if (!item) {
+		return RETURNVALUE_NOTPOSSIBLE;
+	}
+
+	if (!item->isPickupable()) {
+		return RETURNVALUE_CANNOTPICKUP;
+	}
+
+	if (item->isStoreItem()) {
+		return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
+	}
+
+	if (!player->hasCapacity(item, item->getItemCount())) {
+		return RETURNVALUE_NOTENOUGHCAPACITY;
+	}
+
+	return g_moveEvents->onPlayerEquip(player, item, slot, true);
+}
+
 // Implementation of player invoked events
 void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= false*/, uint8_t tier /*= 0*/)
 {
 	auto playerRef = getPlayerByID(playerId);
 	Player* player = playerRef.get();
 	if (!player) {
+		return;
+	}
+
+	if (itemId == 0 || itemId >= Item::items.size()) {
 		return;
 	}
 
@@ -2671,6 +2696,8 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 	Item* equipItem = searchForItem(backpack, itemId, hasTier, tier);
 
 	ReturnValue ret = RETURNVALUE_NOERROR;
+	Item* restoreRightItem = nullptr;
+	Item* restoreLeftItem = nullptr;
 	if (isHotkeyEquippedItem(slotItem, itemId, hasTier, tier)) {
 		if (!backpack) {
 			player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
@@ -2682,13 +2709,21 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 		if (it.weaponType == WEAPON_AMMO) {
 			if (rightItem && rightItem->getWeaponType() == WEAPON_QUIVER) {
 				ret = internalMoveItem(equipItem->getParent(), rightItem->getContainer(), INDEX_WHEREEVER, equipItem, equipItem->getItemCount(), nullptr, 0, player);
+			} else {
+				ret = internalMoveItem(equipItem->getParent(), player, CONST_SLOT_AMMO, equipItem, equipItem->getItemCount(), nullptr, 0, player);
 			}
 		} else {
 			Item* leftItem = player->getInventoryItem(CONST_SLOT_LEFT);
 			const int32_t slotPosition = equipItem->getSlotPosition();
-			if ((slotPosition & SLOTP_LEFT) && (slotPosition & SLOTP_TWO_HAND) && rightItem && rightItem->getWeaponType() != WEAPON_QUIVER) {
+			const bool equipTwoHandedLeft = (slotPosition & SLOTP_LEFT) && (slotPosition & SLOTP_TWO_HAND);
+			if (equipTwoHandedLeft && rightItem && rightItem->getWeaponType() != WEAPON_QUIVER) {
 				if (!backpack) {
 					player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+					return;
+				}
+				ret = validateHotkeyEquip(player, equipItem, slot);
+				if (ret != RETURNVALUE_NOERROR) {
+					player->sendCancelMessage(ret);
 					return;
 				}
 				ret = internalMoveItem(rightItem->getParent(), backpack, INDEX_WHEREEVER, rightItem, rightItem->getItemCount(), nullptr, 0, player);
@@ -2696,11 +2731,18 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 					player->sendCancelMessage(ret);
 					return;
 				}
+				restoreRightItem = rightItem;
 			}
 
-			if (slot == CONST_SLOT_RIGHT && it.weaponType != WEAPON_QUIVER && leftItem && leftItem->getSlotPosition() & SLOTP_TWO_HAND) {
+			if (slot == CONST_SLOT_RIGHT && it.weaponType != WEAPON_QUIVER && leftItem &&
+			    (leftItem->getSlotPosition() & SLOTP_TWO_HAND)) {
 				if (!backpack) {
 					player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+					return;
+				}
+				ret = validateHotkeyEquip(player, equipItem, slot);
+				if (ret != RETURNVALUE_NOERROR) {
+					player->sendCancelMessage(ret);
 					return;
 				}
 				ret = internalMoveItem(leftItem->getParent(), backpack, INDEX_WHEREEVER, leftItem, leftItem->getItemCount(), nullptr, 0, player);
@@ -2708,6 +2750,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 					player->sendCancelMessage(ret);
 					return;
 				}
+				restoreLeftItem = leftItem;
 			}
 
 			ret = internalMoveItem(equipItem->getParent(), player, slot, equipItem, equipItem->getItemCount(), nullptr, 0, player);
@@ -2715,6 +2758,14 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 	}
 
 	if (ret != RETURNVALUE_NOERROR) {
+		if (restoreLeftItem && !restoreLeftItem->isRemoved()) {
+			internalMoveItem(restoreLeftItem->getParent(), player, CONST_SLOT_LEFT, restoreLeftItem,
+			                 restoreLeftItem->getItemCount(), nullptr, 0, player);
+		}
+		if (restoreRightItem && !restoreRightItem->isRemoved()) {
+			internalMoveItem(restoreRightItem->getParent(), player, CONST_SLOT_RIGHT, restoreRightItem,
+			                 restoreRightItem->getItemCount(), nullptr, 0, player);
+		}
 		player->sendCancelMessage(ret);
 		return;
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2770,7 +2770,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /*= 
 	}
 
 	player->setNextAction(OTSYS_TIME() + getMoveItemExhaustionDelay(Position(0xFFFF, slot, 0)));
-	player->sendAstraPlayerInventorySnapshot();
+	player->scheduleAstraPlayerInventorySnapshot();
 }
 
 void Game::playerMove(uint32_t playerId, Direction direction)

--- a/src/game.h
+++ b/src/game.h
@@ -380,6 +380,7 @@ public:
 	// Implementation of player invoked events
 	void playerMoveThing(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                     const Position& toPos, uint8_t count);
+	void playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier = false, uint8_t tier = 0);
 	void playerMoveCreatureByID(uint32_t playerId, uint32_t movingCreatureId, const Position& movingCreatureOrigPos,
 	                            const Position& toPos);
 	void playerMoveCreature(Player* player, Creature* movingCreature, const Position& movingCreatureOrigPos,

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -128,7 +128,7 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 }
 
 void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTier, bool sendQuiverCount,
-                             bool sendQuickLootFlags)
+                             bool sendQuickLootFlags, bool sendAstraItemState)
 {
 	addItemId(item->getID());
 
@@ -149,6 +149,30 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 	if (sendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
 	    (alwaysSendTier || (ConfigManager::getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) && it.classification > 0))) {
 		addByte(item->getTier());
+	}
+
+	if (sendAstraItemState) {
+		const bool hasDuration = (it.showDuration || item->hasAttribute(ITEM_ATTRIBUTE_DURATION) ||
+		                          item->hasAttribute(ITEM_ATTRIBUTE_DURATION_TIMESTAMP)) &&
+		                         item->getDuration() > 0;
+		addByte(hasDuration ? 1 : 0);
+		if (hasDuration) {
+			add<uint32_t>(static_cast<uint32_t>(std::max<int32_t>(0, item->getDuration()) / 1000));
+			addByte(it.stopTime ? 1 : 0);
+		}
+
+		uint32_t charges = 0;
+		if (it.charges != 0) {
+			charges = item->getSubType();
+		} else if (it.showCharges || item->hasAttribute(ITEM_ATTRIBUTE_CHARGES)) {
+			charges = item->getCharges();
+		}
+
+		addByte(charges > 0 ? 1 : 0);
+		if (charges > 0) {
+			add<uint32_t>(charges);
+			addByte((it.charges != 0 && charges == it.charges) ? 1 : 0);
+		}
 	}
 }
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -125,7 +125,7 @@ public:
 	void addItem(uint16_t id, uint8_t count, bool sendTier = false, bool alwaysSendTier = false,
 	             bool sendQuickLootFlags = false);
 	void addItem(const Item* item, bool sendTier = false, bool alwaysSendTier = false, bool sendQuiverCount = false,
-	             bool sendQuickLootFlags = false);
+	             bool sendQuickLootFlags = false, bool sendAstraItemState = false);
 
 	MsgSize_t getLength() const { return info.length; }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -104,15 +104,6 @@ bool isOwnedOrOpenContainer(const Player* player, const Container* container)
 	return false;
 }
 
-void sendAstraPlayerInventorySnapshotLater(uint32_t playerId)
-{
-	g_dispatcher.addTask([playerId]() {
-		if (auto player = g_game.getPlayerByID(playerId)) {
-			player->sendAstraPlayerInventorySnapshot();
-		}
-	});
-}
-
 void addSpellAugmentBonus(ProficiencySpellAugmentBonus& bonus, Augment_t augmentType, double value)
 {
 	switch (augmentType) {
@@ -2580,7 +2571,7 @@ void Player::onAddContainerItem(const Item* item)
 		}
 	}
 	if (client && (isOwnedInventoryItem(this, item) || isOwnedOrOpenContainer(this, container))) {
-		sendAstraPlayerInventorySnapshot();
+		scheduleAstraPlayerInventorySnapshot();
 	}
 
 	checkTradeState(item);
@@ -2592,7 +2583,7 @@ void Player::onUpdateContainerItem(const Container* container, const Item* oldIt
 	                                             isOwnedInventoryItem(this, oldItem) ||
 	                                             isOwnedInventoryItem(this, newItem));
 	if (oldItem == newItem && updatesAstraInventory) {
-		sendAstraPlayerInventorySnapshot();
+		scheduleAstraPlayerInventorySnapshot();
 	}
 
 	if (oldItem != newItem) {
@@ -2607,7 +2598,7 @@ void Player::onUpdateContainerItem(const Container* container, const Item* oldIt
 void Player::onRemoveContainerItem(const Container* container, const Item* item)
 {
 	if (client && (isOwnedOrOpenContainer(this, container) || isOwnedInventoryItem(this, item))) {
-		sendAstraPlayerInventorySnapshotLater(getID());
+		scheduleAstraPlayerInventorySnapshot();
 	}
 
 	if (tradeState != TRADE_TRANSFER) {
@@ -2698,6 +2689,27 @@ void Player::sendAstraPlayerInventorySnapshot() const
 	if (const ProtocolGame_ptr protocol = client->protocol()) {
 		protocol->sendPlayerInventory();
 	}
+}
+
+void Player::scheduleAstraPlayerInventorySnapshot()
+{
+	if (astraPlayerInventorySnapshotScheduled) {
+		return;
+	}
+
+	astraPlayerInventorySnapshotScheduled = true;
+	const uint32_t playerId = getID();
+	g_dispatcher.addTask([playerId]() {
+		if (auto player = g_game.getPlayerByID(playerId)) {
+			player->flushAstraPlayerInventorySnapshot();
+		}
+	});
+}
+
+void Player::flushAstraPlayerInventorySnapshot()
+{
+	astraPlayerInventorySnapshotScheduled = false;
+	sendAstraPlayerInventorySnapshot();
 }
 
 void Player::checkTradeState(const Item* item)
@@ -4271,7 +4283,7 @@ void Player::addThing(int32_t index, Thing* thing)
 
 	// send to client
 	sendInventoryItem(static_cast<slots_t>(index), item);
-	sendAstraPlayerInventorySnapshot();
+	scheduleAstraPlayerInventorySnapshot();
 }
 
 void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
@@ -4294,7 +4306,7 @@ void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 
 	// event methods
 	onUpdateInventoryItem(item, item);
-	sendAstraPlayerInventorySnapshot();
+	scheduleAstraPlayerInventorySnapshot();
 }
 
 void Player::replaceThing(uint32_t index, Thing* thing)
@@ -4332,7 +4344,7 @@ void Player::replaceThing(uint32_t index, Thing* thing)
 	if (oldItem != item) {
 		oldItem->setParent(nullptr);
 	}
-	sendAstraPlayerInventorySnapshot();
+	scheduleAstraPlayerInventorySnapshot();
 }
 
 void Player::removeThing(Thing* thing, uint32_t count)
@@ -4357,7 +4369,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 			item->setParent(nullptr);
 			inventory[index].reset();
-			sendAstraPlayerInventorySnapshot();
+			scheduleAstraPlayerInventorySnapshot();
 		} else {
 			uint8_t newCount = static_cast<uint8_t>(std::max<int32_t>(0, item->getItemCount() - count));
 			item->setItemCount(newCount);
@@ -4367,7 +4379,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 			// event methods
 			onUpdateInventoryItem(item, item);
-			sendAstraPlayerInventorySnapshot();
+			scheduleAstraPlayerInventorySnapshot();
 		}
 	} else {
 		// send change to client
@@ -4378,7 +4390,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 		item->setParent(nullptr);
 		inventory[index].reset();
-		sendAstraPlayerInventorySnapshot();
+		scheduleAstraPlayerInventorySnapshot();
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2597,9 +2597,6 @@ void Player::onUpdateContainerItem(const Container* container, const Item* oldIt
 
 	if (oldItem != newItem) {
 		onRemoveContainerItem(container, oldItem);
-		if (updatesAstraInventory) {
-			sendAstraPlayerInventorySnapshot();
-		}
 	}
 
 	if (tradeState != TRADE_TRANSFER) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -79,6 +79,40 @@ void addClamped(int32_t& target, int64_t value)
 	                                                 std::numeric_limits<int32_t>::max()));
 }
 
+bool isOwnedInventoryItem(const Player* player, const Item* item)
+{
+	return player && item && item->getTopParent() == player;
+}
+
+bool isOwnedOrOpenContainer(const Player* player, const Container* container)
+{
+	if (!player || !container) {
+		return false;
+	}
+
+	if (container->getTopParent() == player) {
+		return true;
+	}
+
+	for (const auto& it : player->getOpenContainers()) {
+		auto openContainer = it.second.container.lock();
+		if (openContainer.get() == container) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void sendAstraPlayerInventorySnapshotLater(uint32_t playerId)
+{
+	g_dispatcher.addTask([playerId]() {
+		if (auto player = g_game.getPlayerByID(playerId)) {
+			player->sendAstraPlayerInventorySnapshot();
+		}
+	});
+}
+
 void addSpellAugmentBonus(ProficiencySpellAugmentBonus& bonus, Augment_t augmentType, double value)
 {
 	switch (augmentType) {
@@ -2535,12 +2569,37 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 }
 
 // container
-void Player::onAddContainerItem(const Item* item) { checkTradeState(item); }
+void Player::onAddContainerItem(const Item* item)
+{
+	const Container* container = nullptr;
+	if (item) {
+		if (const Cylinder* parent = item->getParent()) {
+			if (const Item* parentItem = parent->getItem()) {
+				container = parentItem->getContainer();
+			}
+		}
+	}
+	if (client && (isOwnedInventoryItem(this, item) || isOwnedOrOpenContainer(this, container))) {
+		sendAstraPlayerInventorySnapshot();
+	}
+
+	checkTradeState(item);
+}
 
 void Player::onUpdateContainerItem(const Container* container, const Item* oldItem, const Item* newItem)
 {
+	const bool updatesAstraInventory = client && (isOwnedOrOpenContainer(this, container) ||
+	                                             isOwnedInventoryItem(this, oldItem) ||
+	                                             isOwnedInventoryItem(this, newItem));
+	if (oldItem == newItem && updatesAstraInventory) {
+		sendAstraPlayerInventorySnapshot();
+	}
+
 	if (oldItem != newItem) {
 		onRemoveContainerItem(container, oldItem);
+		if (updatesAstraInventory) {
+			sendAstraPlayerInventorySnapshot();
+		}
 	}
 
 	if (tradeState != TRADE_TRANSFER) {
@@ -2550,6 +2609,10 @@ void Player::onUpdateContainerItem(const Container* container, const Item* oldIt
 
 void Player::onRemoveContainerItem(const Container* container, const Item* item)
 {
+	if (client && (isOwnedOrOpenContainer(this, container) || isOwnedInventoryItem(this, item))) {
+		sendAstraPlayerInventorySnapshotLater(getID());
+	}
+
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
@@ -2626,6 +2689,17 @@ void Player::onRemoveInventoryItem(Item* item)
 				g_game.internalCloseTrade(this);
 			}
 		}
+	}
+}
+
+void Player::sendAstraPlayerInventorySnapshot() const
+{
+	if (!client) {
+		return;
+	}
+
+	if (const ProtocolGame_ptr protocol = client->protocol()) {
+		protocol->sendPlayerInventory();
 	}
 }
 
@@ -4200,6 +4274,7 @@ void Player::addThing(int32_t index, Thing* thing)
 
 	// send to client
 	sendInventoryItem(static_cast<slots_t>(index), item);
+	sendAstraPlayerInventorySnapshot();
 }
 
 void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
@@ -4222,6 +4297,7 @@ void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 
 	// event methods
 	onUpdateInventoryItem(item, item);
+	sendAstraPlayerInventorySnapshot();
 }
 
 void Player::replaceThing(uint32_t index, Thing* thing)
@@ -4259,6 +4335,7 @@ void Player::replaceThing(uint32_t index, Thing* thing)
 	if (oldItem != item) {
 		oldItem->setParent(nullptr);
 	}
+	sendAstraPlayerInventorySnapshot();
 }
 
 void Player::removeThing(Thing* thing, uint32_t count)
@@ -4283,6 +4360,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 			item->setParent(nullptr);
 			inventory[index].reset();
+			sendAstraPlayerInventorySnapshot();
 		} else {
 			uint8_t newCount = static_cast<uint8_t>(std::max<int32_t>(0, item->getItemCount() - count));
 			item->setItemCount(newCount);
@@ -4292,6 +4370,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 			// event methods
 			onUpdateInventoryItem(item, item);
+			sendAstraPlayerInventorySnapshot();
 		}
 	} else {
 		// send change to client
@@ -4302,6 +4381,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 		item->setParent(nullptr);
 		inventory[index].reset();
+		sendAstraPlayerInventorySnapshot();
 	}
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -1181,6 +1181,7 @@ public:
 	// inventory
 	void onUpdateInventoryItem(Item* oldItem, Item* newItem);
 	void onRemoveInventoryItem(Item* item);
+	void sendAstraPlayerInventorySnapshot() const;
 
 	void sendCancelMessage(std::string_view msg) const
 	{

--- a/src/player.h
+++ b/src/player.h
@@ -1182,6 +1182,7 @@ public:
 	void onUpdateInventoryItem(Item* oldItem, Item* newItem);
 	void onRemoveInventoryItem(Item* item);
 	void sendAstraPlayerInventorySnapshot() const;
+	void scheduleAstraPlayerInventorySnapshot();
 
 	void sendCancelMessage(std::string_view msg) const
 	{
@@ -1544,6 +1545,7 @@ private:
 	void updateInventoryWeight();
 	void reloadEquipmentStats();
 	void applyEquipmentStats();
+	void flushAstraPlayerInventorySnapshot();
 
 	void setNextWalkActionTask(std::unique_ptr<SchedulerTask> task);
 	void setNextWalkTask(std::unique_ptr<SchedulerTask> task);
@@ -1749,6 +1751,7 @@ private:
 	bool tokenLocked = false;
 	bool staminaPzActive = false;
 	bool staminaTrainerActive = false;
+	bool astraPlayerInventorySnapshotScheduled = false;
 	uint8_t m_harmony = 0;
 	bool m_serene = false;
 	uint64_t m_serene_cooldown = 0;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -23,6 +23,9 @@
 #include "scriptmanager.h"
 #include "thread_pool.h"
 
+#include <limits>
+#include <map>
+
 uint32_t ProtocolGame::spectatorId = 1;
 std::set<std::string> ProtocolGame::spectatorNames;
 extern Monsters g_monsters;
@@ -37,6 +40,66 @@ constexpr uint8_t HELPER_OPCODE_CAST_ON_FOOT = 211;
 constexpr uint8_t HELPER_OPCODE_SMART_FOLLOW = 212;
 constexpr uint32_t STORAGE_ASTRA_HELPER_CAVEBOT = 99997;
 constexpr uint32_t STORAGE_ASTRA_HELPER_SMART_FOLLOW = 99998;
+
+using PlayerInventoryKey = std::pair<uint16_t, uint8_t>;
+using PlayerInventoryCounts = std::map<PlayerInventoryKey, uint32_t>;
+
+uint32_t getPlayerInventoryItemAmount(const Item* item)
+{
+	if (!item) {
+		return 0;
+	}
+
+	const ItemType& itemType = Item::items[item->getID()];
+	if (itemType.stackable) {
+		return std::max<uint32_t>(1, item->getItemCount());
+	}
+
+	return 1;
+}
+
+void addPlayerInventoryItem(PlayerInventoryCounts& counts, const Item* item)
+{
+	if (!item) {
+		return;
+	}
+
+	const uint16_t clientId = item->getClientID();
+	if (clientId == 0) {
+		return;
+	}
+
+	const uint8_t tier = item->getClassification() > 0 ? item->getTier() : 0;
+	const PlayerInventoryKey key{clientId, tier};
+	counts[key] += getPlayerInventoryItemAmount(item);
+
+	if (const Container* container = item->getContainer()) {
+		for (const auto& child : container->getItems(true)) {
+			addPlayerInventoryItem(counts, child.get());
+		}
+	}
+}
+
+void addPackedPlayerInventoryCount(NetworkMessage& msg, uint32_t count)
+{
+	if (count < 0x40) {
+		msg.addByte(static_cast<uint8_t>(count));
+	} else if (count < 0x4000) {
+		msg.addByte(static_cast<uint8_t>((count >> 8) + 0x40));
+		msg.addByte(static_cast<uint8_t>(count & 0xFF));
+	} else if (count < 0x1000000) {
+		msg.addByte(0x80);
+		msg.addByte(static_cast<uint8_t>((count >> 16) & 0xFF));
+		msg.addByte(static_cast<uint8_t>((count >> 8) & 0xFF));
+		msg.addByte(static_cast<uint8_t>(count & 0xFF));
+	} else {
+		msg.addByte(0xC0);
+		msg.addByte(static_cast<uint8_t>((count >> 24) & 0xFF));
+		msg.addByte(static_cast<uint8_t>((count >> 16) & 0xFF));
+		msg.addByte(static_cast<uint8_t>((count >> 8) & 0xFF));
+		msg.addByte(static_cast<uint8_t>(count & 0xFF));
+	}
+}
 
 uint32_t getStatPercent(uint32_t current, uint32_t maximum)
 {
@@ -1128,6 +1191,9 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 			g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
 			                     [playerID = player->getID()]() { g_game.playerTurn(playerID, DIRECTION_WEST); });
 			break;
+		case 0x77:
+			parseHotkeyEquip(msg);
+			break;
 		case 0x78:
 			parseThrow(msg);
 			break;
@@ -1382,7 +1448,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 	int32_t count;
 	Item* ground = tile->getGround();
 	if (ground) {
-		msg.addItem(ground, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+		msg.addItem(ground, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 		count = 1;
 	} else {
 		count = 0;
@@ -1394,7 +1460,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 			if (!InstanceUtils::canSeeItemInInstance(playerInstanceId, it->get())) {
 				continue;
 			}
-			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 			count++;
 			if (count == 9 && tile->getPosition() == player->getPosition()) {
 				break;
@@ -1439,7 +1505,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 			if (!InstanceUtils::canSeeItemInInstance(playerInstanceId, it->get())) {
 				continue;
 			}
-			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 			if (++count == MAX_STACKPOS_THINGS) {
 				return;
 			}
@@ -1771,6 +1837,26 @@ void ProtocolGame::parseUseItem(NetworkMessage& msg)
 	uint8_t index = msg.getByte();
 	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
 		g_game.playerUseItem(playerID, pos, stackpos, index, spriteId);
+	});
+}
+
+void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
+{
+	if (!player || player->isAccountManager()) {
+		return;
+	}
+
+	uint16_t itemId = msg.get<uint16_t>();
+	uint8_t tier = 0;
+	bool hasTier = getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
+	               (useItemTierByte || (getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) &&
+	                                   Item::items[itemId].classification > 0));
+	if (hasTier) {
+		tier = msg.getByte();
+	}
+
+	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [playerID = player->getID(), itemId, hasTier, tier]() {
+		g_game.playerEquipItem(playerID, itemId, hasTier, tier);
 	});
 }
 
@@ -2594,7 +2680,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const bool sendQuickLootFlags = shouldSendQuickLootFlags();
 	const bool sendItemTierByte = shouldSendItemTierByte();
 	const bool sendItemTierData = shouldSendItemTierData();
-	msg.addItem(container, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+	msg.addItem(container, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 	msg.addString(container->getName());
 
 	msg.addByte(static_cast<uint8_t>(container->capacity()));
@@ -2607,7 +2693,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const ItemDeque& itemList = container->getItemList();
 	for (ItemDeque::const_iterator cit = itemList.begin() + firstIndex, end = itemList.end(); i < 0xFF && cit != end;
 	     ++cit, ++i) {
-		msg.addItem(cit->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+		msg.addItem(cit->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 	}
 	writeToOutputBuffer(msg);
 }
@@ -2781,11 +2867,11 @@ void ProtocolGame::sendTradeItemRequest(std::string_view traderName, const Item*
 
 		msg.addByte(itemList.size());
 		for (const Item* listItem : itemList) {
-			msg.addItem(listItem, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+			msg.addItem(listItem, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 		}
 	} else {
 		msg.addByte(0x01);
-		msg.addItem(item, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags);
+		msg.addItem(item, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, isAstraClient);
 	}
 	writeToOutputBuffer(msg);
 }
@@ -3125,7 +3211,8 @@ void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const
 	msg.addByte(0x6A);
 	msg.addPosition(pos);
 	msg.addByte(static_cast<uint8_t>(stackpos));
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+	            isAstraClient);
 	writeToOutputBuffer(msg);
 }
 
@@ -3143,7 +3230,8 @@ void ProtocolGame::sendUpdateTileItem(const Position& pos, uint32_t stackpos, co
 	msg.addByte(0x6B);
 	msg.addPosition(pos);
 	msg.addByte(static_cast<uint8_t>(stackpos));
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+	            isAstraClient);
 	writeToOutputBuffer(msg);
 }
 
@@ -3268,6 +3356,8 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	if (isOTC) {
 		sendInventoryItem(CONST_SLOT_STORE_INBOX, player->getStoreInbox());
 	}
+
+	sendPlayerInventory();
 
 	sendStats();
 	sendSkills();
@@ -3428,7 +3518,8 @@ void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
 	if (item) {
 		msg.addByte(0x78);
 		msg.addByte(slot);
-		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+		            isAstraClient);
 	} else {
 		msg.addByte(0x79);
 		msg.addByte(slot);
@@ -3438,6 +3529,46 @@ void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
 	if (imbuementTrackerOpen) {
 		sendImbuementDurations(slot, item);
 	}
+}
+
+void ProtocolGame::sendPlayerInventory()
+{
+	if (!player || !isAstraClient) {
+		return;
+	}
+
+	PlayerInventoryCounts counts;
+	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+		addPlayerInventoryItem(counts, player->getInventoryItem(static_cast<slots_t>(slot)));
+	}
+
+	NetworkMessage msg;
+	msg.addByte(0xF5);
+	constexpr std::size_t astraInventorySlotMarkers = 11;
+	const std::size_t totalItems = std::min<std::size_t>(
+	    counts.size() + astraInventorySlotMarkers, std::numeric_limits<uint16_t>::max());
+	msg.add<uint16_t>(static_cast<uint16_t>(totalItems));
+
+	std::size_t written = 0;
+	for (uint16_t slotMarker = 1; slotMarker <= astraInventorySlotMarkers && written < totalItems; ++slotMarker) {
+		msg.add<uint16_t>(slotMarker);
+		msg.addByte(0);
+		addPackedPlayerInventoryCount(msg, 1);
+		++written;
+	}
+
+	for (const auto& [key, amount] : counts) {
+		if (written >= totalItems) {
+			break;
+		}
+
+		msg.add<uint16_t>(key.first);
+		msg.addByte(key.second);
+		addPackedPlayerInventoryCount(msg, amount);
+		++written;
+	}
+
+	writeToOutputBuffer(msg);
 }
 
 void ProtocolGame::sendModalWindow(const ModalWindow& modalWindow)
@@ -3477,7 +3608,8 @@ void ProtocolGame::sendAddContainerItem(uint8_t cid, const Item* item)
 	NetworkMessage msg;
 	msg.addByte(0x70);
 	msg.addByte(cid);
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+	            isAstraClient);
 	writeToOutputBuffer(msg);
 }
 
@@ -3487,7 +3619,8 @@ void ProtocolGame::sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Ite
 	msg.addByte(0x71);
 	msg.addByte(cid);
 	msg.addByte(slot);
-	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+	            isAstraClient);
 	writeToOutputBuffer(msg);
 }
 
@@ -4357,6 +4490,9 @@ void ProtocolGame::sendFeatures()
 	if (isAstraClient) {
 		features[GameFeature::ExperienceBonus] = true;
 		features[GameFeature::PlayerFamiliars] = true;
+		features[GameFeature::DisplayItemDuration] = true;
+		features[GameFeature::DisplayItemCharges] = true;
+		features[GameFeature::PackedPlayerInventory] = true;
 	}
 	features[GameFeature::QuickLootFlags] = shouldSendQuickLootFlags();
 	features[GameFeature::ThingUpgradeClassification] = false;
@@ -4647,7 +4783,8 @@ void ProtocolGame::sendImbuementDurations(slots_t updatedSlot, const Item* updat
 		const Item* item = p.second;
 
 		msg.addByte(static_cast<uint8_t>(slot));
-		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+		            isAstraClient);
 
 		uint16_t totalSlots = item->getImbuementSlots();
 		msg.addByte(static_cast<uint8_t>(totalSlots));

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1192,7 +1192,11 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 			                     [playerID = player->getID()]() { g_game.playerTurn(playerID, DIRECTION_WEST); });
 			break;
 		case 0x77:
-			parseHotkeyEquip(msg);
+			if (isAstraClient) {
+				parseHotkeyEquip(msg);
+			} else {
+				skipUnreadBytes(msg);
+			}
 			break;
 		case 0x78:
 			parseThrow(msg);
@@ -1842,12 +1846,18 @@ void ProtocolGame::parseUseItem(NetworkMessage& msg)
 
 void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
 {
-	if (!player || player->isAccountManager()) {
+	if (!player || !isAstraClient || player->isAccountManager()) {
+		skipUnreadBytes(msg);
+		return;
+	}
+
+	if (!requireUnreadBytes(msg, 2)) {
 		return;
 	}
 
 	uint16_t itemId = msg.get<uint16_t>();
-	if (itemId == 0 || itemId >= Item::items.size()) {
+	if (itemId == 0 || itemId >= Item::items.size() || Item::items[itemId].id == 0) {
+		skipUnreadBytes(msg);
 		return;
 	}
 
@@ -1856,6 +1866,9 @@ void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
 	               (useItemTierByte || (getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) &&
 	                                   Item::items[itemId].classification > 0));
 	if (hasTier) {
+		if (!requireUnreadBytes(msg, 1)) {
+			return;
+		}
 		tier = msg.getByte();
 	}
 
@@ -3537,7 +3550,7 @@ void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
 
 void ProtocolGame::sendPlayerInventory()
 {
-	if (!player || !isAstraClient) {
+	if (!player || !isAstraClient || isSpectator) {
 		return;
 	}
 
@@ -3549,8 +3562,12 @@ void ProtocolGame::sendPlayerInventory()
 	NetworkMessage msg;
 	msg.addByte(0xF5);
 	constexpr std::size_t astraInventorySlotMarkers = 11;
-	const std::size_t totalItems = std::min<std::size_t>(
-	    counts.size() + astraInventorySlotMarkers, std::numeric_limits<uint16_t>::max());
+	const std::size_t inventoryEntries = counts.size() + astraInventorySlotMarkers;
+	if (inventoryEntries > std::numeric_limits<uint16_t>::max()) {
+		LOG_WARN("[AstraInventory] Inventory snapshot truncated for player {}", player->getName());
+	}
+
+	const std::size_t totalItems = std::min<std::size_t>(inventoryEntries, std::numeric_limits<uint16_t>::max());
 	msg.add<uint16_t>(static_cast<uint16_t>(totalItems));
 
 	std::size_t written = 0;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -74,7 +74,7 @@ void addPlayerInventoryItem(PlayerInventoryCounts& counts, const Item* item)
 	counts[key] += getPlayerInventoryItemAmount(item);
 
 	if (const Container* container = item->getContainer()) {
-		for (const auto& child : container->getItems(true)) {
+		for (const auto& child : container->getItems(false)) {
 			addPlayerInventoryItem(counts, child.get());
 		}
 	}
@@ -1847,6 +1847,10 @@ void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
 	}
 
 	uint16_t itemId = msg.get<uint16_t>();
+	if (itemId == 0 || itemId >= Item::items.size()) {
+		return;
+	}
+
 	uint8_t tier = 0;
 	bool hasTier = getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
 	               (useItemTierByte || (getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) &&

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -109,6 +109,7 @@ private:
 	void parseRuleViolationReport(NetworkMessage& msg);
 
 	void parseThrow(NetworkMessage& msg);
+	void parseHotkeyEquip(NetworkMessage& msg);
 	void parseUseItemEx(NetworkMessage& msg);
 	void parseUseWithCreature(NetworkMessage& msg);
 	void parseUseItem(NetworkMessage& msg);
@@ -250,6 +251,7 @@ private:
 
 	// inventory
 	void sendInventoryItem(slots_t slot, const Item* item);
+	void sendPlayerInventory();
 	void sendImbuementDurations(slots_t updatedSlot = CONST_SLOT_WHEREEVER, const Item* updatedItem = nullptr);
 
 	// messages


### PR DESCRIPTION
## Summary

Imports the final Raventhia inventory/protocol changes from the June 17-18 commit range into this codebase as a single focused import, then addresses the automated review findings from Gemini/Codex and Rabbit.

Changed import files:
- `src/const.h`
- `src/game.cpp`
- `src/game.h`
- `src/networkmessage.cpp`
- `src/networkmessage.h`
- `src/player.cpp`
- `src/player.h`
- `src/protocolgame.cpp`
- `src/protocolgame.h`

Client note added:
- `docs/astra-hotkey-equip-client-contract.md`

## Gemini/Codex checklist

- [x] Validate hotkey `itemId` before indexing `Item::items` in `Game::playerEquipItem`.
- [x] Validate hotkey `itemId` before indexing `Item::items` in `ProtocolGame::parseHotkeyEquip`.
- [x] Avoid duplicate nested inventory counting by using direct container children in `addPlayerInventoryItem`.
- [x] Remove redundant synchronous Astra inventory snapshot in `Player::onUpdateContainerItem` when `oldItem != newItem`.
- [x] Allow occupied-slot hotkey swaps to use the normal `internalMoveItem` exchange path.
- [x] Equip ammo into `CONST_SLOT_AMMO` when no quiver is equipped.
- [x] Pre-validate and rollback hand-clearing moves for two-handed hotkey equips so failed replacements do not leave the player unintentionally unequipped.
- [x] Fix CI build error by avoiding access to private `Player::hasCapacity` from `game.cpp`.

## Rabbit checklist

- [x] Keep PR unmerged until CI/build is green.
- [x] Restrict opcode `0x77` hotkey equip handling to authenticated Astra clients.
- [x] Skip unread bytes for non-Astra `0x77` payloads.
- [x] Harden `parseHotkeyEquip` with unread-byte checks before reading `itemId` and optional `tier`.
- [x] Reject invalid/unloaded `itemId` values before indexing item metadata.
- [x] Document the Astra client opcode `0x77` contract and the subtype/tier ambiguity.
- [x] Send a cancel message when a hotkey item is neither equipped nor found in the backpack.
- [x] Log when packed inventory snapshots are truncated to the `uint16_t` entry limit.
- [x] Prevent Astra spectator/cast sessions from receiving player inventory snapshot opcode `0xF5`.
- [x] Debounce Astra inventory snapshots by coalescing repeated inventory/container changes into one dispatcher-scheduled snapshot.
- [x] Reviewed Rabbit recursion-depth note; no server change added because container nesting is governed by engine invariants, and a defensive depth cap would risk silently truncating valid inventory snapshots.

## Notes

The import keeps the existing local protocol feature behavior and adds the Raventhia-side Astra inventory state, item duration/charges, and packed inventory support where applicable.

Conflicts were resolved in `src/const.h` and `src/protocolgame.cpp` by preserving local features while adding the new Raventhia feature flags and item serialization parameter.

## Validation

- `git diff --check` passed.
- `git diff --cached --check` passed before commits.
- Searched for conflict markers in edited files.
- CI build failure from private `Player::hasCapacity` access was fixed in `f52bd39e`.
- Full build was not run locally because `cmake` is not available in the local PATH.