### PR TITLE
Fix live item state updates after Lua attribute changes

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -704,6 +704,23 @@ void Container::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	}
 }
 
+void Container::refreshThing(Thing* thing)
+{
+	Item* item = thing ? thing->getItem() : nullptr;
+	if (!item) {
+		return;
+	}
+
+	const int32_t index = getThingIndex(thing);
+	if (index == -1) {
+		return;
+	}
+
+	if (getParent()) {
+		onUpdateContainerItem(index, item, item);
+	}
+}
+
 void Container::replaceThing(uint32_t index, Thing* thing)
 {
 	if (!thing) {

--- a/src/container.h
+++ b/src/container.h
@@ -111,6 +111,7 @@ public:
 	void addItemBack(Item* item);
 
 	void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override final;
+	void refreshThing(Thing* thing) override final;
 	void replaceThing(uint32_t index, Thing* thing) override final;
 
 	void removeThing(Thing* thing, uint32_t count) override final;

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -106,6 +106,12 @@ public:
 	virtual void updateThing(Thing* thing, uint16_t itemId, uint32_t count) = 0;
 
 	/**
+	 * Notify observers that an item's runtime state changed without changing its
+	 * id or subtype. Cylinders that expose items to clients override this.
+	 */
+	virtual void refreshThing(Thing*) {}
+
+	/**
 	 * Replace an object with a new
 	 * \param index is the position to change (inventory slot/container position)
 	 * \param thing is the object to update

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2564,10 +2564,10 @@ void Game::refreshItem(Item* item)
 		return;
 	}
 
-	// updateThing notifies the owning player/container or map spectators. It also
-	// serializes the current Astra item state, so direct Lua attribute updates are
-	// visible immediately instead of waiting for another inventory change or relog.
-	cylinder->updateThing(item, item->getID(), item->getSubType());
+	// Refreshing notifies the owning player/container or map spectators without
+	// writing the subtype back into the item. That preserves removed attributes
+	// such as charges while still serializing current Astra item state.
+	cylinder->refreshThing(item);
 }
 
 ReturnValue Game::internalTeleport(Thing* thing, const Position& newPos, bool pushMove /* = true*/,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2553,6 +2553,23 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 	return nullptr;
 }
 
+void Game::refreshItem(Item* item)
+{
+	if (!item || item->isRemoved()) {
+		return;
+	}
+
+	Cylinder* cylinder = item->getParent();
+	if (!cylinder || cylinder == VirtualCylinder::virtualCylinder || cylinder->getThingIndex(item) == -1) {
+		return;
+	}
+
+	// updateThing notifies the owning player/container or map spectators. It also
+	// serializes the current Astra item state, so direct Lua attribute updates are
+	// visible immediately instead of waiting for another inventory change or relog.
+	cylinder->updateThing(item, item->getID(), item->getSubType());
+}
+
 ReturnValue Game::internalTeleport(Thing* thing, const Position& newPos, bool pushMove /* = true*/,
                                    uint32_t flags /*= 0*/,
                                    MagicEffectClasses magicEffect /*= CONST_ME_TELEPORT*/)

--- a/src/game.h
+++ b/src/game.h
@@ -337,6 +337,12 @@ public:
 	Item* transformItem(Item* item, uint16_t newId, int32_t newCount = -1);
 
 	/**
+	 * Re-sends an item after one of its runtime attributes changes without a
+	 * transform (for example, charges or duration changed from Lua).
+	 */
+	void refreshItem(Item* item);
+
+	/**
 	 * Teleports an object to another position
 	 * \param thing is the object to teleport
 	 * \param newPos is the new position

--- a/src/luaitem.cpp
+++ b/src/luaitem.cpp
@@ -16,6 +16,12 @@ using namespace Lua;
 
 void refreshClientItemState(Item* item, itemAttrTypes attribute)
 {
+	if (!item) {
+		return;
+	}
+
+	// Decay state controls server-side scheduling; charges and duration are the
+	// mutable item state serialized for the client.
 	if (attribute == ITEM_ATTRIBUTE_CHARGES || attribute == ITEM_ATTRIBUTE_DURATION) {
 		g_game.refreshItem(item);
 	}

--- a/src/luaitem.cpp
+++ b/src/luaitem.cpp
@@ -14,6 +14,13 @@ extern Game g_game;
 namespace {
 using namespace Lua;
 
+void refreshClientItemState(Item* item, itemAttrTypes attribute)
+{
+	if (attribute == ITEM_ATTRIBUTE_CHARGES || attribute == ITEM_ATTRIBUTE_DURATION) {
+		g_game.refreshItem(item);
+	}
+}
+
 // Item
 int luaItemCreate(lua_State* L)
 {
@@ -532,6 +539,7 @@ int luaItemSetAttribute(lua_State* L)
 				item->setDecaying(DECAYING_PENDING);
 				item->setDuration(getInteger<int32_t>(L, 3));
 				g_game.startDecay(item);
+				refreshClientItemState(item, attribute);
 				pushBoolean(L, true);
 				return 1;
 			}
@@ -544,6 +552,7 @@ int luaItemSetAttribute(lua_State* L)
 		}
 
 		item->setIntAttr(attribute, getInteger<int64_t>(L, 3));
+		refreshClientItemState(item, attribute);
 		pushBoolean(L, true);
 	} else if (ItemAttributes::isStrAttrType(attribute)) {
 		item->setStrAttr(attribute, getString(L, 3));
@@ -580,6 +589,7 @@ int luaItemRemoveAttribute(lua_State* L)
 				g_game.stopDecay(item);
 			}
 			item->removeAttribute(attribute);
+			refreshClientItemState(item, attribute);
 		} else {
 			reportErrorFunc(L, "Attempt to erase protected key \"duration timestamp\"");
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4327,6 +4327,23 @@ void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	scheduleAstraPlayerInventorySnapshot();
 }
 
+void Player::refreshThing(Thing* thing)
+{
+	Item* item = thing ? thing->getItem() : nullptr;
+	if (!item) {
+		return;
+	}
+
+	const int32_t index = getThingIndex(thing);
+	if (index == -1) {
+		return;
+	}
+
+	sendInventoryItem(static_cast<slots_t>(index), item);
+	onUpdateInventoryItem(item, item);
+	scheduleAstraPlayerInventorySnapshot();
+}
+
 void Player::replaceThing(uint32_t index, Thing* thing)
 {
 	if (index > CONST_SLOT_LAST) {

--- a/src/player.h
+++ b/src/player.h
@@ -1578,6 +1578,7 @@ private:
 	void addThing(int32_t index, Thing* thing) override;
 
 	void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
+	void refreshThing(Thing* thing) override;
 	void replaceThing(uint32_t index, Thing* thing) override;
 
 	void removeThing(Thing* thing, uint32_t count) override;

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1093,6 +1093,21 @@ void Tile::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	onUpdateTileItem(item, oldType, item, newType);
 }
 
+void Tile::refreshThing(Thing* thing)
+{
+	Item* item = thing ? thing->getItem() : nullptr;
+	if (!item) {
+		return;
+	}
+
+	if (getThingIndex(thing) == -1) {
+		return;
+	}
+
+	const ItemType& itemType = Item::items[item->getID()];
+	onUpdateTileItem(item, itemType, item, itemType);
+}
+
 void Tile::replaceThing(uint32_t index, Thing* thing)
 {
 	int32_t pos = index;

--- a/src/tile.h
+++ b/src/tile.h
@@ -224,6 +224,7 @@ public:
 	void addThing(int32_t index, Thing* thing) override;
 
 	void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override final;
+	void refreshThing(Thing* thing) override final;
 	void replaceThing(uint32_t index, Thing* thing) override final;
 
 	void removeThing(Thing* thing, uint32_t count) override final;


### PR DESCRIPTION
## Summary

- Refresh an item through its owning cylinder after Lua changes its charges or duration.
- Reuse the normal item-update path so Astra serializes the current item state immediately.
- Cover both setting and removing those dynamic attributes.

## Root cause

`item:setAttribute()` changed the server-side value directly, but did not notify the item parent. Exercise weapons therefore kept their default client-side charge display until another inventory update or relog caused the item to be serialized again.

## Impact

Charge and duration values now update in real time for items in inventory, containers, and on the map. No AstraClient changes are required.

## Validation

- Reproduced and manually verified the training-weapon charge counter updates in real time.
- `git diff --check`
- Build intentionally left to the maintainer, as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Bug Fixes**
  * Corrigida sincronização de estado de itens com o cliente quando atributos como cargas e duração são alterados via scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->