### PR TITLE
Fix action bar, container counters and store animation support

### DIFF
--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -404,28 +404,16 @@ local function getItemTypeInfo(itemId)
 	return clientId, itemType:getName() or ""
 end
 
-local function getClientItemId(itemId)
-	local clientId = getItemTypeInfo(itemId)
-	return clientId
-end
-
-local function getItemName(itemId)
-	local _, name = getItemTypeInfo(itemId)
-	return name
-end
-
-local function resolveItemName(name, itemId)
-	name = tostring(name or "")
-	if name ~= "" then
-		return name
-	end
-	return getItemName(itemId)
-end
-
 local function makeItemThingValue(itemId, itemName)
+	local clientId, resolvedName = getItemTypeInfo(itemId)
+	itemName = tostring(itemName or "")
+	if itemName ~= "" then
+		resolvedName = itemName
+	end
+
 	return {
-		thingId = getClientItemId(itemId),
-		thingName = resolveItemName(itemName, itemId),
+		thingId = clientId,
+		thingName = resolvedName,
 	}
 end
 
@@ -439,19 +427,15 @@ local function makeItemThingValues(items)
 	return values
 end
 
-local function writeThingValues(out, values, itemValues)
+local function writeThingValues(out, values)
 	values = type(values) == "table" and values or {}
 	local count = math.min(#values, 0xFFFF)
 	writeU16(out, count)
 	for index = 1, count do
 		local value = values[index] or {}
-		local thingId = value.thingId
+		local thingId = tonumber(value.thingId) or 0
 		writeU16(out, thingId)
-		if itemValues then
-			writeString(out, resolveItemName(value.thingName, thingId))
-		else
-			writeString(out, value.thingName)
-		end
+		writeString(out, value.thingName)
 	end
 end
 
@@ -636,13 +620,16 @@ function BattlePassSystem.sendRewards(player)
 				out:addByte(math.min(#step.rewards, 0xFF))
 				for index = 1, math.min(#step.rewards, 0xFF) do
 					local reward = step.rewards[index]
-					local randomValuesAreItems = reward.rewardType == 2 or reward.rewardType == 4 or reward.rewardType == 12
-					local choosableValuesAreItems = reward.rewardType == 18
 					local randomValues = reward.randomValues
+					local choosableValues = reward.choosableValues
 					if reward.rewardType == 1 then
 						randomValues = {makeItemThingValue(reward.itemId, reward.itemName)}
+					elseif reward.rewardType == 2 or reward.rewardType == 4 or reward.rewardType == 12 then
+						randomValues = makeItemThingValues(reward.randomValues)
 					elseif reward.rewardType == 17 then
 						randomValues = makeItemThingValues(reward.items)
+					elseif reward.rewardType == 18 then
+						choosableValues = makeItemThingValues(reward.choosableValues)
 					end
 					writeU32(out, reward.rewardId)
 					out:addByte(clamp(reward.rewardType, 0, 0xFF))
@@ -654,8 +641,8 @@ function BattlePassSystem.sendRewards(player)
 					writeBool(out, reward.hasClaimedReward or reward.hasClamedReward)
 					writeU32(out, reward.durationTime)
 					out:addByte(clamp(reward.addons, 0, 0xFF))
-					writeThingValues(out, randomValues, randomValuesAreItems)
-					writeThingValues(out, reward.choosableValues, choosableValuesAreItems)
+					writeThingValues(out, randomValues)
+					writeThingValues(out, choosableValues)
 					writeOutfitGroups(out, reward.maleOutfit)
 					writeOutfitGroups(out, reward.femaleOutfit)
 					writeRewardItems(out, reward.items)

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -435,7 +435,7 @@ local function writeThingValues(out, values)
 		local value = values[index] or {}
 		local thingId = tonumber(value.thingId) or 0
 		writeU16(out, thingId)
-		writeString(out, value.thingName)
+		writeString(out, value.thingName or "")
 	end
 end
 

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -385,14 +385,73 @@ local function writeMissionList(out, missions)
 	end
 end
 
-local function writeThingValues(out, values)
+local function getItemTypeInfo(itemId)
+	itemId = tonumber(itemId) or 0
+	if itemId <= 0 then
+		return 0, ""
+	end
+
+	local itemType = ItemType(itemId)
+	if not itemType then
+		return itemId, ""
+	end
+
+	local clientId = tonumber(itemType:getClientId()) or 0
+	if clientId <= 0 then
+		clientId = itemId
+	end
+
+	return clientId, itemType:getName() or ""
+end
+
+local function getClientItemId(itemId)
+	local clientId = getItemTypeInfo(itemId)
+	return clientId
+end
+
+local function getItemName(itemId)
+	local _, name = getItemTypeInfo(itemId)
+	return name
+end
+
+local function resolveItemName(name, itemId)
+	name = tostring(name or "")
+	if name ~= "" then
+		return name
+	end
+	return getItemName(itemId)
+end
+
+local function makeItemThingValue(itemId, itemName)
+	return {
+		thingId = getClientItemId(itemId),
+		thingName = resolveItemName(itemName, itemId),
+	}
+end
+
+local function makeItemThingValues(items)
+	local values = {}
+	items = type(items) == "table" and items or {}
+	for index = 1, math.min(#items, 0xFFFF) do
+		local item = items[index] or {}
+		values[index] = makeItemThingValue(item.itemId or item.thingId, item.itemName or item.thingName)
+	end
+	return values
+end
+
+local function writeThingValues(out, values, itemValues)
 	values = type(values) == "table" and values or {}
 	local count = math.min(#values, 0xFFFF)
 	writeU16(out, count)
 	for index = 1, count do
 		local value = values[index] or {}
-		writeU16(out, value.thingId)
-		writeString(out, value.thingName)
+		local thingId = value.thingId
+		writeU16(out, thingId)
+		if itemValues then
+			writeString(out, resolveItemName(value.thingName, thingId))
+		else
+			writeString(out, value.thingName)
+		end
 	end
 end
 
@@ -577,6 +636,14 @@ function BattlePassSystem.sendRewards(player)
 				out:addByte(math.min(#step.rewards, 0xFF))
 				for index = 1, math.min(#step.rewards, 0xFF) do
 					local reward = step.rewards[index]
+					local randomValuesAreItems = reward.rewardType == 2 or reward.rewardType == 4 or reward.rewardType == 12
+					local choosableValuesAreItems = reward.rewardType == 18
+					local randomValues = reward.randomValues
+					if reward.rewardType == 1 then
+						randomValues = {makeItemThingValue(reward.itemId, reward.itemName)}
+					elseif reward.rewardType == 17 then
+						randomValues = makeItemThingValues(reward.items)
+					end
 					writeU32(out, reward.rewardId)
 					out:addByte(clamp(reward.rewardType, 0, 0xFF))
 					writeBool(out, reward.freeReward)
@@ -587,8 +654,8 @@ function BattlePassSystem.sendRewards(player)
 					writeBool(out, reward.hasClaimedReward or reward.hasClamedReward)
 					writeU32(out, reward.durationTime)
 					out:addByte(clamp(reward.addons, 0, 0xFF))
-					writeThingValues(out, reward.randomValues)
-					writeThingValues(out, reward.choosableValues)
+					writeThingValues(out, randomValues, randomValuesAreItems)
+					writeThingValues(out, reward.choosableValues, choosableValuesAreItems)
 					writeOutfitGroups(out, reward.maleOutfit)
 					writeOutfitGroups(out, reward.femaleOutfit)
 					writeRewardItems(out, reward.items)

--- a/src/const.h
+++ b/src/const.h
@@ -946,8 +946,9 @@ enum class GameFeature : uint8_t {
 	PlayerFamiliars = 138,
 	DisplayItemCharges = 139,
 	PackedPlayerInventory = 140,
+	AstraQuiverCountU16 = 141,
 
-	Last = 140
+	Last = 141
 };
 
 inline constexpr int32_t CHANNEL_GUILD = 0x00;

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -69,6 +69,10 @@ const std::unordered_map<std::string, ItemParseAttributes_t> ItemParseAttributes
     {"transformdeequipto", ITEM_PARSE_TRANSFORMDEEQUIPTO},
     {"duration", ITEM_PARSE_DURATION},
     {"showduration", ITEM_PARSE_SHOWDURATION},
+    {"wearout", ITEM_PARSE_WEAROUT},
+    {"clockexpire", ITEM_PARSE_CLOCKEXPIRE},
+    {"expire", ITEM_PARSE_EXPIRE},
+    {"expirestop", ITEM_PARSE_EXPIRESTOP},
     {"charges", ITEM_PARSE_CHARGES},
     {"showcharges", ITEM_PARSE_SHOWCHARGES},
     {"showattributes", ITEM_PARSE_SHOWATTRIBUTES},
@@ -1105,6 +1109,26 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 				case ITEM_PARSE_SHOWDURATION: {
 					it.showDuration = valueAttribute.as_bool();
+					break;
+				}
+
+				case ITEM_PARSE_WEAROUT: {
+					it.wearOut = valueAttribute.as_bool();
+					break;
+				}
+
+				case ITEM_PARSE_CLOCKEXPIRE: {
+					it.clockExpire = valueAttribute.as_bool();
+					break;
+				}
+
+				case ITEM_PARSE_EXPIRE: {
+					it.expire = valueAttribute.as_bool();
+					break;
+				}
+
+				case ITEM_PARSE_EXPIRESTOP: {
+					it.expireStop = valueAttribute.as_bool();
 					break;
 				}
 

--- a/src/items.h
+++ b/src/items.h
@@ -86,6 +86,10 @@ enum ItemParseAttributes_t
 	ITEM_PARSE_TRANSFORMDEEQUIPTO,
 	ITEM_PARSE_DURATION,
 	ITEM_PARSE_SHOWDURATION,
+	ITEM_PARSE_WEAROUT,
+	ITEM_PARSE_CLOCKEXPIRE,
+	ITEM_PARSE_EXPIRE,
+	ITEM_PARSE_EXPIRESTOP,
 	ITEM_PARSE_CHARGES,
 	ITEM_PARSE_SHOWCHARGES,
 	ITEM_PARSE_SHOWATTRIBUTES,
@@ -460,6 +464,10 @@ public:
 	bool ignoreBlocking = false;
 	bool allowPickupable = false;
 	bool showDuration = false;
+	bool wearOut = false;
+	bool clockExpire = false;
+	bool expire = false;
+	bool expireStop = false;
 	bool showCharges = false;
 	bool showAttributes = false;
 	bool replaceable = true;

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -106,12 +106,15 @@ void NetworkMessage::addItemId(uint16_t itemId)
 	add<uint16_t>(clientId);
 }
 
-void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alwaysSendTier, bool sendQuickLootFlags)
+void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alwaysSendTier, bool sendQuickLootFlags,
+                             bool sendAstraQuiverCountU16)
 {
 	addItemId(id);
 
 	const ItemType& it = Item::items[id];
-	if (it.stackable) {
+	if (sendAstraQuiverCountU16 && it.weaponType == WEAPON_QUIVER) {
+		add<uint16_t>(count);
+	} else if (it.stackable) {
 		addByte(count);
 	} else if (it.isSplash() || it.isFluidContainer()) {
 		addByte(fluidMap[count & 7]);
@@ -128,14 +131,19 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 }
 
 void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTier, bool sendQuiverCount,
-                             bool sendQuickLootFlags, bool sendAstraItemState)
+                             bool sendQuickLootFlags, bool sendAstraItemState, bool sendAstraQuiverCountU16)
 {
 	addItemId(item->getID());
 
 	const ItemType& it = Item::items[item->getID()];
-	if (sendQuiverCount && item->getWeaponType() == WEAPON_QUIVER) {
+	if ((sendQuiverCount || sendAstraQuiverCountU16) && item->getWeaponType() == WEAPON_QUIVER) {
 		const Container* quiver = item->getContainer();
-		addByte(static_cast<uint8_t>(std::min<uint32_t>(0xFF, quiver ? quiver->getAmmoCount() : 0)));
+		const uint32_t ammoCount = quiver ? quiver->getAmmoCount() : 0;
+		if (sendAstraQuiverCountU16) {
+			add<uint16_t>(static_cast<uint16_t>(std::min<uint32_t>(0xFFFF, ammoCount)));
+		} else {
+			addByte(static_cast<uint8_t>(std::min<uint32_t>(0xFF, ammoCount)));
+		}
 	} else if (it.stackable) {
 		addByte(static_cast<uint8_t>(std::min<uint16_t>(0xFF, item->getItemCount())));
 	} else if (it.isSplash() || it.isFluidContainer()) {
@@ -152,9 +160,8 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 	}
 
 	if (sendAstraItemState) {
-		const bool hasDuration = (it.showDuration || item->hasAttribute(ITEM_ATTRIBUTE_DURATION) ||
-		                          item->hasAttribute(ITEM_ATTRIBUTE_DURATION_TIMESTAMP)) &&
-		                         item->getDuration() > 0;
+		const bool hasVisualDuration = it.showDuration || it.wearOut || it.clockExpire || it.expire || it.expireStop;
+		const bool hasDuration = hasVisualDuration && item->getDuration() > 0;
 		addByte(hasDuration ? 1 : 0);
 		if (hasDuration) {
 			add<uint32_t>(static_cast<uint32_t>(std::max<int32_t>(0, item->getDuration()) / 1000));
@@ -164,7 +171,7 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 		uint32_t charges = 0;
 		if (it.charges != 0) {
 			charges = item->getSubType();
-		} else if (it.showCharges || item->hasAttribute(ITEM_ATTRIBUTE_CHARGES)) {
+		} else if (it.showCharges) {
 			charges = item->getCharges();
 		}
 

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -113,6 +113,7 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 
 	const ItemType& it = Item::items[id];
 	if (sendAstraQuiverCountU16 && it.weaponType == WEAPON_QUIVER) {
+		// This overload only has the caller-provided subtype/count; real quiver ammo count is sent by the Item* overload.
 		add<uint16_t>(count);
 	} else if (it.stackable) {
 		addByte(count);

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -123,9 +123,10 @@ public:
 	void addPosition(const Position& pos);
 	void addItemId(uint16_t itemId);
 	void addItem(uint16_t id, uint8_t count, bool sendTier = false, bool alwaysSendTier = false,
-	             bool sendQuickLootFlags = false);
+	             bool sendQuickLootFlags = false, bool sendAstraQuiverCountU16 = false);
 	void addItem(const Item* item, bool sendTier = false, bool alwaysSendTier = false, bool sendQuiverCount = false,
-	             bool sendQuickLootFlags = false, bool sendAstraItemState = false);
+	             bool sendQuickLootFlags = false, bool sendAstraItemState = false,
+	             bool sendAstraQuiverCountU16 = false);
 
 	MsgSize_t getLength() const { return info.length; }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -452,6 +452,11 @@ bool ProtocolGame::canSendAstraItemState() const
 	return ownerProtocol.get() == this;
 }
 
+bool ProtocolGame::shouldSendAstraQuiverCountU16() const
+{
+	return isAstraClient;
+}
+
 bool ProtocolGame::shouldSendItemTierByte() const
 {
 	return useItemTierByte && getBoolean(ConfigManager::ITEM_TIER_DISPLAY);
@@ -1468,10 +1473,12 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 	const bool sendItemTierByte = shouldSendItemTierByte();
 	const bool sendItemTierData = shouldSendItemTierData();
 	const bool sendAstraItemState = canSendAstraItemState();
+	const bool sendAstraQuiverCountU16 = shouldSendAstraQuiverCountU16();
 	int32_t count;
 	Item* ground = tile->getGround();
 	if (ground) {
-		msg.addItem(ground, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState);
+		msg.addItem(ground, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState,
+		            sendAstraQuiverCountU16);
 		count = 1;
 	} else {
 		count = 0;
@@ -1483,7 +1490,8 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 			if (!InstanceUtils::canSeeItemInInstance(playerInstanceId, it->get())) {
 				continue;
 			}
-			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState);
+			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState,
+			            sendAstraQuiverCountU16);
 			count++;
 			if (count == 9 && tile->getPosition() == player->getPosition()) {
 				break;
@@ -1528,7 +1536,8 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 			if (!InstanceUtils::canSeeItemInInstance(playerInstanceId, it->get())) {
 				continue;
 			}
-			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState);
+			msg.addItem(it->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState,
+			            sendAstraQuiverCountU16);
 			if (++count == MAX_STACKPOS_THINGS) {
 				return;
 			}
@@ -2722,7 +2731,9 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const bool sendItemTierByte = shouldSendItemTierByte();
 	const bool sendItemTierData = shouldSendItemTierData();
 	const bool sendAstraItemState = canSendAstraItemState();
-	msg.addItem(container, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState);
+	const bool sendAstraQuiverCountU16 = shouldSendAstraQuiverCountU16();
+	msg.addItem(container, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState,
+	            sendAstraQuiverCountU16);
 	msg.addString(container->getName());
 
 	msg.addByte(static_cast<uint8_t>(container->capacity()));
@@ -2735,7 +2746,8 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const ItemDeque& itemList = container->getItemList();
 	for (ItemDeque::const_iterator cit = itemList.begin() + firstIndex, end = itemList.end(); i < 0xFF && cit != end;
 	     ++cit, ++i) {
-		msg.addItem(cit->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState);
+		msg.addItem(cit->get(), sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState,
+		            sendAstraQuiverCountU16);
 	}
 	writeToOutputBuffer(msg);
 }
@@ -2909,12 +2921,15 @@ void ProtocolGame::sendTradeItemRequest(std::string_view traderName, const Item*
 
 		msg.addByte(itemList.size());
 		const bool sendAstraItemState = canSendAstraItemState();
+		const bool sendAstraQuiverCountU16 = shouldSendAstraQuiverCountU16();
 		for (const Item* listItem : itemList) {
-			msg.addItem(listItem, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState);
+			msg.addItem(listItem, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, sendAstraItemState,
+			            sendAstraQuiverCountU16);
 		}
 	} else {
 		msg.addByte(0x01);
-		msg.addItem(item, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, canSendAstraItemState());
+		msg.addItem(item, sendItemTierData, sendItemTierByte, isOTC, sendQuickLootFlags, canSendAstraItemState(),
+		            shouldSendAstraQuiverCountU16());
 	}
 	writeToOutputBuffer(msg);
 }
@@ -3255,7 +3270,7 @@ void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const
 	msg.addPosition(pos);
 	msg.addByte(static_cast<uint8_t>(stackpos));
 	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-	            canSendAstraItemState());
+	            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	writeToOutputBuffer(msg);
 }
 
@@ -3274,7 +3289,7 @@ void ProtocolGame::sendUpdateTileItem(const Position& pos, uint32_t stackpos, co
 	msg.addPosition(pos);
 	msg.addByte(static_cast<uint8_t>(stackpos));
 	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-	            canSendAstraItemState());
+	            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	writeToOutputBuffer(msg);
 }
 
@@ -3562,7 +3577,7 @@ void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
 		msg.addByte(0x78);
 		msg.addByte(slot);
 		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-		            canSendAstraItemState());
+		            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	} else {
 		msg.addByte(0x79);
 		msg.addByte(slot);
@@ -3656,7 +3671,7 @@ void ProtocolGame::sendAddContainerItem(uint8_t cid, const Item* item)
 	msg.addByte(0x70);
 	msg.addByte(cid);
 	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-	            canSendAstraItemState());
+	            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	writeToOutputBuffer(msg);
 }
 
@@ -3667,7 +3682,7 @@ void ProtocolGame::sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Ite
 	msg.addByte(cid);
 	msg.addByte(slot);
 	msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-	            canSendAstraItemState());
+	            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	writeToOutputBuffer(msg);
 }
 
@@ -3890,10 +3905,11 @@ void ProtocolGame::sendItemInspection(std::shared_ptr<Item> item, uint16_t itemI
 	msg.addByte(1);
 	msg.addString(item ? item->getName() : std::string_view(itemType.name));
 	if (item) {
-		msg.addItem(item.get(), shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags());
+		msg.addItem(item.get(), shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
+		            false, shouldSendAstraQuiverCountU16());
 	} else {
 		msg.addItem(itemId, itemCount, shouldSendItemTierData(), shouldSendItemTierByte(),
-		            shouldSendQuickLootFlags());
+		            shouldSendQuickLootFlags(), shouldSendAstraQuiverCountU16());
 	}
 	msg.addByte(0);
 
@@ -4537,6 +4553,7 @@ void ProtocolGame::sendFeatures()
 	if (isAstraClient) {
 		features[GameFeature::ExperienceBonus] = true;
 		features[GameFeature::PlayerFamiliars] = true;
+		features[GameFeature::AstraQuiverCountU16] = true;
 	}
 	if (canSendAstraItemState()) {
 		features[GameFeature::DisplayItemDuration] = true;
@@ -4833,7 +4850,7 @@ void ProtocolGame::sendImbuementDurations(slots_t updatedSlot, const Item* updat
 
 		msg.addByte(static_cast<uint8_t>(slot));
 		msg.addItem(item, shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-		            canSendAstraItemState());
+		            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 
 		uint16_t totalSlots = item->getImbuementSlots();
 		msg.addByte(static_cast<uint8_t>(totalSlots));

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -69,6 +69,7 @@ public:
 
 	uint16_t getVersion() const { return version; }
 	bool canSendAstraItemState() const;
+	bool shouldSendAstraQuiverCountU16() const;
 
 	static uint32_t spectatorId;
 	static std::set<std::string> spectatorNames;


### PR DESCRIPTION
## Summary

This PR includes server-side fixes and adjustments for TFS 1.8 related to Astra item handling, container counters, Battle Pass reward previews and client animation behavior support.

## Changes

- Added Astra feature negotiation for 16-bit quiver ammo counts so the client can render quiver/container counts without truncating to one byte.
- Fixed visual item duration serialization so Astra only receives duration state for items with explicit visual timer metadata.
- Fixed visual charges serialization so Astra only receives charge state for item types that expose visual charges/counts.
- Added parsing for item metadata flags used by Astra item timer semantics: `wearout`, `clockexpire`, `expire` and `expirestop`.
- Fixed Battle Pass reward item preview values to send client item ids and resolved item names for item-based rewards.

## Review follow-up

The reports generated by CoderabbitAI and Gemini were reviewed.

## Review fixes

- Reviewed all findings from:
  - `gemini.md`
  - `coderabbitai.md`
- Grouped duplicated or equivalent findings.
- Fixed the Battle Pass item reward value serialization so all item-based `randomValues` and `choosableValues` are normalized to client item ids and resolved names before `writeThingValues` writes the payload.
- Simplified `writeThingValues` so it no longer performs late server-id name lookups with values that may already be client ids.
- Normalized legacy `thingValues` without names by passing an empty string fallback to `writeString`.
- Removed the redundant `getClientItemId` helper by resolving client id and item name directly in `makeItemThingValue`.
- Documented the quiver count limitation of the `addItem(id, count)` overload while preserving the existing behavior and the real `Item*` quiver count path.
- Preserved the current TFS 1.8 behavior and avoided unnecessary refactors or behavior changes.
- Evaluated false positives and non-applicable suggestions before deciding not to change them.

## False positives / not changed

- The `addItem(uint16_t id, uint8_t count, ...)` overload was not widened or refactored because its historical contract only receives caller-provided subtype/count; the actual quiver ammo count is available and sent through the `Item*` overload.
- Duration/charges serialization and `AstraQuiverCountU16` enum numbering were left unchanged because the reports validated those changes and did not identify functional issues there.

## Notes

- The diff was reviewed to avoid including temporary files, logs, build outputs or unrelated changes.
- The Battle Pass fix is intentionally included in this PR per requested scope.
- Only TFS 1.8 server-side files were included.
- The review report files were intentionally excluded from the commit:
  - `gemini.md`
  - `coderabbitai.md`
- The local planning `.md` file created for this review was also excluded from the commit:
  - `review-reports-fix-plan.md`

## Validation

- Reviewed `git diff` and staged only the intended files.
- Confirmed the cached diff contains exactly the intended files for each commit.
- Confirmed `gemini.md`, `coderabbitai.md` and `review-reports-fix-plan.md` were not staged.
- Ran `git diff --check`.
- Ran `git diff --cached --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Melhorias no sistema de recompensas do battlepass com melhor serializa��o de dados
  * Suporte expandido para propriedades de expira��o e desgaste de itens
  * Otimiza��o na transmiss�o de informa��es de muni��o para armas especiais

* **Bug Fixes**
  * Corre��o na serializa��o de valores de recompensas do battlepass
  * Ajustes na detec��o de dura��o e propriedades de itens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->