### PR TITLE
Fix native Prey wildcard actions and time sync

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -512,7 +512,7 @@ startupDatabaseOptimization = false
 
 -- Logging
 -- logToFile: true = save logs to data/logs/server.log, false = console only (default: false)
-logToFile = false
+logToFile = true
 -- logLevel: trace, debug, info, warning, error, critical (default: info)
 logLevel = "info"
 -- Status Server Information
@@ -523,12 +523,12 @@ location = "Sweden"
 
 -- Server Statistics
 -- time in seconds: 30 = 30 seconds, 0 = disabled
-statsDumpInterval = 0
+statsDumpInterval = 10
 -- time in milliseconds: 50 = 0.05 sec, 0 = disabled
-statsSlowLogTime = 0
-slowTaskWarning = false
+statsSlowLogTime = 5
+slowTaskWarning = true
 -- time in milliseconds: 500 = 0.5 sec, 0 = disabled
-statsVerySlowLogTime = 0
+statsVerySlowLogTime = 25
 
 -- Admin Protocol
 adminPort = 7170

--- a/data/logs/.gitignore
+++ b/data/logs/.gitignore
@@ -2,3 +2,6 @@
 *
 # Except this file
 !.gitignore
+!stats/
+stats/*
+!stats/.gitkeep

--- a/data/scripts/creaturescripts/others/custom_bestiary.lua
+++ b/data/scripts/creaturescripts/others/custom_bestiary.lua
@@ -43,26 +43,20 @@ local function getBestiaryEntryForCreature(creature)
 	return nil, raceId
 end
 
-local function getBestiaryKillCounts(playerGuids, raceId)
-	local counts = {}
-	local ids = {}
-	for guid in pairs(playerGuids) do
-		ids[#ids + 1] = guid
-	end
-	if #ids == 0 then
-		return counts
+local function getBestiaryKillCount(playerGuid, raceId)
+	if CustomBestiary.getKillCount then
+		return CustomBestiary.getKillCount(playerGuid, raceId)
 	end
 
-	local inClause = table.concat(ids, ",")
-	local resultId = db.storeQuery("SELECT `player_id`, `kills` FROM `player_bestiary_kills` WHERE `player_id` IN (" ..
-		inClause .. ") AND `raceid` = " .. raceId)
-	if resultId ~= false then
-		repeat
-			counts[result.getDataInt(resultId, "player_id")] = result.getDataInt(resultId, "kills")
-		until not result.next(resultId)
-		result.free(resultId)
+	local resultId = db.storeQuery("SELECT `kills` FROM `player_bestiary_kills` WHERE `player_id` = " ..
+		playerGuid .. " AND `raceid` = " .. raceId)
+	if resultId == false then
+		return 0
 	end
-	return counts
+
+	local kills = result.getDataInt(resultId, "kills")
+	result.free(resultId)
+	return kills
 end
 
 local function addPlayerCharmPoints(playerGuid, points)
@@ -158,9 +152,8 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		return true
 	end
 
-	local killCounts = getBestiaryKillCounts(players, raceId)
 	for playerGuid, player in pairs(players) do
-		local oldKills = killCounts[playerGuid] or 0
+		local oldKills = getBestiaryKillCount(playerGuid, raceId)
 		local killsToAdd = 1
 		local doubleChance = TaskBoard and TaskBoard.getBountyTalismanBonus and
 			TaskBoard.getBountyTalismanBonus(player, raceId, 3) or 0
@@ -171,14 +164,19 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		local oldProgress = CustomBestiary.getProgress(entry, oldKills)
 		local newProgress = CustomBestiary.getProgress(entry, newKills)
 
-		db.query("INSERT INTO `player_bestiary_kills` (`player_id`, `raceid`, `kills`) VALUES (" ..
+		db.asyncQuery("INSERT INTO `player_bestiary_kills` (`player_id`, `raceid`, `kills`) VALUES (" ..
 			playerGuid .. ", " .. raceId .. ", " .. killsToAdd ..
 			") ON DUPLICATE KEY UPDATE `kills` = `kills` + " .. killsToAdd)
 
-		if CustomBestiary.invalidatePlayer then
+		if CustomBestiary.updateKillCache then
+			CustomBestiary.updateKillCache(playerGuid, raceId, killsToAdd)
+		elseif CustomBestiary.invalidatePlayer then
 			CustomBestiary.invalidatePlayer(playerGuid)
 		end
-		if CustomBestiary.sendTracker then
+
+		if CustomBestiary.sendTrackerIfTracked then
+			CustomBestiary.sendTrackerIfTracked(player, raceId)
+		elseif CustomBestiary.sendTracker then
 			CustomBestiary.sendTracker(player)
 		end
 		if oldKills < entry.toKill and newKills >= entry.toKill then

--- a/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
+++ b/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
@@ -8,6 +8,62 @@ local function formatHundredthsPercent(value)
 	return string.format("%.2f", (tonumber(value) or 0) / 100):gsub("0+$", ""):gsub("%.$", "")
 end
 
+local function addLootRecipient(recipients, player)
+	if player then
+		recipients[#recipients + 1] = player
+	end
+end
+
+local function getLootRecipients(player)
+	local recipients = {}
+	local party = player:getParty()
+	if party then
+		addLootRecipient(recipients, party:getLeader())
+		for _, member in ipairs(party:getMembers()) do
+			addLootRecipient(recipients, member)
+		end
+	else
+		addLootRecipient(recipients, player)
+	end
+	return recipients
+end
+
+local function sendUngroupedLootMessage(player, corpse, monsterName, preyLootText, bountyLootText, useColorized)
+	local recipients = getLootRecipients(player)
+	if #recipients == 0 then
+		return
+	end
+
+	local plainText = nil
+	local colorizedText = nil
+	local needColorized = false
+
+	if useColorized then
+		for _, recipient in ipairs(recipients) do
+			if recipient.isUsingAstraClient and recipient:isUsingAstraClient() then
+				needColorized = true
+				break
+			end
+		end
+	end
+
+	local function buildText(colorized)
+		return ("Loot of %s: %s%s%s."):format(
+			monsterName, corpse:getContentDescription(colorized), preyLootText, bountyLootText)
+	end
+
+	for _, recipient in ipairs(recipients) do
+		local wantsColorized = needColorized and recipient.isUsingAstraClient and recipient:isUsingAstraClient()
+		if wantsColorized then
+			colorizedText = colorizedText or buildText(true)
+			sendLootMessage(recipient, colorizedText)
+		else
+			plainText = plainText or buildText(false)
+			sendLootMessage(recipient, plainText)
+		end
+	end
+end
+
 -- Applies the player's drop bonus (equipped items) to the loot chance.
 -- Returns true if the item should be added, false otherwise.
 local function rollWithDropBonus(lootChance, player)
@@ -126,40 +182,7 @@ event.onDropLoot = function(self, corpse)
 				local bountyLootText = bountyLootBonus > 0 and
 					(" (Bounty More Loot +%s%%)"):format(formatHundredthsPercent(bountyLootBonus)) or ""
 				local useColorized = configManager.getBoolean(configKeys.COLORIZED_LOOT_VALUE)
-				local party = player:getParty()
-				if useColorized then
-					-- Per-receiver message: colorized for AstraClient, plain for others
-					local colorizedText = ("Loot of %s: %s%s%s."):format(mType:getNameDescription(),
-					                                                   corpse:getContentDescription(true),
-					                                                   preyLootText, bountyLootText)
-					local plainText = ("Loot of %s: %s%s%s."):format(mType:getNameDescription(),
-					                                               corpse:getContentDescription(false),
-					                                               preyLootText, bountyLootText)
-					if party then
-						local members = party:getMembers()
-						local leader = party:getLeader()
-						if leader then
-							local leaderText = (leader.isUsingAstraClient and leader:isUsingAstraClient()) and colorizedText or plainText
-							sendLootMessage(leader, leaderText)
-						end
-						for _, member in ipairs(members) do
-							local memberText = (member.isUsingAstraClient and member:isUsingAstraClient()) and colorizedText or plainText
-							sendLootMessage(member, memberText)
-						end
-					else
-						local playerText = (player.isUsingAstraClient and player:isUsingAstraClient()) and colorizedText or plainText
-						sendLootMessage(player, playerText)
-					end
-				else
-					local text = ("Loot of %s: %s%s%s."):format(mType:getNameDescription(),
-					                                          corpse:getContentDescription(false),
-					                                          preyLootText, bountyLootText)
-					if party then
-						party:broadcastPartyLoot(text)
-					else
-						sendLootMessage(player, text)
-					end
-				end
+				sendUngroupedLootMessage(player, corpse, mType:getNameDescription(), preyLootText, bountyLootText, useColorized)
 			end
 		end
 	else

--- a/data/scripts/eventcallbacks/player/default_onGainExperience.lua
+++ b/data/scripts/eventcallbacks/player/default_onGainExperience.lua
@@ -103,6 +103,25 @@ end
 
 expTrackerLogout:register()
 
+local function getKillText(monsters, totalCount)
+	local firstName
+	local monsterTypes = 0
+
+	for monsterName in pairs(monsters) do
+		firstName = firstName or monsterName
+		monsterTypes = monsterTypes + 1
+		if monsterTypes > 1 then
+			break
+		end
+	end
+
+	if monsterTypes == 1 then
+		return totalCount > 1 and (totalCount .. " " .. firstName .. "s") or firstName
+	end
+
+	return totalCount .. " creatures"
+end
+
 function message.onGainExperience(self, source, exp, rawExp, sendText)
 	if sendText and exp ~= 0 then
 		local monsterName = source and source:getName() or "Unknown"
@@ -116,46 +135,63 @@ function message.onGainExperience(self, source, exp, rawExp, sendText)
 			end
 		end
 
-		if not expTracker[playerGuid] then expTracker[playerGuid] = {} end
-		if not expTracker[playerGuid][monsterName] then expTracker[playerGuid][monsterName] = { totalExp = 0, count = 0, timer = 0, preyXpBonus = 0 } end
-
-		expTracker[playerGuid][monsterName].totalExp = expTracker[playerGuid][monsterName].totalExp + exp
-		expTracker[playerGuid][monsterName].count = expTracker[playerGuid][monsterName].count + 1
-		expTracker[playerGuid][monsterName].timer = os.time()
-		if preyXpBonus > 0 then
-			expTracker[playerGuid][monsterName].preyXpBonus = preyXpBonus
+		if not expTracker[playerGuid] then
+			expTracker[playerGuid] = { monsters = {}, eventId = nil }
 		end
 
-		addEvent(function()
+		local playerTracker = expTracker[playerGuid]
+		if not playerTracker.monsters[monsterName] then
+			playerTracker.monsters[monsterName] = { totalExp = 0, count = 0, preyXpBonus = 0 }
+		end
+
+		local trackerState = playerTracker.monsters[monsterName]
+		trackerState.totalExp = trackerState.totalExp + exp
+		trackerState.count = trackerState.count + 1
+		if preyXpBonus > 0 then
+			trackerState.preyXpBonus = preyXpBonus
+		end
+
+		if playerTracker.eventId then
+			return exp
+		end
+
+		playerTracker.eventId = addEvent(function()
+			local tracker = expTracker[playerGuid]
+			if tracker then
+				tracker.eventId = nil
+			end
+
 			local player = Player(playerId)
 			if not player then return end
-
-			local tracker = expTracker[playerGuid] and expTracker[playerGuid][monsterName]
 			if not tracker then return end
 
-			local expValue = math.floor(tracker.totalExp)
-			local count = tracker.count
+			local monsters = tracker.monsters
+			tracker.monsters = {}
+
+			local expValue = 0
+			local count = 0
+			local preyBonus = 0
+			for _, monsterTracker in pairs(monsters) do
+				expValue = expValue + (monsterTracker.totalExp or 0)
+				count = count + (monsterTracker.count or 0)
+				preyBonus = math.max(preyBonus, monsterTracker.preyXpBonus or 0)
+			end
+			expValue = math.floor(expValue)
 
 			if expValue > 0 then
 				local expString = getExperienceText(expValue)
 				local preySuffix = ""
-				if tracker.preyXpBonus and tracker.preyXpBonus > 0 then
-					preySuffix = string.format(" (Prey Bonus XP +%d%%)", tracker.preyXpBonus)
+				if preyBonus > 0 then
+					preySuffix = string.format(" (Prey Bonus XP +%d%%)", preyBonus)
 				end
 
-				local killText
-				if count > 1 then
-					killText = count .. " " .. monsterName .. "s"
-				else
-					killText = monsterName
-				end
-
+				local killText = getKillText(monsters, count)
 				local message = "You gained " .. expString .. " for killing " .. killText .. preySuffix .. "."
 
 				player:sendTextMessage(MESSAGE_STATUS_DEFAULT, message)
 
 				local playerInstanceId = player:getInstanceId()
-				local spectators = Game.getSpectators(player:getPosition(), false, true)
+				local spectators = Game.getSpectators(player:getPosition(), false, true, 8, 8, 6, 6)
 				local filtered = {}
 				for _, spectator in ipairs(spectators) do
 					if playerInstanceId == 0 or spectator:getInstanceId() == playerInstanceId then
@@ -171,10 +207,6 @@ function message.onGainExperience(self, source, exp, rawExp, sendText)
 					end
 				end
 			end
-
-			tracker.totalExp = 0
-			tracker.count = 0
-			tracker.preyXpBonus = 0
 		end, 50)
 	end
 	return exp

--- a/data/scripts/eventcallbacks/player/default_onGainExperience.lua
+++ b/data/scripts/eventcallbacks/player/default_onGainExperience.lua
@@ -116,7 +116,7 @@ local function getKillText(monsters, totalCount)
 	end
 
 	if monsterTypes == 1 then
-		return totalCount > 1 and (totalCount .. " " .. firstName .. "s") or firstName
+		return totalCount > 1 and (totalCount .. " creatures") or firstName
 	end
 
 	return totalCount .. " creatures"

--- a/data/scripts/lib/boss_cooldown.lua
+++ b/data/scripts/lib/boss_cooldown.lua
@@ -49,6 +49,9 @@ function Player:setBossCooldown(bossNameOrId, time)
 		return false
 	end
 	local result = kv:set(scope, time)
+	if BossCooldown and BossCooldown.rememberKey then
+		BossCooldown.rememberKey(self, scope, time)
+	end
 	if BossCooldown and BossCooldown.send then
 		BossCooldown.send(self)
 	end

--- a/data/scripts/network/boss_cooldown/bosscooldown.lua
+++ b/data/scripts/network/boss_cooldown/bosscooldown.lua
@@ -235,6 +235,9 @@ function BossCooldown.rememberKey(player, scope, cooldownEnd)
 
 	local raceId = tostring(scope):match("^boss%.cooldown%.(.+)$")
 	if not raceId then
+		if logger and logger.warn then
+			logger.warn("[BossCooldown] Invalid cooldown scope '%s' for player %s (guid %d); invalidating cache.", tostring(scope), player:getName(), player:getGuid())
+		end
 		playerCooldownKeyCache[player:getGuid()] = nil
 		return
 	end

--- a/data/scripts/network/boss_cooldown/bosscooldown.lua
+++ b/data/scripts/network/boss_cooldown/bosscooldown.lua
@@ -3,6 +3,14 @@
 -- Uses KV store (player:kv() -> boss.cooldown.<raceId>)
 
 local OPCODE_BOSS_COOLDOWN = 0x2C
+local PERIODIC_REFRESH_INTERVAL = 5 * 60 * 1000
+local PERIODIC_REFRESH_PLAYER_DELAY = 100
+
+BossCooldown = BossCooldown or {}
+
+local bossListCache
+local bossByRaceIdCache
+local playerCooldownKeyCache = {}
 
 local function supportsAstraClient(player)
 	return player and player.isUsingAstraClient and player:isUsingAstraClient()
@@ -26,19 +34,120 @@ local function getBossOutfit(lookType)
 	return {type = lookType, head = 0, body = 0, legs = 0, feet = 0, addons = 0}
 end
 
-local function getBossList()
+local function normalizeBossOutfit(entry)
+	if entry.outfit and entry.outfit.type then
+		return entry.outfit
+	end
+	return getBossOutfit(entry.outfit and entry.outfit.lookType or 136)
+end
+
+local function buildBossCache()
 	local bosses = {}
+	local bossesByRaceId = {}
 	if CustomBosstiary and CustomBosstiary.monstersByRaceId then
 		for raceId, entry in pairs(CustomBosstiary.monstersByRaceId) do
-			bosses[#bosses + 1] = {
+			local boss = {
 				raceId = raceId,
+				key = tostring(raceId),
 				name = entry.name,
-				outfit = entry.outfit or {},
+				outfit = normalizeBossOutfit(entry),
 			}
+			bosses[#bosses + 1] = boss
+			bossesByRaceId[raceId] = boss
 		end
 	end
 	table.sort(bosses, function(a, b) return a.raceId < b.raceId end)
-	return bosses
+	bossListCache = bosses
+	bossByRaceIdCache = bossesByRaceId
+end
+
+local function getBossList()
+	if not bossListCache then
+		buildBossCache()
+	end
+	return bossListCache
+end
+
+local function getBossByRaceId()
+	if not bossByRaceIdCache then
+		buildBossCache()
+	end
+	return bossByRaceIdCache
+end
+
+local function getCooldownKeys(cooldownKV)
+	local ok, keys = pcall(function()
+		return cooldownKV:keys()
+	end)
+	if ok and type(keys) == "table" then
+		return keys
+	end
+	return nil
+end
+
+local function getPlayerCooldownKeyCache(player, cooldownKV)
+	local guid = player:getGuid()
+	local cachedKeys = playerCooldownKeyCache[guid]
+	if cachedKeys then
+		return cachedKeys
+	end
+
+	local cooldownKeys = getCooldownKeys(cooldownKV)
+	if not cooldownKeys then
+		return nil
+	end
+
+	cachedKeys = {}
+	for _, key in ipairs(cooldownKeys) do
+		local raceId = tonumber(key)
+		if raceId then
+			cachedKeys[tostring(raceId)] = true
+		end
+	end
+	playerCooldownKeyCache[guid] = cachedKeys
+	return cachedKeys
+end
+
+local function appendActiveBoss(activeBosses, boss, cooldownEnd, now)
+	if not boss or not cooldownEnd or cooldownEnd <= now then
+		return
+	end
+
+	activeBosses[#activeBosses + 1] = {
+		id = boss.raceId,
+		cooldown = cooldownEnd,
+		name = boss.name,
+		outfit = boss.outfit,
+	}
+end
+
+local function getActiveBossCooldowns(player, cooldownKV)
+	local now = os.time()
+	local activeBosses = {}
+	local cooldownKeys = getPlayerCooldownKeyCache(player, cooldownKV)
+
+	if cooldownKeys then
+		local bossesByRaceId = getBossByRaceId()
+		for key in pairs(cooldownKeys) do
+			local raceId = tonumber(key)
+			local boss = raceId and bossesByRaceId[raceId]
+			if boss then
+				local cooldownEnd = cooldownKV:get(key) or 0
+				if cooldownEnd > now then
+					appendActiveBoss(activeBosses, boss, cooldownEnd, now)
+				else
+					cooldownKeys[key] = nil
+				end
+			end
+		end
+	else
+		for _, boss in ipairs(getBossList()) do
+			appendActiveBoss(activeBosses, boss, cooldownKV:get(boss.key) or 0, now)
+		end
+	end
+
+	table.sort(activeBosses, function(a, b) return a.id < b.id end)
+	return activeBosses
 end
 
 local function sendCooldowns(player)
@@ -47,34 +156,15 @@ local function sendCooldowns(player)
 	local kv = player:kv()
 	if not kv then return false end
 
-	local now = os.time()
 	local cooldownKV = kv:scoped("boss.cooldown")
-	local activeBosses = {}
-	local bosses = getBossList()
-
-	for _, boss in ipairs(bosses) do
-		local key = tostring(boss.raceId)
-		local cooldownEnd = cooldownKV:get(key) or 0
-		if cooldownEnd > now then
-			local outfit
-			if boss.outfit and boss.outfit.type then
-				outfit = boss.outfit
-			else
-				outfit = getBossOutfit(boss.outfit and boss.outfit.lookType or 136)
-			end
-			activeBosses[#activeBosses + 1] = {
-				id = boss.raceId,
-				cooldown = cooldownEnd,
-				name = boss.name,
-				outfit = outfit,
-			}
-		end
-	end
+	local activeBosses = getActiveBossCooldowns(player, cooldownKV)
 
 	local out = NetworkMessage(player)
 	out:addByte(OPCODE_BOSS_COOLDOWN)
-	out:addByte(math.min(#activeBosses, 255))
-	for _, boss in ipairs(activeBosses) do
+	local bossCount = math.min(#activeBosses, 255)
+	out:addByte(bossCount)
+	for i = 1, bossCount do
+		local boss = activeBosses[i]
 		out:addU16(boss.id)
 		out:addU32(boss.cooldown)
 		out:addString(boss.name)
@@ -88,28 +178,72 @@ local function sendCooldowns(player)
 	return out:sendToPlayer(player)
 end
 
+local function scheduleCooldownRefresh(playerId, delay)
+	addEvent(function(pid)
+		local player = Player(pid)
+		if player then
+			sendCooldowns(player)
+		end
+	end, delay, playerId)
+end
+
 -- Login event
 local bossLogin = CreatureEvent("BossCooldownLogin")
 function bossLogin.onLogin(player)
 	if not supportsAstraClient(player) then return true end
-	addEvent(function(pid)
-		local p = Player(pid)
-		if p then sendCooldowns(p) end
-	end, 3000, player:getId())
+	scheduleCooldownRefresh(player:getId(), 3000)
 	return true
 end
 bossLogin:register()
 
--- Periodic refresh every 30s
+local bossLogout = CreatureEvent("BossCooldownLogout")
+function bossLogout.onLogout(player)
+	playerCooldownKeyCache[player:getGuid()] = nil
+	return true
+end
+bossLogout:register()
+
+-- Lightweight safety refresh. Real updates are pushed by Player:setBossCooldown().
 local bossRefresh = GlobalEvent("BossCooldownPeriodic")
 function bossRefresh.onThink(interval)
+	local delay = 0
 	for _, player in ipairs(Game.getPlayers()) do
-		sendCooldowns(player)
+		if supportsAstraClient(player) then
+			scheduleCooldownRefresh(player:getId(), delay)
+			delay = delay + PERIODIC_REFRESH_PLAYER_DELAY
+		end
 	end
 	return true
 end
-bossRefresh:interval(30000)
+bossRefresh:interval(PERIODIC_REFRESH_INTERVAL)
 bossRefresh:register()
 
-BossCooldown = BossCooldown or {}
+function BossCooldown.invalidateCache()
+	bossListCache = nil
+	bossByRaceIdCache = nil
+end
+
+function BossCooldown.rememberKey(player, scope, cooldownEnd)
+	if not player or not scope then
+		return
+	end
+
+	local cachedKeys = playerCooldownKeyCache[player:getGuid()]
+	if not cachedKeys then
+		return
+	end
+
+	local raceId = tostring(scope):match("^boss%.cooldown%.(.+)$")
+	if not raceId then
+		playerCooldownKeyCache[player:getGuid()] = nil
+		return
+	end
+
+	if cooldownEnd and cooldownEnd > os.time() then
+		cachedKeys[tostring(raceId)] = true
+	else
+		cachedKeys[tostring(raceId)] = nil
+	end
+end
+
 BossCooldown.send = sendCooldowns

--- a/data/scripts/network/cyclopedia/ciclopedia.lua
+++ b/data/scripts/network/cyclopedia/ciclopedia.lua
@@ -216,6 +216,54 @@ rebuildEarnedPoints = function(playerGuid, kills)
 	finishedCache[playerGuid] = finished
 end
 
+local function updateKillCache(playerGuid, raceId, amount)
+	playerGuid = tonumber(playerGuid) or 0
+	raceId = tonumber(raceId) or 0
+	amount = tonumber(amount) or 0
+	if playerGuid <= 0 or raceId <= 0 or amount == 0 then
+		return false
+	end
+
+	local kills = killCache[playerGuid]
+	if not kills then
+		earnedPointsCache[playerGuid] = nil
+		finishedCache[playerGuid] = nil
+		return false
+	end
+
+	kills[raceId] = math.max(0, (kills[raceId] or 0) + amount)
+	rebuildEarnedPoints(playerGuid, kills)
+	return true
+end
+
+local function getKillCount(playerGuid, raceId)
+	playerGuid = tonumber(playerGuid) or 0
+	raceId = tonumber(raceId) or 0
+	if playerGuid <= 0 or raceId <= 0 then
+		return 0
+	end
+
+	local kills = loadKillMap(playerGuid)
+	return kills[raceId] or 0
+end
+
+local function preloadPlayer(playerGuid)
+	playerGuid = tonumber(playerGuid) or 0
+	if playerGuid <= 0 then
+		return false
+	end
+
+	loadKillMap(playerGuid)
+	loadTrackerList(playerGuid)
+	return true
+end
+
+if CustomBestiary then
+	CustomBestiary.updateKillCache = updateKillCache
+	CustomBestiary.getKillCount = getKillCount
+	CustomBestiary.preloadPlayer = preloadPlayer
+end
+
 local function getSpentCharmPoints(charms)
 	local spent = 0
 	for charmId, state in pairs(charms) do
@@ -559,7 +607,28 @@ local function sendTracker(player)
 	return out:sendToPlayer(player)
 end
 
+local function sendTrackerIfTracked(player, raceId)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
+	raceId = tonumber(raceId) or 0
+	if raceId <= 0 then
+		return false
+	end
+
+	local tracker = loadTrackerList(getPlayerGuid(player))
+	for _, trackedRaceId in ipairs(tracker) do
+		if trackedRaceId == raceId then
+			return sendTracker(player)
+		end
+	end
+
+	return false
+end
+
 CustomBestiary.sendTracker = sendTracker
+CustomBestiary.sendTrackerIfTracked = sendTrackerIfTracked
 CustomBestiary.sendProgress = sendBestiaryProgress
 
 local function toggleTracker(player, raceId)
@@ -767,6 +836,9 @@ bestiaryLogout:register()
 
 local bestiaryLogin = CreatureEvent("CustomBestiaryLogin")
 function bestiaryLogin.onLogin(player)
+	if CustomBestiary and CustomBestiary.preloadPlayer then
+		CustomBestiary.preloadPlayer(player:getGuid())
+	end
 	player:registerEvent("CustomBestiaryLogout")
 	return true
 end

--- a/data/scripts/network/prey_system/prey_monsters.lua
+++ b/data/scripts/network/prey_system/prey_monsters.lua
@@ -174,6 +174,7 @@ function PreyMonsters.generateList(playerLevel, excludeNames)
 end
 
 function PreyMonsters.getAllNames(playerLevel, excludeNames)
+	playerLevel = playerLevel or 0
 	excludeNames = excludeNames or {}
 	local excluded = {}
 	for _, name in ipairs(excludeNames) do

--- a/data/scripts/network/prey_system/prey_monsters.lua
+++ b/data/scripts/network/prey_system/prey_monsters.lua
@@ -172,3 +172,22 @@ function PreyMonsters.generateList(playerLevel, excludeNames)
 	end
 	return result
 end
+
+function PreyMonsters.getAllNames(playerLevel, excludeNames)
+	excludeNames = excludeNames or {}
+	local excluded = {}
+	for _, name in ipairs(excludeNames) do
+		excluded[name:lower()] = true
+	end
+
+	local eligible = {}
+	local seen = {}
+	for _, monster in ipairs(monsterPool) do
+		addCandidate(eligible, seen, excluded, monster, playerLevel, false, true)
+	end
+
+	table.sort(eligible, function(a, b)
+		return a:lower() < b:lower()
+	end)
+	return eligible
+end

--- a/data/scripts/network/prey_system/prey_system.lua
+++ b/data/scripts/network/prey_system/prey_system.lua
@@ -21,6 +21,7 @@ local PREY_OPCODE_CLEAR = 0xEC
 local PREY_OPCODE_TOGGLE_AUTO = 0xD8
 local PREY_OPCODE_TOGGLE_LOCK = 0xD9
 local PREY_OPCODE_RESOURCE_BALANCE = 0xEE
+local PREY_NATIVE_OPCODE_TIME_LEFT = 0xE7
 local PREY_NATIVE_OPCODE_REQUEST = 0xED
 local PREY_NATIVE_OPCODE_ACTION = 0xEB
 local PREY_NATIVE_OPCODE_DATA = 0xE8
@@ -31,12 +32,23 @@ local PREY_STATE_LIST_SELECTION = 1
 local PREY_STATE_BONUS_SELECTION = 2
 local PREY_STATE_ACTIVE = 3
 local PREY_STATE_INACTIVE = 4
+local PREY_STATE_WILDCARD_SELECTION = 5
 
 local PREY_NATIVE_STATE_LOCKED = 0
 local PREY_NATIVE_STATE_INACTIVE = 1
 local PREY_NATIVE_STATE_ACTIVE = 2
 local PREY_NATIVE_STATE_SELECTION = 3
+local PREY_NATIVE_STATE_WILDCARD = 5
 local PREY_NATIVE_UNLOCK_STORE = 1
+local PREY_NATIVE_BONUS_NONE = 4
+
+local PREY_NATIVE_ACTION_LIST_REROLL = 0
+local PREY_NATIVE_ACTION_BONUS_REROLL = 1
+local PREY_NATIVE_ACTION_MONSTER_SELECTION = 2
+local PREY_NATIVE_ACTION_REQUEST_ALL_MONSTERS = 3
+local PREY_NATIVE_ACTION_CHANGE_FROM_ALL = 4
+local PREY_NATIVE_ACTION_LOCK_PREY = 5
+local PREY_NATIVE_ACTION_UNLOCK_PERMANENT = 6
 
 local PREY_BONUS_NONE = 0
 local PREY_BONUS_DMG_BOOST = 1
@@ -465,6 +477,19 @@ local function getMonsterOutfit(name)
 	}
 end
 
+local function getMonsterRaceId(name)
+	local monsterType = name and name ~= "" and MonsterType(name)
+	if not monsterType then
+		return nil
+	end
+
+	local raceId = tonumber(monsterType:raceId()) or 0
+	if raceId <= 0 or raceId > 0xFFFF then
+		return nil
+	end
+	return raceId
+end
+
 local function writeMonster(out, name)
 	out:addString(name or "")
 
@@ -517,6 +542,27 @@ local function getTimeUntilFreeReroll(slotData)
 	return math.max(0, math.ceil(((slotData.reroll_at or 0) - os.time()) / 60))
 end
 
+local function getNativeBonusType(slotData)
+	if not slotData or slotData.bonus_type == PREY_BONUS_NONE then
+		return PREY_NATIVE_BONUS_NONE
+	end
+	return math.max(0, slotData.bonus_type - 1)
+end
+
+local function getNativeBonusValue(slotData)
+	if not slotData or slotData.bonus_type == PREY_BONUS_NONE then
+		return 0
+	end
+	return math.max(0, slotData.bonus_value or 0)
+end
+
+local function getNativeBonusGrade(slotData)
+	if not slotData or slotData.bonus_type == PREY_BONUS_NONE then
+		return 0
+	end
+	return math.max(1, math.min(10, math.ceil((slotData.bonus_value or 0) / 5)))
+end
+
 local function normalizeSlot(slotData)
 	if slotData.state == PREY_STATE_EMPTY then
 		slotData.state = PREY_STATE_LIST_SELECTION
@@ -532,6 +578,7 @@ local function normalizeSlot(slotData)
 end
 
 local getOtherSlotMonsters
+local buildWildcardRaceIds
 
 local function ensureSelectionList(player, slot, slotData)
 	if slotData.state ~= PREY_STATE_LIST_SELECTION then
@@ -568,12 +615,19 @@ local function writeSlot(out, player, slot, slotData)
 		for _, name in ipairs(list) do
 			writeMonster(out, name)
 		end
+	elseif slotData.state == PREY_STATE_WILDCARD_SELECTION then
+		out:addByte(PREY_NATIVE_STATE_WILDCARD)
+		local raceIds = buildWildcardRaceIds(player, getPlayerPrey(player), slot)
+		out:addU16(#raceIds)
+		for _, raceId in ipairs(raceIds) do
+			out:addU16(raceId)
+		end
 	elseif slotData.state == PREY_STATE_ACTIVE then
 		out:addByte(PREY_NATIVE_STATE_ACTIVE)
 		writeMonster(out, slotData.monster_name)
-		out:addByte(math.max(0, slotData.bonus_type - 1))
-		out:addU16(slotData.bonus_value)
-		out:addByte(math.max(1, math.min(10, math.ceil(slotData.bonus_value / 5))))
+		out:addByte(getNativeBonusType(slotData))
+		out:addU16(getNativeBonusValue(slotData))
+		out:addByte(getNativeBonusGrade(slotData))
 		out:addU16(slotData.time_left)
 	else
 		out:addByte(PREY_NATIVE_STATE_INACTIVE)
@@ -623,6 +677,18 @@ local function sendSlotUpdate(player, slot)
 	return sent
 end
 
+local function sendPreyTimeLeft(player, slot, timeLeft)
+	if not supportsCustomNetwork(player) then
+		return false
+	end
+
+	local out = NetworkMessage(player)
+	out:addByte(PREY_NATIVE_OPCODE_TIME_LEFT)
+	out:addByte(slot)
+	out:addU16(math.max(0, math.min(0xFFFF, timeLeft or 0)))
+	return out:sendToPlayer(player)
+end
+
 getOtherSlotMonsters = function(player, prey, excludedSlot)
 	local names = {}
 	for slot = 0, PREY_SLOTS - 1 do
@@ -637,6 +703,58 @@ getOtherSlotMonsters = function(player, prey, excludedSlot)
 		end
 	end
 	return names
+end
+
+local function isMonsterUsedByOtherSlot(player, prey, excludedSlot, monsterName)
+	local lowerName = (monsterName or ""):lower()
+	for slot = 0, PREY_SLOTS - 1 do
+		if slot ~= excludedSlot and isPreySlotUnlocked(player, slot) then
+			local slotData = prey.slots[slot]
+			if (slotData.monster_name or ""):lower() == lowerName then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+local function isWildcardRaceAvailable(player, prey, slot, raceId)
+	for _, availableRaceId in ipairs(buildWildcardRaceIds(player, prey, slot)) do
+		if availableRaceId == raceId then
+			return true
+		end
+	end
+	return false
+end
+
+local function getPreyMonsterNameByRaceId(raceId)
+	raceId = tonumber(raceId) or 0
+	if raceId <= 0 then
+		return nil
+	end
+
+	for _, name in ipairs(PreyMonsters.getAllNames()) do
+		if getMonsterRaceId(name) == raceId then
+			return name
+		end
+	end
+	return nil
+end
+
+buildWildcardRaceIds = function(player, prey, slot)
+	local raceIds = {}
+	local seen = {}
+	local names = PreyMonsters.getAllNames(player:getLevel())
+	for _, name in ipairs(names) do
+		local raceId = getMonsterRaceId(name)
+		if raceId and not seen[raceId] then
+			seen[raceId] = true
+			table.insert(raceIds, raceId)
+		end
+	end
+
+	table.sort(raceIds)
+	return raceIds
 end
 
 local function initializeSlot(player, slot)
@@ -921,6 +1039,8 @@ local function preyTick()
 								slotData.state = PREY_STATE_INACTIVE
 							end
 							sendSlotUpdate(player, slot)
+						else
+							sendPreyTimeLeft(player, slot, slotData.time_left)
 						end
 					end
 				end
@@ -1105,6 +1225,65 @@ local function nativeBonusReroll(player, slot)
 	sendPreyBalances(player)
 end
 
+local function nativeRequestAllMonsters(player, slot)
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
+	end
+
+	local prey = getPlayerPrey(player)
+	prey.wildcards = getPlayerBonusRerolls(player)
+	if prey.wildcards < PREY_LOCK_COST then
+		return sendError(player, "You do not have enough Prey Wildcards.")
+	end
+
+	local slotData = prey.slots[slot]
+	if #buildWildcardRaceIds(player, prey, slot) == 0 then
+		return sendError(player, "Could not build the Prey creature list.")
+	end
+
+	prey.wildcards = setPlayerBonusRerolls(player, prey.wildcards - PREY_LOCK_COST)
+	slotData.state = PREY_STATE_WILDCARD_SELECTION
+	slotData.monster_name = ""
+	slotData.list_monsters = {}
+	slotData.time_left = 0
+	sendSlotUpdate(player, slot)
+	sendPreyBalances(player)
+end
+
+local function nativeChangeFromAll(player, slot, raceId)
+	if not requirePreySlotUnlocked(player, slot) then
+		return false
+	end
+
+	local monsterName = getPreyMonsterNameByRaceId(raceId)
+	if not monsterName then
+		return sendError(player, "Invalid Prey creature.")
+	end
+
+	local prey = getPlayerPrey(player)
+	local slotData = prey.slots[slot]
+	if slotData.state ~= PREY_STATE_WILDCARD_SELECTION then
+		return sendError(player, "There is no active Prey creature list for this slot.")
+	end
+	if not isWildcardRaceAvailable(player, prey, slot, raceId) then
+		return sendError(player, "Invalid Prey creature.")
+	end
+	if isMonsterUsedByOtherSlot(player, prey, slot, monsterName) then
+		return sendError(player, "This creature is already used by another Prey slot.")
+	end
+
+	slotData.monster_name = monsterName
+	slotData.list_monsters = {}
+	if slotData.bonus_type == PREY_BONUS_NONE or (slotData.bonus_value or 0) <= 0 then
+		rerollBonus(slotData)
+	end
+	slotData.time_left = PREY_DURATION_SECS
+	slotData.state = PREY_STATE_ACTIVE
+	sendSlotUpdate(player, slot)
+	sendActiveBonusMessage(player, slotData)
+	sendPreyBalances(player)
+end
+
 local nativeRequestHandler = PacketHandler(PREY_NATIVE_OPCODE_REQUEST)
 function nativeRequestHandler.onReceive(player, msg)
 	initializeEmptySlots(player)
@@ -1164,23 +1343,30 @@ function nativeActionHandler.onReceive(player, msg)
 	if slot >= PREY_SLOTS then
 		return sendError(player, "Invalid slot.")
 	end
-	if action == 6 then
+	if action == PREY_NATIVE_ACTION_UNLOCK_PERMANENT then
 		return unlockPermanentPreySlot(player, slot)
 	end
 	if not requirePreySlotUnlocked(player, slot) then
 		return false
 	end
 
-	if action == 0 then
+	if action == PREY_NATIVE_ACTION_LIST_REROLL then
 		return nativeListReroll(player, slot)
-	elseif action == 1 then
+	elseif action == PREY_NATIVE_ACTION_BONUS_REROLL then
 		return nativeBonusReroll(player, slot)
-	elseif action == 2 then
+	elseif action == PREY_NATIVE_ACTION_MONSTER_SELECTION then
 		if msg:len() - msg:tell() < 1 then
 			return
 		end
 		return nativeSelectMonster(player, slot, msg:getByte())
-	elseif action == 5 then
+	elseif action == PREY_NATIVE_ACTION_REQUEST_ALL_MONSTERS then
+		return nativeRequestAllMonsters(player, slot)
+	elseif action == PREY_NATIVE_ACTION_CHANGE_FROM_ALL then
+		if msg:len() - msg:tell() < 2 then
+			return
+		end
+		return nativeChangeFromAll(player, slot, msg:getU16())
+	elseif action == PREY_NATIVE_ACTION_LOCK_PREY then
 		if msg:len() - msg:tell() < 1 then
 			return
 		end

--- a/data/scripts/network/prey_system/prey_system.lua
+++ b/data/scripts/network/prey_system/prey_system.lua
@@ -579,6 +579,7 @@ end
 
 local getOtherSlotMonsters
 local buildWildcardRaceIds
+local preyMonsterNamesByRaceId
 
 local function ensureSelectionList(player, slot, slotData)
 	if slotData.state ~= PREY_STATE_LIST_SELECTION then
@@ -733,18 +734,23 @@ local function getPreyMonsterNameByRaceId(raceId)
 		return nil
 	end
 
-	for _, name in ipairs(PreyMonsters.getAllNames()) do
-		if getMonsterRaceId(name) == raceId then
-			return name
+	if not preyMonsterNamesByRaceId then
+		preyMonsterNamesByRaceId = {}
+		for _, name in ipairs(PreyMonsters.getAllNames()) do
+			local monsterRaceId = getMonsterRaceId(name)
+			if monsterRaceId then
+				preyMonsterNamesByRaceId[monsterRaceId] = name
+			end
 		end
 	end
-	return nil
+
+	return preyMonsterNamesByRaceId[raceId]
 end
 
 buildWildcardRaceIds = function(player, prey, slot)
 	local raceIds = {}
 	local seen = {}
-	local names = PreyMonsters.getAllNames(player:getLevel())
+	local names = PreyMonsters.getAllNames(player:getLevel(), getOtherSlotMonsters(player, prey, slot))
 	for _, name in ipairs(names) do
 		local raceId = getMonsterRaceId(name)
 		if raceId and not seen[raceId] then
@@ -1231,12 +1237,16 @@ local function nativeRequestAllMonsters(player, slot)
 	end
 
 	local prey = getPlayerPrey(player)
+	local slotData = prey.slots[slot]
+	if slotData.state == PREY_STATE_WILDCARD_SELECTION then
+		return sendError(player, "You are already selecting a creature from the list.")
+	end
+
 	prey.wildcards = getPlayerBonusRerolls(player)
 	if prey.wildcards < PREY_LOCK_COST then
 		return sendError(player, "You do not have enough Prey Wildcards.")
 	end
 
-	local slotData = prey.slots[slot]
 	if #buildWildcardRaceIds(player, prey, slot) == 0 then
 		return sendError(player, "Could not build the Prey creature list.")
 	end

--- a/data/scripts/network/prey_system/prey_system.lua
+++ b/data/scripts/network/prey_system/prey_system.lua
@@ -595,7 +595,7 @@ local function ensureSelectionList(player, slot, slotData)
 	return true
 end
 
-local function writeSlot(out, player, slot, slotData)
+local function writeSlot(out, player, slot, slotData, wildcardRaceIds)
 	out:addByte(slot)
 	if not isPreySlotUnlocked(player, slot) then
 		out:addByte(PREY_NATIVE_STATE_LOCKED)
@@ -618,7 +618,7 @@ local function writeSlot(out, player, slot, slotData)
 		end
 	elseif slotData.state == PREY_STATE_WILDCARD_SELECTION then
 		out:addByte(PREY_NATIVE_STATE_WILDCARD)
-		local raceIds = buildWildcardRaceIds(player, getPlayerPrey(player), slot)
+		local raceIds = wildcardRaceIds or buildWildcardRaceIds(player, getPlayerPrey(player), slot)
 		out:addU16(#raceIds)
 		for _, raceId in ipairs(raceIds) do
 			out:addU16(raceId)
@@ -663,7 +663,7 @@ local function sendFullPrey(player, sendBalances)
 	return true
 end
 
-local function sendSlotUpdate(player, slot)
+local function sendSlotUpdate(player, slot, wildcardRaceIds)
 	if not supportsCustomNetwork(player) then
 		return false
 	end
@@ -671,7 +671,7 @@ local function sendSlotUpdate(player, slot)
 	local prey = getPlayerPrey(player)
 	local out = NetworkMessage(player)
 	out:addByte(PREY_NATIVE_OPCODE_DATA)
-	writeSlot(out, player, slot, prey.slots[slot])
+	writeSlot(out, player, slot, prey.slots[slot], wildcardRaceIds)
 	syncPreyCombatBonuses(player, prey)
 	local sent = out:sendToPlayer(player)
 	saveSlotToDB(player:getGuid(), slot, prey.slots[slot], prey.wildcards)
@@ -1247,7 +1247,8 @@ local function nativeRequestAllMonsters(player, slot)
 		return sendError(player, "You do not have enough Prey Wildcards.")
 	end
 
-	if #buildWildcardRaceIds(player, prey, slot) == 0 then
+	local raceIds = buildWildcardRaceIds(player, prey, slot)
+	if #raceIds == 0 then
 		return sendError(player, "Could not build the Prey creature list.")
 	end
 
@@ -1256,7 +1257,7 @@ local function nativeRequestAllMonsters(player, slot)
 	slotData.monster_name = ""
 	slotData.list_monsters = {}
 	slotData.time_left = 0
-	sendSlotUpdate(player, slot)
+	sendSlotUpdate(player, slot, raceIds)
 	sendPreyBalances(player)
 end
 

--- a/data/scripts/network/prey_system/prey_system.lua
+++ b/data/scripts/network/prey_system/prey_system.lua
@@ -39,6 +39,7 @@ local PREY_NATIVE_STATE_INACTIVE = 1
 local PREY_NATIVE_STATE_ACTIVE = 2
 local PREY_NATIVE_STATE_SELECTION = 3
 local PREY_NATIVE_STATE_WILDCARD = 5
+local PREY_NATIVE_STATE_WILDCARD_WITH_MONSTERS = 6
 local PREY_NATIVE_UNLOCK_STORE = 1
 local PREY_NATIVE_BONUS_NONE = 4
 
@@ -393,6 +394,22 @@ local function setStorageFlag(player, baseStorage, slot, enabled)
 	player:setStorageValue(baseStorage + slot, enabled and 1 or -1)
 end
 
+local function getPreyLockType(player, slot)
+	if getStorageFlag(player, PREY_STORAGE_AUTO_BONUS_BASE, slot) then
+		return 1
+	end
+	if getStorageFlag(player, PREY_STORAGE_LOCK_BASE, slot) then
+		return 2
+	end
+	return 0
+end
+
+local function writePreyLockType(out, player, slot)
+	if supportsAstraPreyExtension(player) then
+		out:addByte(getPreyLockType(player, slot))
+	end
+end
+
 local function sendResourceBalance(player, resourceType, value)
 	if not supportsCustomNetwork(player) then
 		return false
@@ -579,6 +596,7 @@ end
 
 local getOtherSlotMonsters
 local buildWildcardRaceIds
+local getPreyMonsterNameByRaceId
 local preyMonsterNamesByRaceId
 
 local function ensureSelectionList(player, slot, slotData)
@@ -601,6 +619,7 @@ local function writeSlot(out, player, slot, slotData, wildcardRaceIds)
 		out:addByte(PREY_NATIVE_STATE_LOCKED)
 		out:addByte(PREY_NATIVE_UNLOCK_STORE)
 		out:addU16(0)
+		writePreyLockType(out, player, slot)
 		if supportsAstraPreyExtension(player) then
 			out:addU32(PREY_PERMANENT_SLOT_COST)
 		end
@@ -617,11 +636,15 @@ local function writeSlot(out, player, slot, slotData, wildcardRaceIds)
 			writeMonster(out, name)
 		end
 	elseif slotData.state == PREY_STATE_WILDCARD_SELECTION then
-		out:addByte(PREY_NATIVE_STATE_WILDCARD)
+		local includeMonsterData = supportsAstraPreyExtension(player)
+		out:addByte(includeMonsterData and PREY_NATIVE_STATE_WILDCARD_WITH_MONSTERS or PREY_NATIVE_STATE_WILDCARD)
 		local raceIds = wildcardRaceIds or buildWildcardRaceIds(player, getPlayerPrey(player), slot)
 		out:addU16(#raceIds)
 		for _, raceId in ipairs(raceIds) do
 			out:addU16(raceId)
+			if includeMonsterData then
+				writeMonster(out, getPreyMonsterNameByRaceId(raceId))
+			end
 		end
 	elseif slotData.state == PREY_STATE_ACTIVE then
 		out:addByte(PREY_NATIVE_STATE_ACTIVE)
@@ -634,6 +657,7 @@ local function writeSlot(out, player, slot, slotData, wildcardRaceIds)
 		out:addByte(PREY_NATIVE_STATE_INACTIVE)
 	end
 	out:addU16(getTimeUntilFreeReroll(slotData))
+	writePreyLockType(out, player, slot)
 end
 
 local function sendPreyPrices(player)
@@ -728,7 +752,7 @@ local function isWildcardRaceAvailable(player, prey, slot, raceId)
 	return false
 end
 
-local function getPreyMonsterNameByRaceId(raceId)
+getPreyMonsterNameByRaceId = function(raceId)
 	raceId = tonumber(raceId) or 0
 	if raceId <= 0 then
 		return nil

--- a/data/scripts/network/quickloot.lua
+++ b/data/scripts/network/quickloot.lua
@@ -387,6 +387,14 @@ local function sendLootStats(player, itemId, count)
 	return msg:sendToPlayer(player)
 end
 
+local function getMaxQuickLootCorpses()
+	local maxCorpses = configManager.getNumber(configKeys.QUICK_LOOT_MAX_CORPSES)
+	if not maxCorpses or maxCorpses <= 0 then
+		return 30
+	end
+	return maxCorpses
+end
+
 local function findDestinationContainerCached(player, category, cache)
 	local containerId = getManagedContainer(player, category, true)
 
@@ -486,7 +494,20 @@ local function lootCorpse(player, corpse)
 	sendLootContainers(player)
 end
 
-local function findCorpsesOnTile(tile)
+local function canPlayerLootCorpse(player, corpse)
+	if not corpse then
+		return false
+	end
+
+	local owner = corpse:getCorpseOwner()
+	if owner == 0 then
+		return true
+	end
+
+	return owner == player:getId() or player:getAccountType() >= ACCOUNT_TYPE_GAMEMASTER
+end
+
+local function findCorpsesOnTile(tile, maxCorpses, player)
 	if not tile then
 		return {}
 	end
@@ -503,7 +524,12 @@ local function findCorpsesOnTile(tile)
 			if container then
 				local owner = container:getCorpseOwner()
 				if owner ~= 0 or item:getId() == ITEM_REWARD_CONTAINER then
-					table.insert(corpses, container)
+					if not player or canPlayerLootCorpse(player, container) then
+						table.insert(corpses, container)
+						if maxCorpses and #corpses >= maxCorpses then
+							break
+						end
+					end
 				end
 			end
 		end
@@ -512,25 +538,12 @@ local function findCorpsesOnTile(tile)
 	return corpses
 end
 
-local function canPlayerLootCorpse(player, corpse)
-	if not corpse then
-		return false
-	end
-
-	local owner = corpse:getCorpseOwner()
-	if owner == 0 then
-		return true
-	end
-
-	return owner == player:getId() or player:getAccountType() >= ACCOUNT_TYPE_GAMEMASTER
-end
-
 local function lootCorpsesOnTile(player, tile, maxCorpses)
 	if not tile then
 		return 0
 	end
 
-	local corpses = findCorpsesOnTile(tile)
+	local corpses = findCorpsesOnTile(tile, maxCorpses, player)
 	local lootedCount = 0
 
 	for _, corpse in ipairs(corpses) do
@@ -589,10 +602,6 @@ local function lootCorpseAuto(filterPlayer, destPlayer, corpse)
 		::continue::
 	end
 
-	if totalLooted > 0 then
-		sendLootContainers(destPlayer)
-	end
-
 	return totalLooted
 end
 
@@ -603,9 +612,13 @@ function killEvent.onKill(player, target)
 		return true
 	end
 
+	local settings = player:kv():scoped("settings")
+	if not settings:get("quickLoot") then
+		return true
+	end
+
 	local killerId = player:getId()
 	local targetPos = target:getPosition()
-	local targetName = target:getName()
 
 	addEvent(function()
 		local killer = Player(killerId)
@@ -616,8 +629,8 @@ function killEvent.onKill(player, target)
 			return
 		end
 
-		local settings = killer:kv():scoped("settings")
-		if not settings:get("quickLoot") then
+		local delayedSettings = killer:kv():scoped("settings")
+		if not delayedSettings:get("quickLoot") then
 			return
 		end
 
@@ -638,7 +651,8 @@ function killEvent.onKill(player, target)
 			end
 		end
 
-		local corpses = findCorpsesOnTile(tile)
+		local maxCorpses = getMaxQuickLootCorpses()
+		local corpses = findCorpsesOnTile(tile, maxCorpses, killer)
 		local totalLooted = 0
 
 		for _, corpse in ipairs(corpses) do
@@ -649,6 +663,7 @@ function killEvent.onKill(player, target)
 		end
 
 		if totalLooted > 0 then
+			sendLootContainers(recipient)
 			recipient:sendTextMessage(MESSAGE_STATUS_DEFAULT, "You looted " .. totalLooted .. " items via QuickLoot.")
 		end
 	end, 500)
@@ -666,10 +681,7 @@ function quickLootHandler.onReceive(player, msg)
 	local variant = msg:getByte()
 	local pos = msg:getPosition()
 
-	local maxCorpses = configManager.getNumber(configKeys.QUICK_LOOT_MAX_CORPSES)
-	if not maxCorpses or maxCorpses <= 0 then
-		maxCorpses = 30
-	end
+	local maxCorpses = getMaxQuickLootCorpses()
 
 	if variant == 2 then
 		-- Loot nearby (3x3 area)

--- a/data/scripts/network/quickloot.lua
+++ b/data/scripts/network/quickloot.lua
@@ -550,10 +550,8 @@ local function lootCorpsesOnTile(player, tile, maxCorpses)
 		if lootedCount >= maxCorpses then
 			break
 		end
-		if canPlayerLootCorpse(player, corpse) then
-			lootCorpse(player, corpse)
-			lootedCount = lootedCount + 1
-		end
+		lootCorpse(player, corpse)
+		lootedCount = lootedCount + 1
 	end
 
 	return lootedCount

--- a/data/scripts/network/task_board/bounty_tasks.lua
+++ b/data/scripts/network/task_board/bounty_tasks.lua
@@ -524,6 +524,14 @@ function BountyTasks.onLogin(player)
 	return true
 end
 
+function BountyTasks.preload(player)
+	if not player then
+		return false
+	end
+	loadBountyData(getPlayerGuid(player))
+	return true
+end
+
 function BountyTasks.changeDifficulty(player, difficulty)
 	if difficulty == nil or difficulty < 0 or difficulty > 3 then
 		return false

--- a/data/scripts/network/task_board/creature_events.lua
+++ b/data/scripts/network/task_board/creature_events.lua
@@ -99,6 +99,13 @@ function taskBoardLogin.onLogin(player)
 		end
 	end
 
+	if bountyEnabled then
+		local bounty = getBountyModule()
+		if bounty and bounty.preload then
+			bounty.preload(player)
+		end
+	end
+
 	-- Send 0xBA and every 0xBB slot in the same login flow. Do not defer this
 	-- path: the Astra Hunting Task UI may be opened right after login.
 	local taskHunting = getTaskHuntingModule()

--- a/src/kv/kv.cpp
+++ b/src/kv/kv.cpp
@@ -237,7 +237,7 @@ std::vector<std::string> KVStore::loadPrefix(const std::string &prefix) {
 	}
 
 	std::string keySearch = db.escapeString(escaped + "%");
-	const auto query = fmt::format("SELECT `key_name` FROM `kv_store` WHERE `key_name` LIKE {} ESCAPE '\\'", keySearch);
+	const auto query = fmt::format("SELECT `key_name` FROM `kv_store` WHERE `key_name` LIKE {} ESCAPE '\\\\'", keySearch);
 	const auto result = db.storeQuery(query);
 	if (result == nullptr) {
 		return keys;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -29,6 +29,7 @@
 #include "stress_test.h"
 #include "teleport.h"
 #include "logger.h"
+#include "tasks.h"
 #include <fmt/format.h>
 #include "globalevent.h"
 
@@ -809,14 +810,27 @@ int LuaScriptInterface::luaErrorHandler(lua_State* L)
 
 bool LuaScriptInterface::callFunction(int params)
 {
-#ifdef STATS_ENABLED
 	int32_t scriptId;
 	int32_t callbackId;
 	bool timerEvent;
 	LuaScriptInterface* scriptInterface;
 	getScriptEnv()->getEventInfo(scriptId, scriptInterface, callbackId, timerEvent);
-	std::chrono::steady_clock::time_point time_point = std::chrono::steady_clock::now();
+	(void)callbackId;
+	(void)timerEvent;
+	const bool slowTaskWarning = getBoolean(ConfigManager::SLOW_TASK_WARNING);
+	uint64_t slowThresholdNs = SLOW_TASK_THRESHOLD_NS;
+	if (slowTaskWarning) {
+		const int64_t reactorBudgetMs = getInteger(ConfigManager::REACTOR_TIME_BUDGET_MS);
+		if (reactorBudgetMs > 0) {
+			slowThresholdNs = static_cast<uint64_t>(reactorBudgetMs) * 1'000'000;
+		}
+	}
+#ifdef STATS_ENABLED
+	const bool shouldMeasure = true;
+#else
+	const bool shouldMeasure = slowTaskWarning;
 #endif
+	const auto time_point = shouldMeasure ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 
 	bool result = false;
 	int size = lua_gettop(luaState);
@@ -832,10 +846,21 @@ bool LuaScriptInterface::callFunction(int params)
 		lua_settop(luaState, size - params - 1);
 	}
 
+	if (shouldMeasure) {
+		const uint64_t ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+		    std::chrono::steady_clock::now() - time_point).count();
+		if (slowTaskWarning && ns > slowThresholdNs) {
+			const auto& scriptFile = scriptInterface ? scriptInterface->getFileByIdForStats(scriptId) :
+			                                           getFileByIdForStats(scriptId);
+			LOG_WARN(">> Slow Lua callback detected: {}ms [{}]",
+			         ns / 1'000'000, scriptFile);
+		}
 #ifdef STATS_ENABLED
-	uint64_t ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - time_point).count();
-	g_stats.addLuaStats(std::make_unique<Stat>(ns, getFileByIdForStats(scriptId), ""));
+		const auto& scriptFile = scriptInterface ? scriptInterface->getFileByIdForStats(scriptId) :
+		                                           getFileByIdForStats(scriptId);
+		g_stats.addLuaStats(std::make_unique<Stat>(ns, scriptFile, ""));
 #endif
+	}
 
 	resetScriptEnv();
 	return result;
@@ -843,6 +868,28 @@ bool LuaScriptInterface::callFunction(int params)
 
 void LuaScriptInterface::callVoidFunction(int params)
 {
+	int32_t scriptId;
+	int32_t callbackId;
+	bool timerEvent;
+	LuaScriptInterface* scriptInterface;
+	getScriptEnv()->getEventInfo(scriptId, scriptInterface, callbackId, timerEvent);
+	(void)callbackId;
+	(void)timerEvent;
+	const bool slowTaskWarning = getBoolean(ConfigManager::SLOW_TASK_WARNING);
+	uint64_t slowThresholdNs = SLOW_TASK_THRESHOLD_NS;
+	if (slowTaskWarning) {
+		const int64_t reactorBudgetMs = getInteger(ConfigManager::REACTOR_TIME_BUDGET_MS);
+		if (reactorBudgetMs > 0) {
+			slowThresholdNs = static_cast<uint64_t>(reactorBudgetMs) * 1'000'000;
+		}
+	}
+#ifdef STATS_ENABLED
+	const bool shouldMeasure = true;
+#else
+	const bool shouldMeasure = slowTaskWarning;
+#endif
+	const auto time_point = shouldMeasure ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
+
 	int size = lua_gettop(luaState);
 	if (protectedCall(luaState, params, 0) != 0) {
 		LuaScriptInterface::reportError(nullptr, Lua::popString(luaState));
@@ -851,6 +898,22 @@ void LuaScriptInterface::callVoidFunction(int params)
 	if ((lua_gettop(luaState) + params + 1) != size) {
 		LuaScriptInterface::reportError(nullptr, "Stack size changed!");
 		lua_settop(luaState, size - params - 1);
+	}
+
+	if (shouldMeasure) {
+		const uint64_t ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+		    std::chrono::steady_clock::now() - time_point).count();
+		if (slowTaskWarning && ns > slowThresholdNs) {
+			const auto& scriptFile = scriptInterface ? scriptInterface->getFileByIdForStats(scriptId) :
+			                                           getFileByIdForStats(scriptId);
+			LOG_WARN(">> Slow Lua callback detected: {}ms [{}]",
+			         ns / 1'000'000, scriptFile);
+		}
+#ifdef STATS_ENABLED
+		const auto& scriptFile = scriptInterface ? scriptInterface->getFileByIdForStats(scriptId) :
+		                                           getFileByIdForStats(scriptId);
+		g_stats.addLuaStats(std::make_unique<Stat>(ns, scriptFile, ""));
+#endif
 	}
 
 	resetScriptEnv();
@@ -2941,6 +3004,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::EXP_SHARE_FLOORS);
 	registerEnumIn("configKeys", ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE);
 	registerEnumIn("configKeys", ConfigManager::MAX_PACKETS_PER_SECOND);
+	registerEnumIn("configKeys", ConfigManager::QUICK_LOOT_MAX_CORPSES);
 	registerEnumIn("configKeys", ConfigManager::STAMINA_REGEN_MINUTE);
 	registerEnumIn("configKeys", ConfigManager::STAMINA_REGEN_PREMIUM);
 	registerEnumIn("configKeys", ConfigManager::STAMINA_TRAINER);

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -86,22 +86,32 @@ void Dispatcher::executeTask(std::unique_ptr<Task> task)
 
 	UPDATE_OTSYS_TIME();
 
-#if defined(STATS_ENABLED) || defined(SLOW_TASK_DETECTION)
-	const auto taskStart = std::chrono::steady_clock::now();
+	const bool slowTaskWarning = getBoolean(ConfigManager::SLOW_TASK_WARNING);
+	uint64_t slowThresholdNs = SLOW_TASK_THRESHOLD_NS;
+	if (slowTaskWarning) {
+		const int64_t reactorBudgetMs = getInteger(ConfigManager::REACTOR_TIME_BUDGET_MS);
+		if (reactorBudgetMs > 0) {
+			slowThresholdNs = static_cast<uint64_t>(reactorBudgetMs) * 1'000'000;
+		}
+	}
+#ifdef STATS_ENABLED
+	const bool shouldMeasure = true;
+#else
+	const bool shouldMeasure = slowTaskWarning;
 #endif
+	const auto taskStart = shouldMeasure ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
 
 	dispatcherCycle.fetch_add(1, std::memory_order_relaxed);
 	totalTasksProcessed.fetch_add(1, std::memory_order_relaxed);
 	(*task)();
 
-#ifdef SLOW_TASK_DETECTION
-	const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
-	    std::chrono::steady_clock::now() - taskStart).count();
-	const uint64_t elapsedNs = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
+	if (shouldMeasure) {
+		const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+		    std::chrono::steady_clock::now() - taskStart).count();
+		const uint64_t elapsedNs = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
 
-	if (elapsedNs > SLOW_TASK_THRESHOLD_NS && !task->skipSlowDetection) {
-		slowTaskCount.fetch_add(1, std::memory_order_relaxed);
-		if (getBoolean(ConfigManager::SLOW_TASK_WARNING)) {
+		if (slowTaskWarning && elapsedNs > slowThresholdNs && !task->skipSlowDetection) {
+			slowTaskCount.fetch_add(1, std::memory_order_relaxed);
 			const auto elapsedMs = elapsedNs / 1'000'000;
 			if (!task->description.empty()) {
 				LOG_WARN(">> Slow task detected: {}ms [{}] {}", elapsedMs, task->description, task->extraDescription);
@@ -109,15 +119,11 @@ void Dispatcher::executeTask(std::unique_ptr<Task> task)
 				LOG_WARN(">> Slow task detected: {}ms [unknown]", elapsedMs);
 			}
 		}
-	}
-#endif
 
 #ifdef STATS_ENABLED
-	if (g_stats.isEnabled() && g_stats.isRunning() && task->trackInStats) {
-		const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
-		    std::chrono::steady_clock::now() - taskStart).count();
-		const uint64_t executionTime = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
-		g_stats.addDispatcherStat(0, std::make_unique<Stat>(executionTime, task->description, task->extraDescription));
-	}
+		if (g_stats.isEnabled() && g_stats.isRunning() && task->trackInStats) {
+			g_stats.addDispatcherStat(0, std::make_unique<Stat>(elapsedNs, task->description, task->extraDescription));
+		}
 #endif
+	}
 }


### PR DESCRIPTION
## Summary
- Support Astra native Prey actions 3/4 for the 5-card choose-from-all creature flow.
- Consume the 5 Prey Wildcards when opening the full creature list, then require that pending state before accepting the selected raceId.
- Send lightweight Prey time-left packets during combat ticks instead of full slot syncs, so tracker timers update without heavy kill/task refreshes.

## Validation
- `npx --yes luaparse data/scripts/network/prey_system/prey_system.lua > $null`
- `npx --yes luaparse data/scripts/network/prey_system/prey_monsters.lua > $null`
- `git diff --cached --check`

No compile run here; Mateus compiles locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced wildcard creature selection in the Prey System, including expanded client list selection support.
  * Added more frequent “time left” updates for active prey bonuses.
  * Extended tracker/bestiary support with improved preloading and on-demand tracker delivery.
  * Added bounty task preloading to reduce login-time delays.

* **Bug Fixes**
  * Improved bestiary kill-count handling to use more reliable per-race tracking.
  * Refined ungrouped loot messaging so recipients receive the correct message format.

* **Chores**
  * Enabled enhanced logging and runtime statistics/slow-task diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->