### PR TITLE
[codex] Send Astra item equip metadata

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -948,8 +948,9 @@ enum class GameFeature : uint8_t {
 	PackedPlayerInventory = 140,
 	AstraQuiverCountU16 = 141,
 	AstraOutfitStoreMode = 142,
+	AstraItemMetadata = 143,
 
-	Last = 142
+	Last = 143
 };
 
 inline constexpr int32_t CHANNEL_GUILD = 0x00;

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -106,6 +106,25 @@ void NetworkMessage::addItemId(uint16_t itemId)
 	add<uint16_t>(clientId);
 }
 
+namespace {
+
+constexpr uint8_t AstraItemFlagEquipable = 1 << 0;
+constexpr uint8_t AstraItemFlagAmmo = 1 << 1;
+
+uint8_t getAstraItemMetadataFlags(const ItemType& it)
+{
+	uint8_t flags = 0;
+	if (it.weaponType == WEAPON_AMMO) {
+		flags |= AstraItemFlagAmmo;
+	}
+	if (it.weaponType != WEAPON_NONE || it.slotPosition != SLOTP_HAND) {
+		flags |= AstraItemFlagEquipable;
+	}
+	return flags;
+}
+
+} // namespace
+
 void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alwaysSendTier, bool sendQuickLootFlags,
                              bool sendAstraQuiverCountU16)
 {
@@ -181,6 +200,9 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 			add<uint32_t>(charges);
 			addByte((it.charges != 0 && charges == it.charges) ? 1 : 0);
 		}
+
+		add<uint16_t>(it.slotPosition);
+		addByte(getAstraItemMetadataFlags(it));
 	}
 }
 

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -111,22 +111,37 @@ namespace {
 constexpr uint8_t AstraItemFlagEquipable = 1 << 0;
 constexpr uint8_t AstraItemFlagAmmo = 1 << 1;
 
+bool isAstraItemMetadataEquipable(const ItemType& it)
+{
+	return it.weaponType != WEAPON_NONE || it.ammoType != AMMO_NONE || it.attack != 0 || it.defense != 0 ||
+	       it.extraDefense != 0 || it.armor != 0 || (it.slotPosition & SLOTP_NECKLACE) != 0 ||
+	       (it.slotPosition & SLOTP_RING) != 0 || (it.slotPosition & SLOTP_AMMO) != 0 ||
+	       (it.slotPosition & SLOTP_FEET) != 0 || (it.slotPosition & SLOTP_HEAD) != 0 ||
+	       (it.slotPosition & SLOTP_ARMOR) != 0 || (it.slotPosition & SLOTP_LEGS) != 0;
+}
+
 uint8_t getAstraItemMetadataFlags(const ItemType& it)
 {
 	uint8_t flags = 0;
 	if (it.weaponType == WEAPON_AMMO) {
 		flags |= AstraItemFlagAmmo;
 	}
-	if (it.weaponType != WEAPON_NONE || it.slotPosition != SLOTP_HAND) {
+	if (isAstraItemMetadataEquipable(it)) {
 		flags |= AstraItemFlagEquipable;
 	}
 	return flags;
 }
 
+void addAstraItemMetadata(NetworkMessage& msg, const ItemType& it)
+{
+	msg.add<uint16_t>(it.slotPosition);
+	msg.addByte(getAstraItemMetadataFlags(it));
+}
+
 } // namespace
 
 void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alwaysSendTier, bool sendQuickLootFlags,
-                             bool sendAstraQuiverCountU16)
+                             bool sendAstraItemState, bool sendAstraQuiverCountU16)
 {
 	addItemId(id);
 
@@ -147,6 +162,12 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count, bool sendTier, bool alw
 	if (sendTier && ConfigManager::getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
 	    (alwaysSendTier || (ConfigManager::getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION) && it.classification > 0))) {
 		addByte(static_cast<uint8_t>(it.tier));
+	}
+
+	if (sendAstraItemState) {
+		addByte(0); // no instance duration is available in the id/count overload
+		addByte(0); // no instance charges are available in the id/count overload
+		addAstraItemMetadata(*this, it);
 	}
 }
 
@@ -201,8 +222,7 @@ void NetworkMessage::addItem(const Item* item, bool sendTier, bool alwaysSendTie
 			addByte((it.charges != 0 && charges == it.charges) ? 1 : 0);
 		}
 
-		add<uint16_t>(it.slotPosition);
-		addByte(getAstraItemMetadataFlags(it));
+		addAstraItemMetadata(*this, it);
 	}
 }
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -123,7 +123,8 @@ public:
 	void addPosition(const Position& pos);
 	void addItemId(uint16_t itemId);
 	void addItem(uint16_t id, uint8_t count, bool sendTier = false, bool alwaysSendTier = false,
-	             bool sendQuickLootFlags = false, bool sendAstraQuiverCountU16 = false);
+	             bool sendQuickLootFlags = false, bool sendAstraItemState = false,
+	             bool sendAstraQuiverCountU16 = false);
 	void addItem(const Item* item, bool sendTier = false, bool alwaysSendTier = false, bool sendQuiverCount = false,
 	             bool sendQuickLootFlags = false, bool sendAstraItemState = false,
 	             bool sendAstraQuiverCountU16 = false);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4000,10 +4000,10 @@ void ProtocolGame::sendItemInspection(std::shared_ptr<Item> item, uint16_t itemI
 	msg.addString(item ? item->getName() : std::string_view(itemType.name));
 	if (item) {
 		msg.addItem(item.get(), shouldSendItemTierData(), shouldSendItemTierByte(), isOTC, shouldSendQuickLootFlags(),
-		            false, shouldSendAstraQuiverCountU16());
+		            canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	} else {
 		msg.addItem(itemId, itemCount, shouldSendItemTierData(), shouldSendItemTierByte(),
-		            shouldSendQuickLootFlags(), shouldSendAstraQuiverCountU16());
+		            shouldSendQuickLootFlags(), canSendAstraItemState(), shouldSendAstraQuiverCountU16());
 	}
 	msg.addByte(0);
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4655,6 +4655,7 @@ void ProtocolGame::sendFeatures()
 		features[GameFeature::DisplayItemDuration] = true;
 		features[GameFeature::DisplayItemCharges] = true;
 		features[GameFeature::PackedPlayerInventory] = true;
+		features[GameFeature::AstraItemMetadata] = true;
 	}
 	features[GameFeature::QuickLootFlags] = shouldSendQuickLootFlags();
 	features[GameFeature::ThingUpgradeClassification] = false;


### PR DESCRIPTION
## Summary

This PR adds the server-side half of the Astra item metadata contract used by the Action Bar equip/unequip fix.

## What changed

- Added the `AstraItemMetadata` game feature after the existing Astra item-state features.
- Advertised `AstraItemMetadata` when `canSendAstraItemState()` is enabled.
- Appended item equip metadata to the Astra item-state block:
  - `slotPosition`
  - flags for equipable items and ammo
- Derived the flags from server-owned `ItemType` data (`slotPosition`, `weaponType`, ammo/attack/defense/armor, and equipment slots) instead of client-side IDs or item names.
- Extended the `itemId/count` `NetworkMessage::addItem` overload to serialize the Astra item-state block when negotiated, keeping it aligned with the `Item*` overload.
- Updated item inspection serialization so inspected items also follow the negotiated Astra item-state contract.

## Why

The client cannot reliably infer ring, amulet/necklace, and arrow/ammo equipability from the 8.60 DAT/local metadata. The server already has the correct authoritative item properties, so it now sends compact metadata that the Astra client can use when assigning Action Bar objects.

This also addresses Gemini review feedback around metadata flag logic and protocol alignment. In this codebase `SLOTP_HAND` exists and is the default slot value, so the fix does not use `slotPosition != 0`; instead it uses the same kind of explicit equipment criteria already used by the server inventory list.

## Impact

This is the required server companion for https://github.com/Mateuzkl/AstraClient/pull/71. Together, the PRs restore Action Bar `Equip/Unequip` for rings, amulets, and arrows without hardcoded item IDs or client `items.xml` dependency.

## Validation

- Ran `git diff --check` for the changed server files.
- Verified the PR diff excludes `gemini.md` and unrelated/generated files.
- Build/runtime validation was not run because the local environment does not expose the required build tooling in PATH.
