### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(actions)"
+
+  - package-ecosystem: "vcpkg"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(vcpkg)"


### PR DESCRIPTION
Adds .github/dependabot.yml with weekly updates for GitHub Actions and vcpkg. The vcpkg manifest is in the repository root, so directory is set to /.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for GitHub Actions and vcpkg packages on a weekly schedule to maintain the project's dependencies current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->