### PR TITLE
perf: add a local walk cache for monsters

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -322,7 +322,7 @@ public:
 	virtual void onWalk();
 	virtual bool getNextStep(Direction& dir, uint32_t& flags);
 
-	virtual void onAddTileItem(const Tile*, const Position&) {}
+	virtual void onAddTileItem(const Tile*, const Position&, const Item*) {}
 	virtual void onUpdateTileItem(const Tile*, const Position&, const Item*, const ItemType&,
 	                              const Item*, const ItemType&)
 	{}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -712,6 +712,12 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 {
 	Tile* tile = getTile(pos.x, pos.y, pos.z);
+	if (const Monster* monster = creature.getMonster()) {
+		if (const auto cachedWalkable = monster->getWalkCache(pos)) {
+			return *cachedWalkable ? tile : nullptr;
+		}
+	}
+
 	if (creature.getTile() != tile) {
 		if (!tile) {
 			return nullptr;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -713,8 +713,13 @@ const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
 {
 	Tile* tile = getTile(pos.x, pos.y, pos.z);
 	if (const Monster* monster = creature.getMonster()) {
-		if (const auto cachedWalkable = monster->getWalkCache(pos)) {
-			return *cachedWalkable ? tile : nullptr;
+		// A damaging magic field's walkability also depends on volatile monster state
+		// (isIgnoringFieldDamage + hasBeenAttacked) that the walk cache cannot track, so always
+		// re-query field tiles live instead of trusting a possibly-stale cached bit.
+		if (!tile || !tile->hasFlag(TILESTATE_MAGICFIELD)) {
+			if (const auto cachedWalkable = monster->getWalkCache(pos)) {
+				return *cachedWalkable ? tile : nullptr;
+			}
 		}
 	}
 

--- a/src/map.h
+++ b/src/map.h
@@ -8,6 +8,7 @@
 
 #include "house.h"
 #include "mapcache.h"
+#include "map_constants.h"
 #include "position.h"
 #include "spawn.h"
 #include "town.h"
@@ -201,10 +202,10 @@ private:
 class Map
 {
 public:
-	static constexpr int32_t maxViewportX = 11; // min value: maxClientViewportX + 1
-	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
-	static constexpr int32_t maxClientViewportX = 8;
-	static constexpr int32_t maxClientViewportY = 6;
+	static constexpr int32_t maxViewportX = MapConstants::maxViewportX;
+	static constexpr int32_t maxViewportY = MapConstants::maxViewportY;
+	static constexpr int32_t maxClientViewportX = MapConstants::maxClientViewportX;
+	static constexpr int32_t maxClientViewportY = MapConstants::maxClientViewportY;
 
 
 	uint32_t clean() const;

--- a/src/map_constants.h
+++ b/src/map_constants.h
@@ -6,8 +6,7 @@
 
 #include <cstdint>
 
-namespace MapConstants
-{
+namespace MapConstants {
 inline constexpr int32_t maxViewportX = 11; // min value: maxClientViewportX + 1
 inline constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 inline constexpr int32_t maxClientViewportX = 8;

--- a/src/map_constants.h
+++ b/src/map_constants.h
@@ -1,0 +1,17 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_MAP_CONSTANTS_H
+#define FS_MAP_CONSTANTS_H
+
+#include <cstdint>
+
+namespace MapConstants
+{
+inline constexpr int32_t maxViewportX = 11; // min value: maxClientViewportX + 1
+inline constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
+inline constexpr int32_t maxClientViewportX = 8;
+inline constexpr int32_t maxClientViewportY = 6;
+}
+
+#endif

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -266,11 +266,101 @@ bool Monster::canWalkOnFieldType(CombatType_t combatType) const
 	}
 }
 
+std::optional<bool> Monster::getWalkCache(const Position& pos) const
+{
+	if (!usesWalkCache()) {
+		return std::nullopt;
+	}
+
+	if (!isWalkCacheLoaded) {
+		updateMapCache();
+	}
+
+	const Position& myPos = getPosition();
+	if (myPos.z != pos.z) {
+		return false;
+	}
+
+	if (pos == myPos) {
+		return true;
+	}
+
+	const int32_t dx = Position::getOffsetX(pos, myPos);
+	const int32_t dy = Position::getOffsetY(pos, myPos);
+	if (std::abs(dx) > maxWalkCacheWidth || std::abs(dy) > maxWalkCacheHeight) {
+		return std::nullopt;
+	}
+
+	return localMapCache[getWalkCacheIndex(dx, dy)];
+}
+
+void Monster::updateMapCache() const
+{
+	isWalkCacheLoaded = false;
+
+	const Position& myPos = getPosition();
+	for (int32_t dy = -maxWalkCacheHeight; dy <= maxWalkCacheHeight; ++dy) {
+		for (int32_t dx = -maxWalkCacheWidth; dx <= maxWalkCacheWidth; ++dx) {
+			const Position pos(myPos.x + dx, myPos.y + dy, myPos.z);
+			updateTileCache(g_game.map.getTile(pos), dx, dy);
+		}
+	}
+
+	isWalkCacheLoaded = true;
+}
+
+void Monster::updateTileCache(const Tile* tile, int32_t dx, int32_t dy) const
+{
+	if (std::abs(dx) > maxWalkCacheWidth || std::abs(dy) > maxWalkCacheHeight) {
+		return;
+	}
+
+	constexpr uint32_t flags = FLAG_PATHFINDING | FLAG_IGNOREFIELDDAMAGE;
+	localMapCache[getWalkCacheIndex(dx, dy)] = tile && tile->queryAdd(0, *this, 1, flags) == RETURNVALUE_NOERROR;
+}
+
+void Monster::updateTileCache(const Tile* tile, const Position& pos) const
+{
+	const Position& myPos = getPosition();
+	if (pos.z != myPos.z) {
+		return;
+	}
+
+	updateTileCache(tile, Position::getOffsetX(pos, myPos), Position::getOffsetY(pos, myPos));
+}
+
 void Monster::onAttackedCreatureDisappear(bool) { attackTicks = 0; }
+
+void Monster::onAddTileItem(const Tile* tile, const Position& pos)
+{
+	if (isWalkCacheLoaded) {
+		updateTileCache(tile, pos);
+	}
+}
+
+void Monster::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*, const ItemType& oldType,
+                               const Item*, const ItemType& newType)
+{
+	if (isWalkCacheLoaded && (oldType.blockSolid || oldType.blockPathFind || oldType.isGroundTile() ||
+	                          newType.blockSolid || newType.blockPathFind || newType.isGroundTile())) {
+		updateTileCache(tile, pos);
+	}
+}
+
+void Monster::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& itemType, const Item*)
+{
+	if (isWalkCacheLoaded && (itemType.blockSolid || itemType.blockPathFind || itemType.isGroundTile())) {
+		updateTileCache(tile, pos);
+	}
+}
 
 void Monster::onCreatureAppear(Creature* creature, bool isLogin)
 {
 	Creature::onCreatureAppear(creature, isLogin);
+
+	if (creature != this && isWalkCacheLoaded) {
+		updateTileCache(creature->getTile(), creature->getPosition());
+	}
 
 	if (mType->info.creatureAppearEvent != -1) {
 		// onCreatureAppear(self, creature)
@@ -316,6 +406,10 @@ void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
+	if (creature != this && isWalkCacheLoaded) {
+		updateTileCache(creature->getTile(), creature->getPosition());
+	}
+
 	if (mType->info.creatureDisappearEvent != -1) {
 		// onCreatureDisappear(self, creature)
 		LuaScriptInterface* scriptInterface = mType->info.scriptInterface;
@@ -353,6 +447,67 @@ void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
                              const Position& oldPos, bool teleport)
 {
+	if (isWalkCacheLoaded) {
+		if (creature == this) {
+			const int32_t dx = newPos.x - oldPos.x;
+			const int32_t dy = newPos.y - oldPos.y;
+			const int32_t dz = newPos.z - oldPos.z;
+
+			if (teleport || dz != 0 || std::abs(dx) > 1 || std::abs(dy) > 1) {
+				updateMapCache();
+			} else {
+				const Position& myPos = getPosition();
+
+				if (dy < 0) {
+					localMapCache <<= mapWalkWidth;
+					for (int32_t x = -maxWalkCacheWidth; x <= maxWalkCacheWidth; ++x) {
+						updateTileCache(g_game.map.getTile(myPos.x + x, myPos.y - maxWalkCacheHeight, myPos.z), x,
+						                -maxWalkCacheHeight);
+					}
+				} else if (dy > 0) {
+					localMapCache >>= mapWalkWidth;
+					for (int32_t x = -maxWalkCacheWidth; x <= maxWalkCacheWidth; ++x) {
+						updateTileCache(g_game.map.getTile(myPos.x + x, myPos.y + maxWalkCacheHeight, myPos.z), x,
+						                maxWalkCacheHeight);
+					}
+				}
+
+				if (dx > 0) {
+					const int32_t startY = dy > 0 ? dy : 0;
+					const int32_t endY = dy < 0 ? mapWalkHeight - 1 + dy : mapWalkHeight - 1;
+					for (int32_t y = startY; y <= endY; ++y) {
+						const std::size_t rowBase = static_cast<std::size_t>(y) * mapWalkWidth;
+						for (int32_t x = 0; x < mapWalkWidth - 1; ++x) {
+							localMapCache[rowBase + x] = localMapCache[rowBase + x + 1];
+						}
+					}
+					for (int32_t y = -maxWalkCacheHeight; y <= maxWalkCacheHeight; ++y) {
+						updateTileCache(g_game.map.getTile(myPos.x + maxWalkCacheWidth, myPos.y + y, myPos.z),
+						                maxWalkCacheWidth, y);
+					}
+				} else if (dx < 0) {
+					const int32_t startY = dy > 0 ? dy : 0;
+					const int32_t endY = dy < 0 ? mapWalkHeight - 1 + dy : mapWalkHeight - 1;
+					for (int32_t y = startY; y <= endY; ++y) {
+						const std::size_t rowBase = static_cast<std::size_t>(y) * mapWalkWidth;
+						for (int32_t x = mapWalkWidth - 2; x >= 0; --x) {
+							localMapCache[rowBase + x + 1] = localMapCache[rowBase + x];
+						}
+					}
+					for (int32_t y = -maxWalkCacheHeight; y <= maxWalkCacheHeight; ++y) {
+						updateTileCache(g_game.map.getTile(myPos.x - maxWalkCacheWidth, myPos.y + y, myPos.z),
+						                -maxWalkCacheWidth, y);
+					}
+				}
+
+				updateTileCache(oldTile, oldPos);
+			}
+		} else {
+			updateTileCache(newTile, newPos);
+			updateTileCache(oldTile, oldPos);
+		}
+	}
+
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
 	if (mType->info.creatureMoveEvent != -1) {
@@ -1248,11 +1403,11 @@ BlockType_t Monster::blockHit(const std::shared_ptr<Creature>& attacker, CombatT
 	}
 
 	if (field) {
-		ignoreFieldDamage = true;
+		setIgnoreFieldDamage(true);
 	} else if (damage > 0 && combatType != COMBAT_HEALING && attacker) {
 		const auto master = attacker->getMaster();
 		if (attacker->isPlayer() || (master && master->isPlayer())) {
-			ignoreFieldDamage = true;
+			setIgnoreFieldDamage(true);
 		}
 	}
 
@@ -1349,7 +1504,7 @@ void Monster::onAddCondition(ConditionType_t)
 void Monster::onEndCondition(ConditionType_t type)
 {
 	if (type == CONDITION_FIRE || type == CONDITION_ENERGY || type == CONDITION_POISON) {
-		ignoreFieldDamage = false;
+		setIgnoreFieldDamage(false);
 	}
 
 	updateIdleStatus();
@@ -1397,7 +1552,7 @@ void Monster::onThink(uint32_t interval)
 			addEventWalk();
 
 			if (getAttackedCreatureShared() && getTimeSinceLastMove() >= 3000) {
-				ignoreFieldDamage = true;
+				setIgnoreFieldDamage(true);
 			}
 
 			if (isSummon()) {
@@ -1994,6 +2149,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 	if (!walkingToSpawn && (followCreature.expired() || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
 		if (getTimeSinceLastMove() >= EVENT_CREATURE_THINK_INTERVAL) {
 			randomStepping = true;
+			invalidateWalkCache();
 			// choose a random direction
 			result = getRandomStep(getPosition(), direction);
 		}
@@ -2001,6 +2157,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 		auto master = getMaster();
 		if (!hasFollowPath && master && !master->isPlayer()) {
 			randomStepping = true;
+			invalidateWalkCache();
 			result = getRandomStep(getPosition(), direction);
 		} else {
 			randomStepping = false;
@@ -2013,7 +2170,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 				}
 
 				if (ignoreFieldDamage) {
-					ignoreFieldDamage = false;
+					setIgnoreFieldDamage(false);
 				}
 				// target dancing
 				if (auto ac = attackedCreature.lock(); ac && ac == followCreature.lock()) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -272,13 +272,10 @@ std::optional<bool> Monster::getWalkCache(const Position& pos) const
 		return std::nullopt;
 	}
 
-	if (!isWalkCacheLoaded) {
-		updateMapCache();
-	}
-
 	const Position& myPos = getPosition();
 	if (myPos.z != pos.z) {
-		return false;
+		// The cache only models same-floor offsets; let canWalkTo fall back to queryAdd.
+		return std::nullopt;
 	}
 
 	if (pos == myPos) {
@@ -289,6 +286,10 @@ std::optional<bool> Monster::getWalkCache(const Position& pos) const
 	const int32_t dy = pos.getOffsetY(myPos);
 	if (std::abs(dx) > maxWalkCacheWidth || std::abs(dy) > maxWalkCacheHeight) {
 		return std::nullopt;
+	}
+
+	if (!isWalkCacheLoaded) {
+		updateMapCache();
 	}
 
 	return localMapCache[getWalkCacheIndex(dx, dy)];

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2174,9 +2174,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 					return false;
 				}
 
-				if (ignoreFieldDamage) {
-					setIgnoreFieldDamage(false);
-				}
+				ignoreFieldDamage = false;
 				// target dancing
 				if (auto ac = attackedCreature.lock(); ac && ac == followCreature.lock()) {
 					if (isFleeing()) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -285,8 +285,8 @@ std::optional<bool> Monster::getWalkCache(const Position& pos) const
 		return true;
 	}
 
-	const int32_t dx = Position::getOffsetX(pos, myPos);
-	const int32_t dy = Position::getOffsetY(pos, myPos);
+	const int32_t dx = pos.getOffsetX(myPos);
+	const int32_t dy = pos.getOffsetY(myPos);
 	if (std::abs(dx) > maxWalkCacheWidth || std::abs(dy) > maxWalkCacheHeight) {
 		return std::nullopt;
 	}
@@ -326,7 +326,7 @@ void Monster::updateTileCache(const Tile* tile, const Position& pos) const
 		return;
 	}
 
-	updateTileCache(tile, Position::getOffsetX(pos, myPos), Position::getOffsetY(pos, myPos));
+	updateTileCache(tile, pos.getOffsetX(myPos), pos.getOffsetY(myPos));
 }
 
 void Monster::onAttackedCreatureDisappear(bool) { attackTicks = 0; }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -331,9 +331,9 @@ void Monster::updateTileCache(const Tile* tile, const Position& pos) const
 
 void Monster::onAttackedCreatureDisappear(bool) { attackTicks = 0; }
 
-void Monster::onAddTileItem(const Tile* tile, const Position& pos)
+void Monster::onAddTileItem(const Tile* tile, const Position& pos, const Item* item)
 {
-	if (isWalkCacheLoaded) {
+	if (isWalkCacheLoaded && item && canAffectWalkCache(Item::items[item->getID()])) {
 		updateTileCache(tile, pos);
 	}
 }
@@ -341,15 +341,14 @@ void Monster::onAddTileItem(const Tile* tile, const Position& pos)
 void Monster::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*, const ItemType& oldType,
                                const Item*, const ItemType& newType)
 {
-	if (isWalkCacheLoaded && (oldType.blockSolid || oldType.blockPathFind || oldType.isGroundTile() ||
-	                          newType.blockSolid || newType.blockPathFind || newType.isGroundTile())) {
+	if (isWalkCacheLoaded && (canAffectWalkCache(oldType) || canAffectWalkCache(newType))) {
 		updateTileCache(tile, pos);
 	}
 }
 
 void Monster::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& itemType, const Item*)
 {
-	if (isWalkCacheLoaded && (itemType.blockSolid || itemType.blockPathFind || itemType.isGroundTile())) {
+	if (isWalkCacheLoaded && canAffectWalkCache(itemType)) {
 		updateTileCache(tile, pos);
 	}
 }
@@ -359,7 +358,8 @@ void Monster::onCreatureAppear(Creature* creature, bool isLogin)
 	Creature::onCreatureAppear(creature, isLogin);
 
 	if (creature != this && isWalkCacheLoaded) {
-		updateTileCache(creature->getTile(), creature->getPosition());
+		const Position& creaturePos = creature->getPosition();
+		updateTileCache(g_game.map.getTile(creaturePos), creaturePos);
 	}
 
 	if (mType->info.creatureAppearEvent != -1) {
@@ -404,10 +404,13 @@ void Monster::onCreatureAppear(Creature* creature, bool isLogin)
 
 void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 {
+	const bool updateWalkCache = creature != this && isWalkCacheLoaded;
+	const Position creaturePos = creature->getPosition();
+
 	Creature::onRemoveCreature(creature, isLogout);
 
-	if (creature != this && isWalkCacheLoaded) {
-		updateTileCache(creature->getTile(), creature->getPosition());
+	if (updateWalkCache) {
+		updateTileCache(g_game.map.getTile(creaturePos), creaturePos);
 	}
 
 	if (mType->info.creatureDisappearEvent != -1) {
@@ -472,10 +475,13 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 					}
 				}
 
+				// Vertical movement refreshes one edge row; do not shift that fresh row again
+				// when the same step also moves horizontally.
+				const int32_t horizontalStartY = dy < 0 ? 1 : 0;
+				const int32_t horizontalEndY = dy > 0 ? mapWalkHeight - 2 : mapWalkHeight - 1;
+
 				if (dx > 0) {
-					const int32_t startY = dy > 0 ? dy : 0;
-					const int32_t endY = dy < 0 ? mapWalkHeight - 1 + dy : mapWalkHeight - 1;
-					for (int32_t y = startY; y <= endY; ++y) {
+					for (int32_t y = horizontalStartY; y <= horizontalEndY; ++y) {
 						const std::size_t rowBase = static_cast<std::size_t>(y) * mapWalkWidth;
 						for (int32_t x = 0; x < mapWalkWidth - 1; ++x) {
 							localMapCache[rowBase + x] = localMapCache[rowBase + x + 1];
@@ -486,9 +492,7 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 						                maxWalkCacheWidth, y);
 					}
 				} else if (dx < 0) {
-					const int32_t startY = dy > 0 ? dy : 0;
-					const int32_t endY = dy < 0 ? mapWalkHeight - 1 + dy : mapWalkHeight - 1;
-					for (int32_t y = startY; y <= endY; ++y) {
+					for (int32_t y = horizontalStartY; y <= horizontalEndY; ++y) {
 						const std::size_t rowBase = static_cast<std::size_t>(y) * mapWalkWidth;
 						for (int32_t x = mapWalkWidth - 2; x >= 0; --x) {
 							localMapCache[rowBase + x + 1] = localMapCache[rowBase + x];

--- a/src/monster.h
+++ b/src/monster.h
@@ -5,10 +5,11 @@
 #define FS_MONSTER_H
 
 #include <bitset>
+#include <cassert>
 #include <cstddef>
 #include <optional>
 
-#include "map.h"
+#include "map_constants.h"
 #include "monsters.h"
 #include "tile.h"
 
@@ -112,7 +113,7 @@ public:
 
 	void onAttackedCreatureDisappear(bool isLogout) override;
 
-	void onAddTileItem(const Tile* tile, const Position& pos) override;
+	void onAddTileItem(const Tile* tile, const Position& pos, const Item* item) override;
 	void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
 	                      const Item* newItem, const ItemType& newType) override;
 	void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& itemType, const Item* item) override;
@@ -223,8 +224,8 @@ private:
 	uint8_t influencedLevel = 0;
 	bool fiendish = false;
 
-	static constexpr int32_t mapWalkWidth = Map::maxViewportX * 2 + 1;
-	static constexpr int32_t mapWalkHeight = Map::maxViewportY * 2 + 1;
+	static constexpr int32_t mapWalkWidth = MapConstants::maxViewportX * 2 + 1;
+	static constexpr int32_t mapWalkHeight = MapConstants::maxViewportY * 2 + 1;
 	static constexpr int32_t maxWalkCacheWidth = (mapWalkWidth - 1) / 2;
 	static constexpr int32_t maxWalkCacheHeight = (mapWalkHeight - 1) / 2;
 	static constexpr std::size_t mapWalkCacheSize = static_cast<std::size_t>(mapWalkWidth) * mapWalkHeight;
@@ -263,6 +264,10 @@ private:
 	bool getDanceStep(const Position& creaturePos, Direction& direction, bool keepAttack = true,
 	                  bool keepDistance = true);
 	bool canWalkTo(Position pos, Direction direction) const;
+	static bool canAffectWalkCache(const ItemType& itemType)
+	{
+		return itemType.blockSolid || itemType.blockPathFind || itemType.isGroundTile() || itemType.isMagicField();
+	}
 	bool usesWalkCache() const { return !randomStepping; }
 	void invalidateWalkCache() noexcept { isWalkCacheLoaded = false; }
 	void setIgnoreFieldDamage(bool value)
@@ -275,8 +280,10 @@ private:
 	void updateMapCache() const;
 	void updateTileCache(const Tile* tile, int32_t dx, int32_t dy) const;
 	void updateTileCache(const Tile* tile, const Position& pos) const;
-	static constexpr std::size_t getWalkCacheIndex(int32_t dx, int32_t dy)
+	[[nodiscard]] static std::size_t getWalkCacheIndex(int32_t dx, int32_t dy)
 	{
+		assert(dx >= -maxWalkCacheWidth && dx <= maxWalkCacheWidth && dy >= -maxWalkCacheHeight &&
+		       dy <= maxWalkCacheHeight);
 		return static_cast<std::size_t>(maxWalkCacheHeight + dy) * mapWalkWidth +
 		       static_cast<std::size_t>(maxWalkCacheWidth + dx);
 	}

--- a/src/monster.h
+++ b/src/monster.h
@@ -266,17 +266,16 @@ private:
 	bool canWalkTo(Position pos, Direction direction) const;
 	static bool canAffectWalkCache(const ItemType& itemType)
 	{
-		return itemType.blockSolid || itemType.blockPathFind || itemType.isGroundTile() || itemType.isMagicField();
+		// Mirror the predicates Tile::queryAdd uses under FLAG_PATHFINDING: solid/pathfind/ground/magic-field,
+		// plus teleport and floor-change items (TILESTATE_TELEPORT/FLOORCHANGE make queryAdd return NOTPOSSIBLE).
+		return itemType.blockSolid || itemType.blockPathFind || itemType.isGroundTile() || itemType.isMagicField() ||
+		       itemType.isTeleport() || itemType.floorChange != 0;
 	}
 	bool usesWalkCache() const { return !randomStepping; }
 	void invalidateWalkCache() noexcept { isWalkCacheLoaded = false; }
-	void setIgnoreFieldDamage(bool value)
-	{
-		if (ignoreFieldDamage != value) {
-			ignoreFieldDamage = value;
-			invalidateWalkCache();
-		}
-	}
+	// Plain setter: the walk cache never trusts magic-field tiles (Map::canWalkTo re-queries them live),
+	// and no other cached tile depends on ignoreFieldDamage, so changing it must not invalidate the cache.
+	void setIgnoreFieldDamage(bool value) { ignoreFieldDamage = value; }
 	void updateMapCache() const;
 	void updateTileCache(const Tile* tile, int32_t dx, int32_t dy) const;
 	void updateTileCache(const Tile* tile, const Position& pos) const;

--- a/src/monster.h
+++ b/src/monster.h
@@ -4,6 +4,11 @@
 #ifndef FS_MONSTER_H
 #define FS_MONSTER_H
 
+#include <bitset>
+#include <cstddef>
+#include <optional>
+
+#include "map.h"
 #include "monsters.h"
 #include "tile.h"
 
@@ -103,9 +108,14 @@ public:
 	uint32_t getManaCost() const { return mType->info.manaCost; }
 	void setSpawn(std::shared_ptr<Spawn> newSpawn) { spawn = newSpawn; }
 	bool canWalkOnFieldType(CombatType_t combatType) const;
+	std::optional<bool> getWalkCache(const Position& pos) const;
 
 	void onAttackedCreatureDisappear(bool isLogout) override;
 
+	void onAddTileItem(const Tile* tile, const Position& pos) override;
+	void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
+	                      const Item* newItem, const ItemType& newType) override;
+	void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& itemType, const Item* item) override;
 	void onCreatureAppear(Creature* creature, bool isLogin) override;
 	void onRemoveCreature(Creature* creature, bool isLogout) override;
 	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
@@ -213,6 +223,15 @@ private:
 	uint8_t influencedLevel = 0;
 	bool fiendish = false;
 
+	static constexpr int32_t mapWalkWidth = Map::maxViewportX * 2 + 1;
+	static constexpr int32_t mapWalkHeight = Map::maxViewportY * 2 + 1;
+	static constexpr int32_t maxWalkCacheWidth = (mapWalkWidth - 1) / 2;
+	static constexpr int32_t maxWalkCacheHeight = (mapWalkHeight - 1) / 2;
+	static constexpr std::size_t mapWalkCacheSize = static_cast<std::size_t>(mapWalkWidth) * mapWalkHeight;
+
+	mutable std::bitset<mapWalkCacheSize> localMapCache;
+	mutable bool isWalkCacheLoaded = false;
+
 	void onCreatureEnter(Creature* creature);
 	void onCreatureLeave(Creature* creature);
 	bool selectBlockerTarget();
@@ -244,6 +263,23 @@ private:
 	bool getDanceStep(const Position& creaturePos, Direction& direction, bool keepAttack = true,
 	                  bool keepDistance = true);
 	bool canWalkTo(Position pos, Direction direction) const;
+	bool usesWalkCache() const { return !randomStepping; }
+	void invalidateWalkCache() noexcept { isWalkCacheLoaded = false; }
+	void setIgnoreFieldDamage(bool value)
+	{
+		if (ignoreFieldDamage != value) {
+			ignoreFieldDamage = value;
+			invalidateWalkCache();
+		}
+	}
+	void updateMapCache() const;
+	void updateTileCache(const Tile* tile, int32_t dx, int32_t dy) const;
+	void updateTileCache(const Tile* tile, const Position& pos) const;
+	static constexpr std::size_t getWalkCacheIndex(int32_t dx, int32_t dy)
+	{
+		return static_cast<std::size_t>(maxWalkCacheHeight + dy) * mapWalkWidth +
+		       static_cast<std::size_t>(maxWalkCacheWidth + dx);
+	}
 	void fleeFromTarget(const Position& targetPos, Direction& direction);
 
 	static bool pushItem(Item* item);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -469,7 +469,7 @@ void Tile::onAddTileItem(Item* item)
 	}
 
 	for (const auto& spectator : spectators) {
-		spectator->onAddTileItem(this, cylinderMapPos);
+		spectator->onAddTileItem(this, cylinderMapPos, item);
 	}
 
 	if ((!hasFlag(TILESTATE_PROTECTIONZONE) || getBoolean(ConfigManager::CLEAN_PROTECTION_ZONES)) &&

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -468,6 +468,10 @@ void Tile::onAddTileItem(Item* item)
 		}
 	}
 
+	for (const auto& spectator : spectators) {
+		spectator->onAddTileItem(this, cylinderMapPos);
+	}
+
 	if ((!hasFlag(TILESTATE_PROTECTIONZONE) || getBoolean(ConfigManager::CLEAN_PROTECTION_ZONES)) &&
 	    item->isCleanable()) {
 		if (!getHouseTile()) {


### PR DESCRIPTION
## Summary

Ports the useful parts of BlackTek's local-map-cache work to this codebase without cherry-picking its incompatible Creature/shared-pointer implementation.

- Keeps the cache entirely inside `Monster` as a fixed-size `std::bitset`; it has no dynamic ownership or allocation.
- Builds the cache lazily on the first monster path search and falls back to the existing `Map::canWalkTo` checks outside its range or during random stepping.
- Keeps entries current for monster movement, teleports, creature appearance/removal, and tile item additions, updates, and removals.
- Invalidates the cache when random movement or field-damage behavior changes, so cached `queryAdd` results are never reused across those state changes.
- Adds the missing tile-add spectator callback required to refresh a loaded cache after a wall, field, or other item is created.

Based on:
- https://github.com/Black-Tek/BlackTek-Server/commit/ec362f2073739f2cdcece62d189af09c99bc0b44
- https://github.com/Black-Tek/BlackTek-Server/commit/e2b35290aa51c2aafd9173719d7d2bc807580cd1

## Validation

- `git diff --check`
- `tools/check-shared-get-escapes.cmake`
- `tools/check-manual-delete.cmake`

Not built locally by request; please compile and exercise monster chasing, random walking, teleports, item/field changes, summons, and return-to-spawn before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a monster walkability cache to improve pathfinding and movement efficiency.
* **Bug Fixes**
  * Improved tile-item add notifications so spectator views update more consistently when items change on tiles.
* **Refactor**
  * Centralized map viewport sizing constants and updated movement/walkability logic to use safer cache-aware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->