### PR TITLE
Rebuild Battle Pass season system

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -34,6 +34,12 @@ PlayerStorageKeys = {
     dailyRewardStreak = 90722,
     dailyRewardJokerTokens = 90723,
 
+    -- Battle Pass
+    -- The detailed state is persisted in player KV under the "battlepass" scope.
+    -- These numeric storages are intentionally reserved for timers/version markers.
+    battlePassSeasonEpoch = 90730,
+    battlePassDoubleSkillUntil = 90731,
+
     -- Forge system
     forgeDust = 10000,
     forgeDustLimit = 10001,
@@ -62,6 +68,8 @@ GlobalStorageKeys = {
     workbenchOwner = 30051,
     boostedCreatureIndex = 90001,
     boostedCreatureDay = 90002,
+    battlePassSeasonEpoch = 90500,
+    battlePassSeasonStartedAt = 90501,
 }
 
 AccountStorageKeys = {}

--- a/data/scripts/creaturescripts/others/custom_bestiary.lua
+++ b/data/scripts/creaturescripts/others/custom_bestiary.lua
@@ -182,6 +182,9 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		if oldKills < entry.toKill and newKills >= entry.toKill then
 			addPlayerCharmPoints(playerGuid, entry.charmPoints)
 		end
+		if CustomBestiary.sendProgress then
+			CustomBestiary.sendProgress(player, raceId, newKills)
+		end
 		if newProgress > oldProgress then
 			sendBestiaryUnlockMessage(player, entry, newProgress)
 		end

--- a/data/scripts/lib/reward_battlepass.lua
+++ b/data/scripts/lib/reward_battlepass.lua
@@ -204,5 +204,5 @@ end
 
 reward[80] = {
 	free = { type = "level", count = 2 },
-	deluxe = { type = "outfit", male = { { looktype = 1289, name = "Dragon Slayer" } }, female = { { looktype = 1289, name = "Dragon Slayer" } }, addons = 3 },
+	deluxe = { type = "charms", count = 250 },
 }

--- a/data/scripts/lib/reward_battlepass.lua
+++ b/data/scripts/lib/reward_battlepass.lua
@@ -1,0 +1,163 @@
+-- Battle Pass season data.
+--
+-- This is the only file that should need changing when a new season starts:
+-- 1. Change season.id (and rewards/missions as desired).
+-- 2. Reload the server scripts or restart the server.
+-- 3. Use /battlepass newseason as a GM.
+--
+-- All reward item ids below exist in this data pack. Replace them with the
+-- season's final items before opening the season to players.
+
+BattlePassConfig = {
+	requirements = {
+		minimumLevel = 8,
+		requireVocation = true,
+	},
+
+	season = {
+		id = "season-02",
+		-- Leave startsAt at 0 to start when /battlepass newseason is used.
+		-- A Unix timestamp can be used to schedule a fixed start.
+		startsAt = 0,
+		durationDays = 35,
+		resetHour = 10,
+		maxStep = 50,
+		pointsPerStep = 100,
+	},
+
+	deluxe = {
+		price = 250,
+	},
+
+	reroll = {
+		goldPerLevel = 800,
+	},
+
+	dailyMissions = {
+		free = {
+			{ id = "daily_rotworm", name = "Rotworm Cleanup", description = "Kill 40 rotworms or carrion worms.", maxProgress = 40, points = 25, targets = { "rotworm", "carrion worm" } },
+			{ id = "daily_troll", name = "Troll Patrol", description = "Kill 40 trolls.", maxProgress = 40, points = 25, targets = { "troll", "swamp troll", "frost troll" } },
+			{ id = "daily_orc", name = "Orc Skirmish", description = "Kill 40 orcs.", maxProgress = 40, points = 25, targets = { "orc", "orc spearman", "orc warrior", "orc berserker", "orc leader" } },
+			{ id = "daily_cyclops", name = "One-Eyed Trouble", description = "Kill 20 cyclops.", maxProgress = 20, points = 25, targets = { "cyclops", "cyclops smith", "cyclops drone" } },
+			{ id = "daily_dragon", name = "Dragon Pressure", description = "Kill 10 dragons or dragon lords.", maxProgress = 10, points = 25, targets = { "dragon", "dragon lord" } },
+		},
+		deluxe = {
+			{ id = "daily_deluxe_any", name = "Daily Hunter", description = "Kill 80 creatures.", maxProgress = 80, points = 40, targets = "*" },
+			{ id = "daily_deluxe_minotaur", name = "Minotaur Sweep", description = "Kill 60 minotaurs.", maxProgress = 60, points = 40, targets = { "minotaur", "minotaur archer", "minotaur guard", "minotaur mage" } },
+			{ id = "daily_deluxe_undead", name = "Restless Dead", description = "Kill 50 undead creatures.", maxProgress = 50, points = 40, targets = { "skeleton", "ghoul", "crypt shambler", "mummy", "vampire" } },
+			{ id = "daily_deluxe_dragon", name = "Dragon Daily", description = "Kill 25 dragons.", maxProgress = 25, points = 40, targets = { "dragon", "dragon lord", "wyrm" } },
+			{ id = "daily_deluxe_demon", name = "Demonic Daily", description = "Kill 10 demons.", maxProgress = 10, points = 40, targets = { "demon", "demon outcast" } },
+		},
+	},
+
+	-- General missions use unlockWeek 1..5, matching the Season 2 timeline.
+	generalMissions = {
+		{ id = "bronze_any_150", tier = "bronze", unlockWeek = 1, name = "Fresh Start", description = "Kill 150 creatures during the season.", maxProgress = 150, points = 100, targets = "*" },
+		{ id = "bronze_rotworm_120", tier = "bronze", unlockWeek = 1, name = "Tunnel Sweep", description = "Kill 120 rotworms.", maxProgress = 120, points = 100, targets = { "rotworm", "carrion worm" } },
+		{ id = "silver_cyclops_100", tier = "silver", unlockWeek = 1, name = "Cyclops Camp", description = "Kill 100 cyclops.", maxProgress = 100, points = 200, targets = { "cyclops", "cyclops smith", "cyclops drone" } },
+		{ id = "silver_dragon_80", tier = "silver", unlockWeek = 1, name = "Dragon Hunter", description = "Kill 80 dragons.", maxProgress = 80, points = 200, targets = { "dragon" } },
+
+		{ id = "bronze_troll_120", tier = "bronze", unlockWeek = 2, name = "Troll Breaker", description = "Kill 120 trolls.", maxProgress = 120, points = 100, targets = { "troll", "swamp troll", "frost troll" } },
+		{ id = "bronze_goblin_120", tier = "bronze", unlockWeek = 2, name = "Goblin Control", description = "Kill 120 goblins.", maxProgress = 120, points = 100, targets = { "goblin", "goblin assassin", "goblin leader", "goblin scavenger" } },
+		{ id = "silver_giant_spider_40", tier = "silver", unlockWeek = 2, name = "Web Cleaner", description = "Kill 40 giant spiders.", maxProgress = 40, points = 200, targets = { "giant spider" } },
+		{ id = "silver_vampire_60", tier = "silver", unlockWeek = 2, name = "Night Watch", description = "Kill 60 vampires.", maxProgress = 60, points = 200, targets = { "vampire", "vampire bride", "vampire viscount" } },
+
+		{ id = "bronze_minotaur_120", tier = "bronze", unlockWeek = 3, name = "Maze Breaker", description = "Kill 120 minotaurs.", maxProgress = 120, points = 100, targets = { "minotaur", "minotaur archer", "minotaur guard", "minotaur mage" } },
+		{ id = "bronze_orc_150", tier = "bronze", unlockWeek = 3, name = "Orc Campaign", description = "Kill 150 orcs.", maxProgress = 150, points = 100, targets = { "orc", "orc spearman", "orc warrior", "orc berserker", "orc leader", "orc warlord" } },
+		{ id = "bronze_dwarf_120", tier = "bronze", unlockWeek = 3, name = "Dwarf Advance", description = "Kill 120 dwarves.", maxProgress = 120, points = 100, targets = { "dwarf", "dwarf soldier", "dwarf guard", "dwarf geomancer" } },
+		{ id = "silver_necromancer_60", tier = "silver", unlockWeek = 3, name = "Necromancer Hunt", description = "Kill 60 necromancers or priests.", maxProgress = 60, points = 200, targets = { "necromancer", "priestess", "blood priest" } },
+		{ id = "silver_hero_50", tier = "silver", unlockWeek = 3, name = "Hero Trial", description = "Kill 50 heroes or black knights.", maxProgress = 50, points = 200, targets = { "hero", "black knight" } },
+		{ id = "gold_demon_25", tier = "gold", unlockWeek = 3, name = "Demon Contract", description = "Kill 25 demons.", maxProgress = 25, points = 300, targets = { "demon" } },
+
+		{ id = "bronze_amazon_100", tier = "bronze", unlockWeek = 4, name = "Amazon Trail", description = "Kill 100 amazons or valkyries.", maxProgress = 100, points = 100, targets = { "amazon", "valkyrie" } },
+		{ id = "bronze_undead_150", tier = "bronze", unlockWeek = 4, name = "Undead Campaign", description = "Kill 150 undead creatures.", maxProgress = 150, points = 100, targets = { "skeleton", "ghoul", "crypt shambler", "mummy", "vampire", "lich" } },
+		{ id = "silver_beholder_80", tier = "silver", unlockWeek = 4, name = "Evil Eyes", description = "Kill 80 beholders.", maxProgress = 80, points = 200, targets = { "beholder", "elder beholder", "bonelord", "elder bonelord" } },
+		{ id = "silver_dragon_lord_40", tier = "silver", unlockWeek = 4, name = "Dragon Lord Hunt", description = "Kill 40 dragon lords.", maxProgress = 40, points = 200, targets = { "dragon lord" } },
+		{ id = "silver_hydra_30", tier = "silver", unlockWeek = 4, name = "Hydra Heads", description = "Kill 30 hydras.", maxProgress = 30, points = 200, targets = { "hydra" } },
+		{ id = "gold_dragon_family_200", tier = "gold", unlockWeek = 4, name = "Wyrm Scale", description = "Kill 200 dragons, dragon lords or wyrms.", maxProgress = 200, points = 300, targets = { "dragon", "dragon lord", "wyrm" } },
+
+		{ id = "bronze_larva_120", tier = "bronze", unlockWeek = 5, name = "Desert Nest", description = "Kill 120 larvas or scarabs.", maxProgress = 120, points = 100, targets = { "larva", "scarab", "ancient scarab" } },
+		{ id = "bronze_slime_80", tier = "bronze", unlockWeek = 5, name = "Slime Splitter", description = "Kill 80 slimes.", maxProgress = 80, points = 100, targets = { "slime" } },
+		{ id = "silver_serpent_30", tier = "silver", unlockWeek = 5, name = "Serpent Strike", description = "Kill 30 serpent spawns.", maxProgress = 30, points = 200, targets = { "serpent spawn" } },
+		{ id = "silver_any_350", tier = "silver", unlockWeek = 5, name = "Battle Routine", description = "Kill 350 creatures during the season.", maxProgress = 350, points = 200, targets = "*" },
+		{ id = "gold_strong_120", tier = "gold", unlockWeek = 5, name = "Stronghold Breaker", description = "Kill 120 strong creatures.", maxProgress = 120, points = 300, targets = { "warlock", "demon", "hydra", "serpent spawn", "frost dragon", "behemoth" } },
+		{ id = "gold_any_800", tier = "gold", unlockWeek = 5, name = "Season Veteran", description = "Kill 800 creatures during the season.", maxProgress = 800, points = 300, targets = "*" },
+	},
+
+	-- Supported reward types: item, randomItem, randomMount, exercise,
+	-- doubleSkill, level, prey, xpBoost, regeneration, charms, outfit,
+	-- extraSkill, multiItem and choiceItem. All item rewards go to the server's
+	-- persistent Store Inbox, which is used as the Battle Pass reward inbox.
+	rewards = {},
+}
+
+local reward = BattlePassConfig.rewards
+local exerciseWeapons = { 28552, 28553, 28554, 28555, 28556, 28557, 50293 }
+local durableWeapons = { 35279, 35280, 35281, 35282, 35283, 35284, 50294 }
+local lastingWeapons = { 35285, 35286, 35287, 35288, 35289, 35290, 50295 }
+
+local function item(itemId, count, charges)
+	return { type = "item", itemId = itemId, count = count or 1, charges = charges or 0 }
+end
+
+local function randomItem(items, count)
+	return { type = "randomItem", items = items, count = count or 1 }
+end
+
+local function exercise(items, charges, boosted)
+	return { type = boosted and "boostedExercise" or "exercise", choices = items, count = 1, charges = charges }
+end
+
+-- Free rewards follow the published Season 2 cadence. Deluxe has one reward
+-- per step. These defaults are intentionally made from server-valid ids, so
+-- the season is playable immediately and can be customised safely here.
+reward[1] = { deluxe = { type = "outfit", male = { { looktype = 128, name = "Citizen" } }, female = { { looktype = 136, name = "Citizen" } }, addons = 1 } }
+reward[2] = { deluxe = { type = "charms", count = 50 } }
+reward[3] = { free = item(36725), deluxe = { type = "randomMount", mounts = { { id = 1, looktype = 368, name = "Widow Queen" }, { id = 2, looktype = 369, name = "Racing Bird" }, { id = 3, looktype = 370, name = "War Bear" } } } }
+reward[4] = { deluxe = { type = "prey", count = 4 } }
+reward[5] = { deluxe = exercise(durableWeapons, 3600, true) }
+reward[6] = { free = { type = "randomMount", mounts = { { id = 4, looktype = 371, name = "Black Sheep" }, { id = 5, looktype = 372, name = "Midnight Panther" }, { id = 6, looktype = 373, name = "Draptor" } } }, deluxe = item(36725) }
+reward[7] = { deluxe = { type = "regeneration", durationHours = 6 } }
+reward[8] = { deluxe = { type = "prey", count = 3 } }
+reward[9] = { free = exercise(exerciseWeapons, 3600), deluxe = { type = "doubleSkill", durationHours = 6 } }
+reward[10] = { deluxe = { type = "outfit", male = { { looktype = 130, name = "Mage" } }, female = { { looktype = 138, name = "Mage" } }, addons = 2 } }
+reward[11] = { deluxe = exercise(exerciseWeapons, 3600) }
+reward[12] = { free = { type = "doubleSkill", durationHours = 6 }, deluxe = { type = "prey", count = 4 } }
+reward[13] = { deluxe = { type = "charms", count = 50 } }
+reward[14] = { deluxe = randomItem({ 3043, 2160 }, 1) }
+reward[15] = { free = { type = "level", count = 1 }, deluxe = { type = "outfit", male = { { looktype = 130, name = "Mage" } }, female = { { looktype = 138, name = "Mage" } }, addons = 1 } }
+reward[16] = { deluxe = { type = "randomMount", mounts = { { id = 16, looktype = 390, name = "Crystal Wolf" }, { id = 17, looktype = 392, name = "War Horse" }, { id = 18, looktype = 401, name = "Kingly Deer" } } } }
+reward[17] = { deluxe = { type = "level", count = 1 } }
+reward[18] = { free = { type = "prey", count = 3 }, deluxe = { type = "regeneration", durationHours = 3 } }
+reward[19] = { deluxe = { type = "charms", count = 100 } }
+reward[20] = { deluxe = item(36725) }
+reward[21] = { free = randomItem({ 3043, 2160 }, 2), deluxe = item(36725) }
+reward[22] = { deluxe = randomItem({ 3043, 2160 }, 1) }
+reward[23] = { deluxe = { type = "multiItem", items = { { itemId = 3043, count = 5 }, { itemId = 2160, count = 2 } } } }
+reward[24] = { free = randomItem({ 3043, 2160 }, 1), deluxe = { type = "prey", count = 3 } }
+reward[25] = { deluxe = { type = "outfit", male = { { looktype = 130, name = "Mage" } }, female = { { looktype = 138, name = "Mage" } }, addons = 2 } }
+reward[26] = { deluxe = { type = "multiItem", items = { { itemId = 28558, count = 1 }, { itemId = 3043, count = 3 } } } }
+reward[27] = { free = { type = "xpBoost", durationHours = 2, percent = 50 }, deluxe = { type = "xpBoost", durationHours = 2, percent = 50 } }
+reward[28] = { deluxe = exercise(durableWeapons, 3600, true) }
+reward[29] = { deluxe = { type = "regeneration", durationHours = 18 } }
+reward[30] = { free = { type = "regeneration", durationHours = 12 }, deluxe = { type = "choiceItem", choices = exerciseWeapons, count = 1, charges = 3600 } }
+reward[31] = { deluxe = item(36725) }
+reward[32] = { deluxe = exercise(durableWeapons, 3600, true) }
+reward[33] = { free = exercise(lastingWeapons, 5400), deluxe = item(28558) }
+reward[34] = { deluxe = randomItem({ 3043, 2160 }, 1) }
+reward[35] = { deluxe = { type = "randomMount", mounts = { { id = 29, looktype = 502, name = "Ironblight" }, { id = 30, looktype = 503, name = "Magma Crawler" }, { id = 31, looktype = 506, name = "Dragonling" } } } }
+reward[36] = { free = { type = "doubleSkill", durationHours = 2 }, deluxe = exercise(lastingWeapons, 5400) }
+reward[37] = { deluxe = item(36726) }
+reward[38] = { deluxe = item(28558) }
+reward[39] = { free = item(28558), deluxe = { type = "prey", count = 5 } }
+reward[40] = { deluxe = { type = "multiItem", items = { { itemId = 36725, count = 1 }, { itemId = 36726, count = 1 } } } }
+reward[41] = { deluxe = { type = "extraSkill", count = 10, durationHours = 3 } }
+reward[42] = { free = item(36726), deluxe = { type = "regeneration", durationHours = 6 } }
+reward[43] = { deluxe = { type = "prey", count = 3 } }
+reward[44] = { deluxe = { type = "xpBoost", durationHours = 3, percent = 50 } }
+reward[45] = { free = { type = "prey", count = 3 }, deluxe = item(36725) }
+reward[46] = { deluxe = randomItem({ 3043, 2160, 36725 }, 1) }
+reward[47] = { deluxe = item(36726) }
+reward[48] = { free = { type = "doubleSkill", durationHours = 12 }, deluxe = { type = "doubleSkill", durationHours = 12 } }
+reward[49] = { free = { type = "xpBoost", durationHours = 2, percent = 50 }, deluxe = item(36725) }
+reward[50] = { free = { type = "level", count = 2 }, deluxe = { type = "outfit", male = { { looktype = 1289, name = "Dragon Slayer" } }, female = { { looktype = 1289, name = "Dragon Slayer" } }, addons = 3 } }

--- a/data/scripts/lib/reward_battlepass.lua
+++ b/data/scripts/lib/reward_battlepass.lua
@@ -21,8 +21,11 @@ BattlePassConfig = {
 		startsAt = 0,
 		durationDays = 35,
 		resetHour = 10,
-		maxStep = 50,
-		pointsPerStep = 100,
+		-- The existing Season 2 mission pool can award 6,775 points. Eighty
+		-- points per step keeps the 80-level track attainable without changing
+		-- the published mission values.
+		maxStep = 80,
+		pointsPerStep = 80,
 	},
 
 	deluxe = {
@@ -31,6 +34,24 @@ BattlePassConfig = {
 
 	reroll = {
 		goldPerLevel = 800,
+	},
+
+	-- The shop unlocks when the player completes level 80. From then until the
+	-- season ends, completed daily missions award their normal point value as
+	-- shop points. `shopPoints` can be added to an individual daily mission to
+	-- override that amount. All catalog data is seasonal and lives here.
+	shop = {
+		items = {
+			{ id = 1, type = "mount", title = "Black Sheep Mount", description = "A dark and dependable companion.", price = 250, mountId = 4, looktype = 371 },
+			{ id = 2, type = "mount", title = "Crystal Wolf Mount", description = "A fierce crystalline wolf mount.", price = 900, mountId = 16, looktype = 390 },
+			{ id = 3, type = "mount", title = "Dragonling Mount", description = "Ride a young dragonling into battle.", price = 1500, mountId = 31, looktype = 506 },
+			{ id = 4, type = "item", title = "Stamina Extension", description = "One stamina extension delivered to your Store Inbox.", price = 350, itemId = 36725, count = 1, repeatable = true },
+			{ id = 5, type = "item", title = "Training Dummy", description = "A training dummy delivered to your Store Inbox.", price = 700, itemId = 28558, count = 1, repeatable = true },
+			{ id = 6, type = "item", title = "Durable Exercise Weapon", description = "A durable exercise weapon for your training.", price = 900, itemId = 35279, count = 1, repeatable = true },
+			{ id = 7, type = "prey", title = "Prey Wildcards", description = "Receive two Prey wildcards.", price = 200, count = 2, repeatable = true },
+			{ id = 8, type = "charms", title = "Charm Points", description = "Receive 50 charm points.", price = 600, count = 50, repeatable = true },
+			{ id = 9, type = "outfit", title = "Dragon Slayer Outfit", description = "Unlock the Dragon Slayer outfit with the first addon.", price = 1800, male = { { looktype = 1289, name = "Dragon Slayer" } }, female = { { looktype = 1289, name = "Dragon Slayer" } }, addons = 1 },
+		},
 	},
 
 	dailyMissions = {
@@ -161,3 +182,27 @@ reward[47] = { deluxe = item(36726) }
 reward[48] = { free = { type = "doubleSkill", durationHours = 12 }, deluxe = { type = "doubleSkill", durationHours = 12 } }
 reward[49] = { free = { type = "xpBoost", durationHours = 2, percent = 50 }, deluxe = item(36725) }
 reward[50] = { free = { type = "level", count = 2 }, deluxe = { type = "outfit", male = { { looktype = 1289, name = "Dragon Slayer" } }, female = { { looktype = 1289, name = "Dragon Slayer" } }, addons = 3 } }
+
+-- Levels 51-80 keep the same supported reward types and only use ids that
+-- exist in this data pack. Change this table freely for a later season.
+local extendedRewards = {
+	{ free = item(3043, 5), deluxe = item(36725) },
+	{ deluxe = { type = "prey", count = 3 } },
+	{ free = exercise(exerciseWeapons, 3600), deluxe = exercise(durableWeapons, 3600, true) },
+	{ deluxe = { type = "charms", count = 50 } },
+	{ free = { type = "doubleSkill", durationHours = 3 }, deluxe = { type = "regeneration", durationHours = 6 } },
+	{ deluxe = item(28558) },
+	{ free = randomItem({ 3043, 2160 }, 2), deluxe = { type = "xpBoost", durationHours = 2, percent = 50 } },
+	{ deluxe = { type = "randomMount", mounts = { { id = 4, looktype = 371, name = "Black Sheep" }, { id = 16, looktype = 390, name = "Crystal Wolf" }, { id = 31, looktype = 506, name = "Dragonling" } } } },
+	{ free = { type = "prey", count = 2 }, deluxe = item(36726) },
+	{ deluxe = { type = "multiItem", items = { { itemId = 36725, count = 1 }, { itemId = 3043, count = 3 } } } },
+}
+
+for step = 51, 80 do
+	reward[step] = extendedRewards[((step - 51) % #extendedRewards) + 1]
+end
+
+reward[80] = {
+	free = { type = "level", count = 2 },
+	deluxe = { type = "outfit", male = { { looktype = 1289, name = "Dragon Slayer" } }, female = { { looktype = 1289, name = "Dragon Slayer" } }, addons = 3 },
+}

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -17,10 +17,13 @@ local REQUEST_GET_REWARDS = 2
 local REQUEST_REROLL = 3
 local REQUEST_REDEEM = 4
 local REQUEST_BUY_PREMIUM = 5
+local REQUEST_GET_SHOP = 6
+local REQUEST_BUY_SHOP = 7
 
 local RESPONSE_MISSIONS = 1
 local RESPONSE_REWARDS = 2
 local RESPONSE_ERROR = 3
+local RESPONSE_SHOP = 4
 
 local function supportsCustomNetwork(player)
 	return player and player.isUsingAstraClient and player:isUsingAstraClient()
@@ -38,6 +41,7 @@ local REQUEST_COOLDOWN_SECONDS = 1
 local rateLimitedActions = {
 	getMissions = true,
 	getRewards = true,
+	getShop = true,
 }
 local lastRequest = {}
 
@@ -128,10 +132,12 @@ local function ensureStateTables(state)
 	state.dailyAwarded = type(state.dailyAwarded) == "table" and state.dailyAwarded or {}
 	state.dailySlots = type(state.dailySlots) == "table" and state.dailySlots or {}
 	state.claimed = type(state.claimed) == "table" and state.claimed or {}
+	state.shopPurchases = type(state.shopPurchases) == "table" and state.shopPurchases or {}
 	state.points = clamp(state.points, 0, config.season.maxStep * config.season.pointsPerStep)
+	state.shopPoints = clamp(state.shopPoints, 0, 0xFFFFFFFF)
 	state.rerollCounter = tonumber(state.rerollCounter) or 0
 	state.premium = state.premium == true
-	state.completed = state.completed == true or state.points >= config.season.maxStep * config.season.pointsPerStep
+	state.completed = state.points >= config.season.maxStep * config.season.pointsPerStep
 end
 
 local function resetStateForSeason(season)
@@ -146,6 +152,8 @@ local function resetStateForSeason(season)
 		dailyProgress = {},
 		dailyAwarded = {},
 		claimed = {},
+		shopPurchases = {},
+		shopPoints = 0,
 		rerollCounter = 0,
 		completed = false,
 	}
@@ -203,6 +211,10 @@ local function addBattlePassPoints(state, amount)
 	local maxPoints = config.season.maxStep * config.season.pointsPerStep
 	state.points = clamp((tonumber(state.points) or 0) + amount, 0, maxPoints)
 	state.completed = state.points >= maxPoints
+end
+
+local function addShopPoints(state, amount)
+	state.shopPoints = clamp((tonumber(state.shopPoints) or 0) + amount, 0, 0xFFFFFFFF)
 end
 
 local function missionMatches(mission, monsterName)
@@ -421,6 +433,58 @@ local function makeItemThingValues(items)
 	return values
 end
 
+local shopTypes = {
+	item = 1,
+	mount = 2,
+	outfit = 3,
+	prey = 4,
+	charms = 5,
+}
+
+local function getShopEntries()
+	local shop = config.shop
+	return type(shop) == "table" and type(shop.items) == "table" and shop.items or {}
+end
+
+local function getShopEntry(shopId)
+	shopId = tonumber(shopId) or 0
+	for _, entry in ipairs(getShopEntries()) do
+		if tonumber(entry.id) == shopId then
+			return entry
+		end
+	end
+	return nil
+end
+
+local function getShopOutfit(player, entry)
+	local outfits = player:getSex() == PLAYERSEX_FEMALE and entry.female or entry.male
+	if type(outfits) ~= "table" or #outfits == 0 then
+		outfits = entry.male or entry.female or {}
+	end
+	return outfits[1]
+end
+
+local function isShopEntryPurchased(player, state, entry)
+	if entry.repeatable == true then
+		return false
+	end
+
+	local shopId = tostring(tonumber(entry.id) or 0)
+	if state.shopPurchases[shopId] == true then
+		return true
+	end
+	if entry.type == "mount" and tonumber(entry.mountId) and player:hasMount(tonumber(entry.mountId)) then
+		return true
+	end
+	if entry.type == "outfit" then
+		local outfit = getShopOutfit(player, entry)
+		if outfit and outfit.looktype and player:hasOutfit(outfit.looktype, tonumber(entry.addons) or 0) then
+			return true
+		end
+	end
+	return false
+end
+
 local function writeThingValues(out, values)
 	values = type(values) == "table" and values or {}
 	local count = math.min(#values, 0xFFFF)
@@ -530,6 +594,37 @@ local function getRequirementError(player)
 		end
 	end
 	return nil
+end
+
+function BattlePassSystem.sendShop(player)
+	local requirementError = getRequirementError(player)
+	if requirementError then
+		return sendBattlePassError(player, requirementError)
+	end
+
+	local state, store = loadState(player)
+	local entries = getShopEntries()
+	saveState(store, state)
+
+	return sendBattlePassMessage(player, RESPONSE_SHOP, function(out)
+		writeU32(out, state.shopPoints)
+		writeBool(out, state.completed)
+		writeU16(out, #entries)
+		for _, entry in ipairs(entries) do
+			local itemClientId = select(1, getItemTypeInfo(entry.itemId))
+			local outfit = entry.type == "outfit" and getShopOutfit(player, entry) or nil
+			writeU16(out, entry.id)
+			writeString(out, entry.title or entry.name or "Battle Pass Offer")
+			writeString(out, entry.description or "")
+			writeU32(out, entry.price)
+			out:addByte(clamp(shopTypes[entry.type] or 0, 0, 0xFF))
+			writeBool(out, entry.repeatable == true)
+			writeBool(out, isShopEntryPurchased(player, state, entry))
+			writeU16(out, itemClientId)
+			writeU16(out, entry.looktype or (outfit and outfit.looktype) or 0)
+			out:addByte(clamp(entry.addons, 0, 0xFF))
+		end
+	end)
 end
 
 function BattlePassSystem.sendMissions(player)
@@ -920,6 +1015,88 @@ local function deliverReward(player, reward, objectId)
 	return false, "Unsupported reward type."
 end
 
+local function deliverShopEntry(player, entry)
+	if entry.type == "item" then
+		return addItemsToBattlePassInbox(player, {
+			{ itemId = tonumber(entry.itemId) or 0, count = math.max(1, tonumber(entry.count) or 1), charges = math.max(0, tonumber(entry.charges) or 0) },
+		})
+	elseif entry.type == "mount" then
+		local mountId = tonumber(entry.mountId) or 0
+		if mountId <= 0 or player:hasMount(mountId) then
+			return false, "You already own this mount."
+		end
+		return player:addMount(mountId), "Could not add this mount."
+	elseif entry.type == "outfit" then
+		local outfit = getShopOutfit(player, entry)
+		if not outfit or not outfit.looktype then
+			return false, "This season has an invalid outfit configured."
+		end
+		local addons = math.max(0, tonumber(entry.addons) or 0)
+		if addons > 0 then
+			player:addOutfitAddon(outfit.looktype, addons)
+		else
+			player:addOutfit(outfit.looktype)
+		end
+		return true
+	elseif entry.type == "prey" then
+		local count = math.max(1, tonumber(entry.count) or 1)
+		if not PreySystem or not PreySystem.addWildcards or not PreySystem.addWildcards(player, count) then
+			return false, "Prey System is not available."
+		end
+		return true
+	elseif entry.type == "charms" then
+		local count = math.max(1, tonumber(entry.count) or 1)
+		if not db.query("UPDATE `players` SET `charmpoints` = `charmpoints` + " .. count .. " WHERE `id` = " .. player:getGuid()) then
+			return false, "Could not add charm points."
+		end
+		return true
+	end
+
+	return false, "Unsupported Battle Pass shop offer."
+end
+
+function BattlePassSystem.purchaseShopEntry(player, shopId)
+	local requirementError = getRequirementError(player)
+	if requirementError then
+		return false, requirementError
+	end
+
+	local state, store, season = loadState(player)
+	if os.time() < season.beginTime or os.time() >= season.endTime then
+		return false, "The Battle Pass season is not active."
+	end
+	if not state.completed then
+		return false, string.format("Complete Battle Pass level %d before using the shop.", config.season.maxStep)
+	end
+
+	local entry = getShopEntry(shopId)
+	if not entry then
+		return false, "Battle Pass shop offer not found."
+	end
+	if isShopEntryPurchased(player, state, entry) then
+		return false, "You already own this offer."
+	end
+
+	local price = math.max(0, tonumber(entry.price) or 0)
+	if state.shopPoints < price then
+		return false, "You do not have enough Battle Pass shop points."
+	end
+
+	local delivered, errorMessage = deliverShopEntry(player, entry)
+	if not delivered then
+		return false, errorMessage or "Could not deliver this offer."
+	end
+
+	state.shopPoints = state.shopPoints - price
+	if entry.repeatable ~= true then
+		state.shopPurchases[tostring(tonumber(entry.id) or 0)] = true
+	end
+	saveState(store, state)
+	player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "[Battle Pass] Shop offer purchased.")
+	BattlePassSystem.sendShop(player)
+	return true
+end
+
 function BattlePassSystem.redeemReward(player, data)
 	local step = tonumber(data and data.index) or 0
 	local rewardId = tonumber(data and data.rewardId) or 0
@@ -970,7 +1147,7 @@ function BattlePassSystem.rerollDailyMission(player, data)
 	end
 
 	local state, store, season, daily = loadState(player)
-	if state.completed or os.time() < season.beginTime or os.time() >= season.endTime then
+	if os.time() < season.beginTime or os.time() >= season.endTime then
 		player:sendCancelMessage("[Battle Pass] This season is not accepting mission progress.")
 		return false
 	end
@@ -1053,8 +1230,15 @@ local function updateMissionProgress(player, state, mission, daily, monsterName)
 
 	if current >= mission.maxProgress and not wasMissionAwarded(state, mission, daily) then
 		setMissionAwarded(state, mission, daily)
-		addBattlePassPoints(state, mission.points)
-		player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "[Battle Pass] Mission completed: " .. mission.name .. " (+" .. mission.points .. " points).")
+		if state.completed and daily then
+			local shopPoints = math.max(0, tonumber(mission.shopPoints) or tonumber(mission.points) or 0)
+			addShopPoints(state, shopPoints)
+			player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "[Battle Pass] Daily mission completed: " .. mission.name .. " (+" .. shopPoints .. " shop points).")
+		else
+			local battlePassPoints = math.max(0, tonumber(mission.points) or 0)
+			addBattlePassPoints(state, battlePassPoints)
+			player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "[Battle Pass] Mission completed: " .. mission.name .. " (+" .. battlePassPoints .. " points).")
+		end
 	end
 
 	return true
@@ -1073,7 +1257,7 @@ function BattlePassSystem.onKill(player, target)
 	end
 
 	local state, store, season, daily = loadState(player)
-	if state.completed or os.time() < season.beginTime or os.time() >= season.endTime then
+	if os.time() < season.beginTime or os.time() >= season.endTime then
 		return true
 	end
 
@@ -1082,10 +1266,10 @@ function BattlePassSystem.onKill(player, target)
 	local previousStep = getCurrentRewardStep(state.points)
 
 	local dailyMissions = getActiveDailyMissions(state, daily.key)
-	if not state.completed and dailyMissions[1] then
+	if dailyMissions[1] then
 		changed = updateMissionProgress(player, state, dailyMissions[1], true, monsterName) or changed
 	end
-	if not state.completed and isPremiumActive(state) and dailyMissions[2] then
+	if isPremiumActive(state) and dailyMissions[2] then
 		changed = updateMissionProgress(player, state, dailyMissions[2], true, monsterName) or changed
 	end
 
@@ -1100,6 +1284,9 @@ function BattlePassSystem.onKill(player, target)
 		sendMissionState(player, state, season, daily)
 		if getCurrentRewardStep(state.points) > previousStep then
 			BattlePassSystem.sendRewards(player)
+		end
+		if state.completed then
+			BattlePassSystem.sendShop(player)
 		end
 	end
 	return true
@@ -1141,6 +1328,7 @@ function BattlePassSystem.resetPlayer(player)
 	if supportsCustomNetwork(player) then
 		sendMissionState(player, state, season, daily)
 		BattlePassSystem.sendRewards(player)
+		BattlePassSystem.sendShop(player)
 	end
 	return true
 end
@@ -1194,10 +1382,19 @@ local function handleBattlePassRequest(player, action, data)
 		BattlePassSystem.sendMissions(player)
 	elseif action == "getRewards" then
 		BattlePassSystem.sendRewards(player)
+	elseif action == "getShop" then
+		BattlePassSystem.sendShop(player)
 	elseif action == "reroll" then
 		BattlePassSystem.rerollDailyMission(player, data)
 	elseif action == "redeem" then
 		BattlePassSystem.redeemReward(player, data)
+	elseif action == "buyShop" then
+		local success, errorMessage = BattlePassSystem.purchaseShopEntry(player, data.shopId)
+		if not success then
+			player:sendCancelMessage("[Battle Pass] " .. errorMessage)
+			sendBattlePassError(player, errorMessage)
+			BattlePassSystem.sendShop(player)
+		end
 	elseif action == "buyPremium" or action == "buyDeluxe" or action == "purchasePremium" then
 		local errorMessage = BattlePassSystem.purchasePremium(player)
 		if errorMessage then
@@ -1224,6 +1421,8 @@ function battlePassHandler.onReceive(player, msg)
 		return handleBattlePassRequest(player, "getMissions", {})
 	elseif request == REQUEST_GET_REWARDS then
 		return handleBattlePassRequest(player, "getRewards", {})
+	elseif request == REQUEST_GET_SHOP then
+		return handleBattlePassRequest(player, "getShop", {})
 	elseif request == REQUEST_REROLL then
 		local missionId = NetworkGuard.readString(msg, 128)
 		if not missionId then
@@ -1247,6 +1446,13 @@ function battlePassHandler.onReceive(player, msg)
 			rewardId = rewardId,
 			objectId = objectId,
 		})
+	elseif request == REQUEST_BUY_SHOP then
+		local shopId = NetworkGuard.readU16(msg)
+		if not shopId or shopId <= 0 then
+			sendBattlePassError(player, "Invalid Battle Pass shop offer.")
+			return true
+		end
+		return handleBattlePassRequest(player, "buyShop", { shopId = shopId })
 	elseif request == REQUEST_BUY_PREMIUM then
 		return handleBattlePassRequest(player, "buyPremium", {})
 	end

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -49,14 +49,24 @@ local dailyFreeMissions = config.dailyMissions and config.dailyMissions.free or 
 local dailyDeluxeMissions = config.dailyMissions and config.dailyMissions.deluxe or {}
 local generalMissions = config.generalMissions or {}
 local missionById = {}
-for _, mission in ipairs(dailyFreeMissions) do
+local function registerMission(mission, poolName)
+	if type(mission) ~= "table" or not mission.id then
+		return
+	end
+	if missionById[mission.id] then
+		error(string.format("[Battle Pass] Duplicate mission id '%s' in %s.", tostring(mission.id), poolName))
+	end
 	missionById[mission.id] = mission
+end
+
+for _, mission in ipairs(dailyFreeMissions) do
+	registerMission(mission, "daily free missions")
 end
 for _, mission in ipairs(dailyDeluxeMissions) do
-	missionById[mission.id] = mission
+	registerMission(mission, "daily deluxe missions")
 end
 for _, mission in ipairs(generalMissions) do
-	missionById[mission.id] = mission
+	registerMission(mission, "general missions")
 end
 
 local function normalizeName(name)
@@ -86,7 +96,7 @@ local function getSeason()
 	local epoch = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonEpoch)) or -1
 	local beginTime = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt)) or -1
 
-	if activeConfigId ~= configuredId or epoch < 1 or beginTime < 1 then
+	if epoch < 1 or beginTime < 1 then
 		epoch = math.max(1, epoch + 1)
 		beginTime = tonumber(seasonConfig.startsAt) or 0
 		if beginTime <= 0 then
@@ -94,6 +104,9 @@ local function getSeason()
 		end
 		Game.setStorageValue(GlobalStorageKeys.battlePassSeasonEpoch, epoch)
 		Game.setStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt, beginTime)
+	end
+
+	if activeConfigId ~= configuredId then
 		store:set("configId", configuredId)
 	end
 
@@ -529,10 +542,16 @@ local function writeRewardItems(out, items)
 	local count = math.min(#items, 0xFFFF)
 	writeU16(out, count)
 	for index = 1, count do
-		local item = items[index] or {}
-		writeU16(out, item.itemId)
-		writeU16(out, item.count)
-		writeBool(out, item.stuck)
+		local item = items[index]
+		if type(item) == "table" then
+			writeU16(out, item.itemId or item.thingId)
+			writeU16(out, item.count)
+			writeBool(out, item.stuck)
+		else
+			writeU16(out, item)
+			writeU16(out, 1)
+			writeBool(out, false)
+		end
 	end
 end
 
@@ -840,14 +859,14 @@ local function findReward(step, rewardId)
 	local configuredStep = config.rewards[step] or {}
 	if configuredStep.free then
 		local freeReward = makeReward(step, true, configuredStep.free)
-		if freeReward.rewardId == rewardId then
+		if freeReward and freeReward.rewardId == rewardId then
 			return freeReward
 		end
 	end
 
 	if configuredStep.deluxe then
 		local premiumReward = makeReward(step, false, configuredStep.deluxe)
-		if premiumReward.rewardId == rewardId then
+		if premiumReward and premiumReward.rewardId == rewardId then
 			return premiumReward
 		end
 	end
@@ -1331,6 +1350,25 @@ function BattlePassSystem.resetPlayer(player)
 		BattlePassSystem.sendShop(player)
 	end
 	return true
+end
+
+function BattlePassSystem.addShopPoints(player, amount)
+	if not player then
+		return false, "Player not found."
+	end
+
+	amount = math.floor(tonumber(amount) or 0)
+	if amount <= 0 then
+		return false, "Amount must be greater than zero."
+	end
+
+	local state, store = loadState(player)
+	addShopPoints(state, amount)
+	saveState(store, state)
+	if supportsCustomNetwork(player) then
+		BattlePassSystem.sendShop(player)
+	end
+	return true, state.shopPoints
 end
 
 function BattlePassSystem.startNewSeason()

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -1362,10 +1362,16 @@ function BattlePassSystem.addShopPoints(player, amount)
 		return false, "Amount must be greater than zero."
 	end
 
-	local state, store = loadState(player)
+	local state, store, season, daily = loadState(player)
+	if not state.completed then
+		state.points = config.season.maxStep * config.season.pointsPerStep
+		ensureStateTables(state)
+	end
 	addShopPoints(state, amount)
 	saveState(store, state)
 	if supportsCustomNetwork(player) then
+		sendMissionState(player, state, season, daily)
+		BattlePassSystem.sendRewards(player)
 		BattlePassSystem.sendShop(player)
 	end
 	return true, state.shopPoints

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -1371,6 +1371,23 @@ function BattlePassSystem.addShopPoints(player, amount)
 	return true, state.shopPoints
 end
 
+function BattlePassSystem.unlockShop(player)
+	if not player then
+		return false, "Player not found."
+	end
+
+	local state, store, season, daily = loadState(player)
+	state.points = config.season.maxStep * config.season.pointsPerStep
+	ensureStateTables(state)
+	saveState(store, state)
+	if supportsCustomNetwork(player) then
+		sendMissionState(player, state, season, daily)
+		BattlePassSystem.sendRewards(player)
+		BattlePassSystem.sendShop(player)
+	end
+	return true
+end
+
 function BattlePassSystem.startNewSeason()
 	local seasonStore = getSeasonStore()
 	local currentEpoch = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonEpoch)) or 0

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -42,6 +42,7 @@ local rateLimitedActions = {
 	getMissions = true,
 	getRewards = true,
 	getShop = true,
+	buyShop = true,
 }
 local lastRequest = {}
 
@@ -51,7 +52,7 @@ local generalMissions = config.generalMissions or {}
 local missionById = {}
 local function registerMission(mission, poolName)
 	if type(mission) ~= "table" or not mission.id then
-		return
+		error(string.format("[Battle Pass] Malformed mission in %s. Every mission must be a table with an id.", poolName))
 	end
 	if missionById[mission.id] then
 		error(string.format("[Battle Pass] Duplicate mission id '%s' in %s.", tostring(mission.id), poolName))
@@ -630,7 +631,10 @@ function BattlePassSystem.sendShop(player)
 		writeBool(out, state.completed)
 		writeU16(out, #entries)
 		for _, entry in ipairs(entries) do
-			local itemClientId = select(1, getItemTypeInfo(entry.itemId))
+			local itemClientId = 0
+			if entry.type == "item" then
+				itemClientId = select(1, getItemTypeInfo(entry.itemId))
+			end
 			local outfit = entry.type == "outfit" and getShopOutfit(player, entry) or nil
 			writeU16(out, entry.id)
 			writeString(out, entry.title or entry.name or "Battle Pass Offer")
@@ -1050,13 +1054,18 @@ local function deliverShopEntry(player, entry)
 		if not outfit or not outfit.looktype then
 			return false, "This season has an invalid outfit configured."
 		end
-		local addons = math.max(0, tonumber(entry.addons) or 0)
-		if addons > 0 then
-			player:addOutfitAddon(outfit.looktype, addons)
-		else
-			player:addOutfit(outfit.looktype)
+		local looktype = tonumber(outfit.looktype) or 0
+		if looktype <= 0 then
+			return false, "This season has an invalid outfit configured."
 		end
-		return true
+		local addons = math.max(0, tonumber(entry.addons) or 0)
+		local delivered
+		if addons > 0 then
+			delivered = player:addOutfitAddon(looktype, addons)
+		else
+			delivered = player:addOutfit(looktype)
+		end
+		return delivered, "Could not add this outfit."
 	elseif entry.type == "prey" then
 		local count = math.max(1, tonumber(entry.count) or 1)
 		if not PreySystem or not PreySystem.addWildcards or not PreySystem.addWildcards(player, count) then
@@ -1168,6 +1177,11 @@ function BattlePassSystem.rerollDailyMission(player, data)
 	local state, store, season, daily = loadState(player)
 	if os.time() < season.beginTime or os.time() >= season.endTime then
 		player:sendCancelMessage("[Battle Pass] This season is not accepting mission progress.")
+		return false
+	end
+	local requirementError = getRequirementError(player)
+	if requirementError then
+		player:sendCancelMessage("[Battle Pass] " .. requirementError)
 		return false
 	end
 	getActiveDailyMissions(state, daily.key)

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -334,7 +334,7 @@ local function buildMissionsPayload(player, state, season, daily)
 		beginTime = season.beginTime,
 		endTime = season.endTime,
 		points = state.points,
-		rerollPrice = config.reroll.goldPerLevel,
+		rerollPrice = (tonumber(config.reroll.goldPerLevel) or 800) * player:getLevel(),
 		deluxePrice = config.deluxe.price,
 		battlePassActive = isPremiumActive(state),
 		currentRewardStep = currentRewardStep,
@@ -653,7 +653,6 @@ end
 function BattlePassSystem.sendMissions(player)
 	local requirementError = getRequirementError(player)
 	if requirementError then
-		player:sendCancelMessage("[Battle Pass] " .. requirementError)
 		return sendBattlePassError(player, requirementError)
 	end
 	local state, store, season, daily = loadState(player)
@@ -752,7 +751,6 @@ end
 local function setRewardClaimState(reward, state)
 	local claimed = state.claimed[tostring(reward.rewardId)] == true
 	reward.hasClaimedReward = claimed
-	reward.hasClamedReward = claimed
 end
 
 local function buildRewardSteps(state)
@@ -838,7 +836,7 @@ function BattlePassSystem.sendRewards(player)
 					writeU16(out, reward.count)
 					writeU16(out, reward.charges)
 					writeBool(out, reward.stuck)
-					writeBool(out, reward.hasClaimedReward or reward.hasClamedReward)
+					writeBool(out, reward.hasClaimedReward)
 					writeU32(out, reward.durationTime)
 					out:addByte(clamp(reward.addons, 0, 0xFF))
 					writeThingValues(out, randomValues)
@@ -973,18 +971,27 @@ local function deliverReward(player, reward, objectId)
 		end
 		return true
 	elseif definition.type == "outfit" then
-		local outfits = player:getSex() == PLAYERSEX_FEMALE and definition.female or definition.male
+		local primaryOutfits = player:getSex() == PLAYERSEX_FEMALE and definition.female or definition.male
+		local fallbackOutfits = player:getSex() == PLAYERSEX_FEMALE and definition.male or definition.female
+		local outfits = primaryOutfits or fallbackOutfits or {}
+		if #outfits == 0 and fallbackOutfits and fallbackOutfits ~= outfits then
+			outfits = fallbackOutfits
+		end
 		if #outfits == 0 then
-			outfits = definition.male or definition.female or {}
+			return false, "This season has an empty outfit reward."
 		end
 		for _, outfit in ipairs(outfits) do
+			local delivered
 			if definition.addons and definition.addons > 0 then
-				player:addOutfitAddon(outfit.looktype, definition.addons)
+				delivered = player:addOutfitAddon(outfit.looktype, definition.addons)
 			else
-				player:addOutfit(outfit.looktype)
+				delivered = player:addOutfit(outfit.looktype)
+			end
+			if delivered == false then
+				return false, "Could not add this outfit."
 			end
 		end
-		return #outfits > 0, #outfits > 0 and nil or "This season has an empty outfit reward."
+		return true
 	elseif definition.type == "level" then
 		return player:addLevel(reward.count), "Could not add the level reward."
 	elseif definition.type == "prey" then
@@ -1297,6 +1304,8 @@ function BattlePassSystem.onKill(player, target)
 	local monsterName = target:getName()
 	local changed = false
 	local previousStep = getCurrentRewardStep(state.points)
+	local wasCompleted = state.completed
+	local previousShopPoints = state.shopPoints
 
 	local dailyMissions = getActiveDailyMissions(state, daily.key)
 	if dailyMissions[1] then
@@ -1318,7 +1327,7 @@ function BattlePassSystem.onKill(player, target)
 		if getCurrentRewardStep(state.points) > previousStep then
 			BattlePassSystem.sendRewards(player)
 		end
-		if state.completed then
+		if (not wasCompleted and state.completed) or state.shopPoints ~= previousShopPoints then
 			BattlePassSystem.sendShop(player)
 		end
 	end
@@ -1378,8 +1387,7 @@ function BattlePassSystem.addShopPoints(player, amount)
 
 	local state, store, season, daily = loadState(player)
 	if not state.completed then
-		state.points = config.season.maxStep * config.season.pointsPerStep
-		ensureStateTables(state)
+		return false, string.format("Complete Battle Pass level %d before adding shop points. Use /battlepass unlockshop <player> for testing.", config.season.maxStep)
 	end
 	addShopPoints(state, amount)
 	saveState(store, state)

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -29,14 +29,10 @@ end
 local DAY_SECONDS = 24 * 60 * 60
 local WEEK_SECONDS = 7 * DAY_SECONDS
 
-local config = {
-	seasonAnchor = os.time({ year = 2024, month = 1, day = 1, hour = 10, min = 0, sec = 0 }),
-	seasonWeeks = 5,
-	maxStep = 50,
-	pointsPerStep = 100,
-	dailyRerollBasePrice = 1000,
-	deluxePrice = 250,
-}
+local config = BattlePassConfig
+if type(config) ~= "table" then
+	error("Battle Pass configuration was not loaded. Check data/scripts/lib/reward_battlepass.lua")
+end
 
 local REQUEST_COOLDOWN_SECONDS = 1
 local rateLimitedActions = {
@@ -45,55 +41,14 @@ local rateLimitedActions = {
 }
 local lastRequest = {}
 
-local freeRewardSteps = {
-	[3] = true, [6] = true, [9] = true, [12] = true, [15] = true, [18] = true,
-	[21] = true, [24] = true, [27] = true, [30] = true, [33] = true, [36] = true,
-	[39] = true, [42] = true, [45] = true, [48] = true, [49] = true, [50] = true,
-}
-
-local dailyMissionPool = {
-	{ id = "daily_any_50", name = "Daily Hunt", description = "Kill 50 creatures.", rewardPoints = 50, maxProgress = 50, targets = "*" },
-	{ id = "daily_any_100", name = "Daily Grinder", description = "Kill 100 creatures.", rewardPoints = 75, maxProgress = 100, targets = "*" },
-	{ id = "daily_rotworm", name = "Rotworm Cleanup", description = "Kill 40 rotworms.", rewardPoints = 50, maxProgress = 40, targets = { "rotworm", "carrion worm" } },
-	{ id = "daily_troll", name = "Troll Patrol", description = "Kill 40 trolls.", rewardPoints = 50, maxProgress = 40, targets = { "troll", "swamp troll", "frost troll" } },
-	{ id = "daily_orc", name = "Orc Skirmish", description = "Kill 40 orcs.", rewardPoints = 60, maxProgress = 40, targets = { "orc", "orc spearman", "orc warrior", "orc berserker", "orc leader" } },
-	{ id = "daily_cyclops", name = "One-Eyed Trouble", description = "Kill 20 cyclops.", rewardPoints = 60, maxProgress = 20, targets = { "cyclops", "cyclops smith", "cyclops drone" } },
-	{ id = "daily_dragon", name = "Dragon Pressure", description = "Kill 10 dragons or dragon lords.", rewardPoints = 75, maxProgress = 10, targets = { "dragon", "dragon lord" } },
-}
-
-local generalMissions = {
-	{ id = "season_any_150", name = "Fresh Start", description = "Kill 150 creatures during this season.", rewardPoints = 100, maxProgress = 150, targets = "*" },
-	{ id = "season_rotworm_120", name = "Tunnel Sweep", description = "Kill 120 rotworms.", rewardPoints = 100, maxProgress = 120, targets = { "rotworm", "carrion worm" } },
-	{ id = "season_troll_120", name = "Troll Breaker", description = "Kill 120 trolls.", rewardPoints = 100, maxProgress = 120, targets = { "troll", "swamp troll", "frost troll" } },
-	{ id = "season_goblin_120", name = "Goblin Control", description = "Kill 120 goblins.", rewardPoints = 100, maxProgress = 120, targets = { "goblin", "goblin assassin", "goblin leader", "goblin scavenger" } },
-	{ id = "season_minotaur_120", name = "Maze Breaker", description = "Kill 120 minotaurs.", rewardPoints = 100, maxProgress = 120, targets = { "minotaur", "minotaur archer", "minotaur guard", "minotaur mage" } },
-	{ id = "season_orc_150", name = "Orc Campaign", description = "Kill 150 orcs.", rewardPoints = 100, maxProgress = 150, targets = { "orc", "orc spearman", "orc warrior", "orc berserker", "orc leader", "orc warlord" } },
-	{ id = "season_dwarf_120", name = "Dwarf Advance", description = "Kill 120 dwarves.", rewardPoints = 100, maxProgress = 120, targets = { "dwarf", "dwarf soldier", "dwarf guard", "dwarf geomancer" } },
-	{ id = "season_amazon_100", name = "Amazon Trail", description = "Kill 100 amazons or valkyries.", rewardPoints = 100, maxProgress = 100, targets = { "amazon", "valkyrie" } },
-	{ id = "season_undead_150", name = "Restless Dead", description = "Kill 150 undead creatures.", rewardPoints = 100, maxProgress = 150, targets = { "skeleton", "ghoul", "crypt shambler", "mummy", "vampire", "lich" } },
-	{ id = "season_larva_120", name = "Desert Nest", description = "Kill 120 larvas or scarabs.", rewardPoints = 100, maxProgress = 120, targets = { "larva", "scarab", "ancient scarab" } },
-	{ id = "season_slime_80", name = "Slime Splitter", description = "Kill 80 slimes.", rewardPoints = 100, maxProgress = 80, targets = { "slime" } },
-
-	{ id = "season_any_350", name = "Battle Routine", description = "Kill 350 creatures during this season.", rewardPoints = 200, maxProgress = 350, targets = "*" },
-	{ id = "season_cyclops_100", name = "Cyclops Camp", description = "Kill 100 cyclops.", rewardPoints = 200, maxProgress = 100, targets = { "cyclops", "cyclops smith", "cyclops drone" } },
-	{ id = "season_dragon_80", name = "Dragon Hunter", description = "Kill 80 dragons.", rewardPoints = 200, maxProgress = 80, targets = { "dragon" } },
-	{ id = "season_gs_40", name = "Web Cleaner", description = "Kill 40 giant spiders.", rewardPoints = 200, maxProgress = 40, targets = { "giant spider" } },
-	{ id = "season_vampire_60", name = "Night Watch", description = "Kill 60 vampires.", rewardPoints = 200, maxProgress = 60, targets = { "vampire", "vampire bride", "vampire viscount" } },
-	{ id = "season_necro_60", name = "Necromancer Hunt", description = "Kill 60 necromancers or priests.", rewardPoints = 200, maxProgress = 60, targets = { "necromancer", "priestess", "blood priest" } },
-	{ id = "season_hero_50", name = "Hero Trial", description = "Kill 50 heroes or black knights.", rewardPoints = 200, maxProgress = 50, targets = { "hero", "black knight" } },
-	{ id = "season_beholder_80", name = "Evil Eyes", description = "Kill 80 beholders.", rewardPoints = 200, maxProgress = 80, targets = { "beholder", "elder beholder", "bonelord", "elder bonelord" } },
-	{ id = "season_dragon_lord_40", name = "Dragon Lord Hunt", description = "Kill 40 dragon lords.", rewardPoints = 200, maxProgress = 40, targets = { "dragon lord" } },
-	{ id = "season_hydra_30", name = "Hydra Heads", description = "Kill 30 hydras.", rewardPoints = 200, maxProgress = 30, targets = { "hydra" } },
-	{ id = "season_serpent_30", name = "Serpent Strike", description = "Kill 30 serpent spawns.", rewardPoints = 200, maxProgress = 30, targets = { "serpent spawn" } },
-
-	{ id = "season_any_800", name = "Season Veteran", description = "Kill 800 creatures during this season.", rewardPoints = 300, maxProgress = 800, targets = "*" },
-	{ id = "season_demon_25", name = "Demon Contract", description = "Kill 25 demons.", rewardPoints = 300, maxProgress = 25, targets = { "demon" } },
-	{ id = "season_dragon_family_200", name = "Wyrm Scale", description = "Kill 200 dragons, dragon lords or wyrms.", rewardPoints = 300, maxProgress = 200, targets = { "dragon", "dragon lord", "wyrm" } },
-	{ id = "season_strong_120", name = "Stronghold Breaker", description = "Kill 120 strong creatures.", rewardPoints = 300, maxProgress = 120, targets = { "warlock", "demon", "hydra", "serpent spawn", "frost dragon", "behemoth" } },
-}
-
+local dailyFreeMissions = config.dailyMissions and config.dailyMissions.free or {}
+local dailyDeluxeMissions = config.dailyMissions and config.dailyMissions.deluxe or {}
+local generalMissions = config.generalMissions or {}
 local missionById = {}
-for _, mission in ipairs(dailyMissionPool) do
+for _, mission in ipairs(dailyFreeMissions) do
+	missionById[mission.id] = mission
+end
+for _, mission in ipairs(dailyDeluxeMissions) do
 	missionById[mission.id] = mission
 end
 for _, mission in ipairs(generalMissions) do
@@ -115,27 +70,42 @@ local function clamp(value, minValue, maxValue)
 	return value
 end
 
-local function getSeason()
-	local now = os.time()
-	local seasonLength = config.seasonWeeks * WEEK_SECONDS
-	local seasonIndex = 1
+local function getSeasonStore()
+	return kv.scoped("battlepass"):scoped("season")
+end
 
-	if now >= config.seasonAnchor then
-		seasonIndex = math.floor((now - config.seasonAnchor) / seasonLength) + 1
+local function getSeason()
+	local seasonConfig = config.season or {}
+	local store = getSeasonStore()
+	local configuredId = tostring(seasonConfig.id or "season")
+	local activeConfigId = store:get("configId")
+	local epoch = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonEpoch)) or -1
+	local beginTime = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt)) or -1
+
+	if activeConfigId ~= configuredId or epoch < 1 or beginTime < 1 then
+		epoch = math.max(1, epoch + 1)
+		beginTime = tonumber(seasonConfig.startsAt) or 0
+		if beginTime <= 0 then
+			beginTime = os.time()
+		end
+		Game.setStorageValue(GlobalStorageKeys.battlePassSeasonEpoch, epoch)
+		Game.setStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt, beginTime)
+		store:set("configId", configuredId)
 	end
 
-	local beginTime = config.seasonAnchor + ((seasonIndex - 1) * seasonLength)
+	local durationDays = math.max(1, tonumber(seasonConfig.durationDays) or 35)
 	return {
-		id = "astra-season-" .. seasonIndex,
+		id = configuredId .. ":" .. epoch,
+		epoch = epoch,
 		beginTime = beginTime,
-		endTime = beginTime + seasonLength,
+		endTime = beginTime + durationDays * DAY_SECONDS,
 	}
 end
 
 local function getDailyWindow()
 	local now = os.time()
 	local date = os.date("*t", now)
-	local beginTime = os.time({ year = date.year, month = date.month, day = date.day, hour = 10, min = 0, sec = 0 })
+	local beginTime = os.time({ year = date.year, month = date.month, day = date.day, hour = tonumber(config.season.resetHour) or 10, min = 0, sec = 0 })
 	if now < beginTime then
 		beginTime = beginTime - DAY_SECONDS
 	end
@@ -158,9 +128,10 @@ local function ensureStateTables(state)
 	state.dailyAwarded = type(state.dailyAwarded) == "table" and state.dailyAwarded or {}
 	state.dailySlots = type(state.dailySlots) == "table" and state.dailySlots or {}
 	state.claimed = type(state.claimed) == "table" and state.claimed or {}
-	state.points = clamp(state.points, 0, config.maxStep * config.pointsPerStep)
+	state.points = clamp(state.points, 0, config.season.maxStep * config.season.pointsPerStep)
 	state.rerollCounter = tonumber(state.rerollCounter) or 0
 	state.premium = state.premium == true
+	state.completed = state.completed == true or state.points >= config.season.maxStep * config.season.pointsPerStep
 end
 
 local function resetStateForSeason(season)
@@ -176,6 +147,7 @@ local function resetStateForSeason(season)
 		dailyAwarded = {},
 		claimed = {},
 		rerollCounter = 0,
+		completed = false,
 	}
 end
 
@@ -187,6 +159,7 @@ local function loadState(player)
 
 	if type(state) ~= "table" or state.seasonId ~= season.id then
 		state = resetStateForSeason(season)
+		player:setStorageValue(PlayerStorageKeys.battlePassSeasonEpoch, season.epoch)
 	else
 		ensureStateTables(state)
 	end
@@ -227,8 +200,9 @@ local function setMissionAwarded(state, mission, daily)
 end
 
 local function addBattlePassPoints(state, amount)
-	local maxPoints = config.maxStep * config.pointsPerStep
+	local maxPoints = config.season.maxStep * config.season.pointsPerStep
 	state.points = clamp((tonumber(state.points) or 0) + amount, 0, maxPoints)
+	state.completed = state.points >= maxPoints
 end
 
 local function missionMatches(mission, monsterName)
@@ -253,21 +227,24 @@ local function getMissionPayload(state, mission, daily)
 		missionDescription = mission.description,
 		currentProgress = progress,
 		maxProgress = mission.maxProgress,
-		rewardPoints = mission.rewardPoints,
+		rewardPoints = mission.points,
 	}
 end
 
 local function getDailyMissionBySlot(state, slot, dailyKey)
-	if not state.dailySlots[tostring(slot)] then
-		local daySeed = tonumber(dailyKey) or math.floor(os.time() / DAY_SECONDS)
-		local firstIndex = (daySeed % #dailyMissionPool) + 1
-		local secondIndex = ((firstIndex + 3) % #dailyMissionPool) + 1
-
-		state.dailySlots["1"] = dailyMissionPool[firstIndex].id
-		state.dailySlots["2"] = dailyMissionPool[secondIndex].id
+	local pool = slot == 1 and dailyFreeMissions or dailyDeluxeMissions
+	if #pool == 0 then
+		return nil
 	end
 
-	return missionById[state.dailySlots[tostring(slot)]]
+	local key = tostring(slot)
+	if not state.dailySlots[key] then
+		local daySeed = tonumber(dailyKey) or math.floor(os.time() / DAY_SECONDS)
+		local index = ((daySeed + slot * 7) % #pool) + 1
+		state.dailySlots[key] = pool[index].id
+	end
+
+	return missionById[state.dailySlots[key]]
 end
 
 local function getActiveDailyMissions(state, dailyKey)
@@ -294,12 +271,23 @@ local function isPremiumActive(state)
 end
 
 local function getCurrentRewardStep(points)
-	return math.min(config.maxStep, math.floor((tonumber(points) or 0) / config.pointsPerStep))
+	return math.min(config.season.maxStep, math.floor((tonumber(points) or 0) / config.season.pointsPerStep))
+end
+
+local function getCurrentWeek(season)
+	if os.time() < season.beginTime then
+		return 0
+	end
+	return math.max(1, math.min(math.ceil((os.time() - season.beginTime + 1) / WEEK_SECONDS), math.ceil((season.endTime - season.beginTime) / WEEK_SECONDS)))
+end
+
+local function isGeneralMissionUnlocked(mission, season)
+	return tonumber(mission.unlockWeek) == nil or tonumber(mission.unlockWeek) <= getCurrentWeek(season)
 end
 
 local function buildMissionsPayload(player, state, season, daily)
 	local currentRewardStep = getCurrentRewardStep(state.points)
-	local nextStepPoints = math.min((currentRewardStep + 1) * config.pointsPerStep, config.maxStep * config.pointsPerStep)
+	local nextStepPoints = math.min((currentRewardStep + 1) * config.season.pointsPerStep, config.season.maxStep * config.season.pointsPerStep)
 
 	local dailyMissions = {}
 	for _, mission in ipairs(getActiveDailyMissions(state, daily.key)) do
@@ -310,7 +298,9 @@ local function buildMissionsPayload(player, state, season, daily)
 
 	local generalPayload = {}
 	for _, mission in ipairs(generalMissions) do
-		table.insert(generalPayload, getMissionPayload(state, mission, false))
+		if isGeneralMissionUnlocked(mission, season) then
+			table.insert(generalPayload, getMissionPayload(state, mission, false))
+		end
 	end
 
 	return {
@@ -318,8 +308,8 @@ local function buildMissionsPayload(player, state, season, daily)
 		beginTime = season.beginTime,
 		endTime = season.endTime,
 		points = state.points,
-		rerollPrice = config.dailyRerollBasePrice,
-		deluxePrice = config.deluxePrice,
+		rerollPrice = config.reroll.goldPerLevel,
+		deluxePrice = config.deluxe.price,
 		battlePassActive = isPremiumActive(state),
 		currentRewardStep = currentRewardStep,
 		nextStepPoints = nextStepPoints,
@@ -422,7 +412,11 @@ local function makeItemThingValues(items)
 	items = type(items) == "table" and items or {}
 	for index = 1, math.min(#items, 0xFFFF) do
 		local item = items[index] or {}
-		values[index] = makeItemThingValue(item.itemId or item.thingId, item.itemName or item.thingName)
+		if type(item) == "table" then
+			values[index] = makeItemThingValue(item.itemId or item.thingId, item.itemName or item.thingName)
+		else
+			values[index] = makeItemThingValue(item)
+		end
 	end
 	return values
 end
@@ -524,40 +518,117 @@ local function sendMissionState(player, state, season, daily)
 	end)
 end
 
+local function getRequirementError(player)
+	local requirements = config.requirements or {}
+	if player:getLevel() < (tonumber(requirements.minimumLevel) or 8) then
+		return string.format("You need level %d to use the Battle Pass.", tonumber(requirements.minimumLevel) or 8)
+	end
+	if requirements.requireVocation then
+		local vocation = player:getVocation()
+		if not vocation or vocation:getId() <= 0 then
+			return "You need to choose a vocation to use the Battle Pass."
+		end
+	end
+	return nil
+end
+
 function BattlePassSystem.sendMissions(player)
+	local requirementError = getRequirementError(player)
+	if requirementError then
+		player:sendCancelMessage("[Battle Pass] " .. requirementError)
+		return sendBattlePassError(player, requirementError)
+	end
 	local state, store, season, daily = loadState(player)
 	saveState(store, state)
 	return sendMissionState(player, state, season, daily)
 end
 
-local function makeReward(step, freeReward)
-	local rewardId = step * 10 + (freeReward and 1 or 2)
-	local count = freeReward and math.max(1, math.floor(step / 6)) or math.max(1, math.floor(step / 3))
+local rewardTypes = {
+	item = 1,
+	randomItem = 2,
+	randomMount = 3,
+	exercise = 4,
+	doubleSkill = 5,
+	level = 6,
+	prey = 7,
+	xpBoost = 8,
+	regeneration = 9,
+	overloadForge = 10,
+	instantReward = 11,
+	boostedExercise = 12,
+	charms = 13,
+	outfit = 14,
+	extraSkill = 15,
+	elementalOutfit = 16,
+	multiItem = 17,
+	choiceItem = 18,
+}
 
-	if step >= 45 then
-		count = count + (freeReward and 2 or 5)
-	elseif step >= 30 then
-		count = count + (freeReward and 1 or 3)
+local function makeMountValues(mounts)
+	local values = {}
+	for index, mount in ipairs(mounts or {}) do
+		values[index] = {
+			thingId = tonumber(mount.looktype) or 0,
+			thingName = tostring(mount.name or "Mount"),
+		}
+	end
+	return values
+end
+
+local function makeOutfitValues(outfits)
+	local values = {}
+	for index, outfit in ipairs(outfits or {}) do
+		values[index] = {
+			thingId = tonumber(outfit.looktype) or 0,
+			thingName = tostring(outfit.name or "Outfit"),
+		}
+	end
+	return values
+end
+
+local function makeReward(step, freeReward, definition)
+	if type(definition) ~= "table" then
+		return nil
 	end
 
-	return {
-		rewardId = rewardId,
-		rewardType = 1,
+	local rewardType = rewardTypes[definition.type]
+	if not rewardType then
+		print(string.format("[Battle Pass] Invalid reward type '%s' at step %d.", tostring(definition.type), step))
+		return nil
+	end
+
+	local reward = {
+		rewardId = step * 10 + (freeReward and 1 or 2),
+		rewardType = rewardType,
 		freeReward = freeReward,
-		-- TODO: Replace the placeholder Crystal Coin rewards with the final season reward table.
-		itemId = 3043,
-		count = count,
-		charges = 0,
-		stuck = false,
+		itemId = tonumber(definition.itemId) or 0,
+		count = math.max(1, tonumber(definition.count) or 1),
+		charges = math.max(0, tonumber(definition.charges) or 0),
+		stuck = definition.stuck == true,
 		hasClaimedReward = false,
-		durationTime = 0,
-		addons = 0,
+		durationTime = math.max(0, tonumber(definition.durationHours) or 0),
+		addons = math.max(0, tonumber(definition.addons) or 0),
 		randomValues = {},
 		choosableValues = {},
-		maleOutfit = {},
-		femaleOutfit = {},
-		items = {},
+		maleOutfit = definition.maleOutfit or {},
+		femaleOutfit = definition.femaleOutfit or {},
+		items = definition.items or {},
+		definition = definition,
 	}
+
+	if definition.type == "randomMount" then
+		reward.randomValues = makeMountValues(definition.mounts)
+	elseif definition.type == "outfit" then
+		reward.randomValues = makeOutfitValues(definition.male)
+		if #reward.randomValues == 0 then
+			reward.randomValues = makeOutfitValues(definition.female)
+		end
+	elseif definition.type == "elementalOutfit" then
+		reward.maleOutfit = definition.maleOutfit or {}
+		reward.femaleOutfit = definition.femaleOutfit or {}
+	end
+
+	return reward
 end
 
 local function setRewardClaimState(reward, state)
@@ -568,18 +639,25 @@ end
 
 local function buildRewardSteps(state)
 	local steps = {}
-	for step = 1, config.maxStep do
+	for step = 1, config.season.maxStep do
 		local rewards = {}
+		local configuredStep = config.rewards[step] or {}
 
-		if freeRewardSteps[step] then
-			local freeReward = makeReward(step, true)
+		if configuredStep.free then
+			local freeReward = makeReward(step, true, configuredStep.free)
+			if freeReward then
 			setRewardClaimState(freeReward, state)
 			table.insert(rewards, freeReward)
+			end
 		end
 
-		local premiumReward = makeReward(step, false)
-		setRewardClaimState(premiumReward, state)
-		table.insert(rewards, premiumReward)
+		if configuredStep.deluxe then
+			local premiumReward = makeReward(step, false, configuredStep.deluxe)
+			if premiumReward then
+				setRewardClaimState(premiumReward, state)
+				table.insert(rewards, premiumReward)
+			end
+		end
 
 		table.insert(steps, {
 			stepId = step,
@@ -590,6 +668,10 @@ local function buildRewardSteps(state)
 end
 
 function BattlePassSystem.sendRewards(player)
+	local requirementError = getRequirementError(player)
+	if requirementError then
+		return sendBattlePassError(player, requirementError)
+	end
 	local state, store = loadState(player)
 	local rewards = buildRewardSteps(state)
 	saveState(store, state)
@@ -625,11 +707,11 @@ function BattlePassSystem.sendRewards(player)
 					if reward.rewardType == 1 then
 						randomValues = {makeItemThingValue(reward.itemId, reward.itemName)}
 					elseif reward.rewardType == 2 or reward.rewardType == 4 or reward.rewardType == 12 then
-						randomValues = makeItemThingValues(reward.randomValues)
+						randomValues = makeItemThingValues(reward.definition.items or reward.definition.choices)
 					elseif reward.rewardType == 17 then
 						randomValues = makeItemThingValues(reward.items)
 					elseif reward.rewardType == 18 then
-						choosableValues = makeItemThingValues(reward.choosableValues)
+						choosableValues = makeItemThingValues(reward.definition.choices)
 					end
 					writeU32(out, reward.rewardId)
 					out:addByte(clamp(reward.rewardType, 0, 0xFF))
@@ -656,31 +738,183 @@ end
 local function findReward(step, rewardId)
 	step = tonumber(step) or 0
 	rewardId = tonumber(rewardId) or 0
-	if step < 1 or step > config.maxStep then
+	if step < 1 or step > config.season.maxStep then
 		return nil
 	end
 
-	if freeRewardSteps[step] then
-		local freeReward = makeReward(step, true)
+	local configuredStep = config.rewards[step] or {}
+	if configuredStep.free then
+		local freeReward = makeReward(step, true, configuredStep.free)
 		if freeReward.rewardId == rewardId then
 			return freeReward
 		end
 	end
 
-	local premiumReward = makeReward(step, false)
-	if premiumReward.rewardId == rewardId then
-		return premiumReward
+	if configuredStep.deluxe then
+		local premiumReward = makeReward(step, false, configuredStep.deluxe)
+		if premiumReward.rewardId == rewardId then
+			return premiumReward
+		end
 	end
 	return nil
 end
 
+local function resolveItemChoice(itemIds, objectId)
+	for _, itemId in ipairs(itemIds or {}) do
+		local clientId = select(1, getItemTypeInfo(itemId))
+		if objectId == itemId or objectId == clientId then
+			return itemId
+		end
+	end
+	return nil
+end
+
+local function addItemsToBattlePassInbox(player, items)
+	local inbox = player:getStoreInbox()
+	if not inbox then
+		return false, "Your Battle Pass inbox is not available."
+	end
+
+	local neededSlots = 0
+	for _, entry in ipairs(items) do
+		local itemType = ItemType(entry.itemId)
+		if not itemType or itemType:getId() ~= entry.itemId then
+			return false, "This season has an invalid reward item configured."
+		end
+		neededSlots = neededSlots + (itemType:isStackable() and 1 or entry.count)
+	end
+	if inbox:getEmptySlots() < neededSlots then
+		return false, "Your Battle Pass inbox does not have enough room for this reward."
+	end
+
+	for _, entry in ipairs(items) do
+		local itemType = ItemType(entry.itemId)
+		local deliveries = itemType:isStackable() and 1 or entry.count
+		local amount = itemType:isStackable() and entry.count or 1
+		for _ = 1, deliveries do
+			local item = Game.createItem(entry.itemId, amount)
+			if not item then
+				return false, "Could not create the reward item."
+			end
+			if entry.charges and entry.charges > 0 then
+				item:setAttribute(ITEM_ATTRIBUTE_CHARGES, entry.charges)
+			end
+			if inbox:addItemEx(item, INDEX_WHEREEVER, FLAG_NOLIMIT) ~= RETURNVALUE_NOERROR then
+				item:remove()
+				return false, "Your Battle Pass inbox does not have enough room for this reward."
+			end
+		end
+	end
+	return true
+end
+
+local function rewardSkillParameter(skillId)
+	local parameters = {
+		[0] = CONDITION_PARAM_SKILL_FIST,
+		[1] = CONDITION_PARAM_SKILL_CLUB,
+		[2] = CONDITION_PARAM_SKILL_SWORD,
+		[3] = CONDITION_PARAM_SKILL_AXE,
+		[4] = CONDITION_PARAM_SKILL_DISTANCE,
+		[5] = CONDITION_PARAM_SKILL_SHIELD,
+		[13] = CONDITION_PARAM_STAT_MAGICPOINTS,
+	}
+	return parameters[skillId]
+end
+
 local function deliverReward(player, reward, objectId)
-	if reward.rewardType == 1 then
-		local added = player:addItem(reward.itemId, reward.count, true)
-		if not added then
-			return false, "Failed to deliver item. Check your inventory."
+	local definition = reward.definition
+	if definition.type == "item" then
+		return addItemsToBattlePassInbox(player, { { itemId = reward.itemId, count = reward.count, charges = reward.charges } })
+	elseif definition.type == "randomItem" then
+		local items = definition.items or {}
+		if #items == 0 then
+			return false, "This season has an empty random-item reward."
+		end
+		local itemId = items[math.random(#items)]
+		return addItemsToBattlePassInbox(player, { { itemId = itemId, count = reward.count, charges = reward.charges } })
+	elseif definition.type == "exercise" or definition.type == "boostedExercise" or definition.type == "choiceItem" then
+		local itemId = resolveItemChoice(definition.choices, objectId)
+		if not itemId then
+			return false, "Choose a valid reward item first."
+		end
+		return addItemsToBattlePassInbox(player, { { itemId = itemId, count = reward.count, charges = reward.charges } })
+	elseif definition.type == "multiItem" then
+		return addItemsToBattlePassInbox(player, definition.items)
+	elseif definition.type == "randomMount" then
+		local available = {}
+		for _, mount in ipairs(definition.mounts or {}) do
+			if mount.id and not player:hasMount(mount.id) then
+				table.insert(available, mount)
+			end
+		end
+		if #available == 0 then
+			return false, "You already own every mount in this reward."
+		end
+		if not player:addMount(available[math.random(#available)].id) then
+			return false, "Could not add the selected mount."
 		end
 		return true
+	elseif definition.type == "outfit" then
+		local outfits = player:getSex() == PLAYERSEX_FEMALE and definition.female or definition.male
+		if #outfits == 0 then
+			outfits = definition.male or definition.female or {}
+		end
+		for _, outfit in ipairs(outfits) do
+			if definition.addons and definition.addons > 0 then
+				player:addOutfitAddon(outfit.looktype, definition.addons)
+			else
+				player:addOutfit(outfit.looktype)
+			end
+		end
+		return #outfits > 0, #outfits > 0 and nil or "This season has an empty outfit reward."
+	elseif definition.type == "level" then
+		return player:addLevel(reward.count), "Could not add the level reward."
+	elseif definition.type == "prey" then
+		if not PreySystem or not PreySystem.addWildcards or not PreySystem.addWildcards(player, reward.count) then
+			return false, "Prey System is not available."
+		end
+		return true
+	elseif definition.type == "charms" then
+		if not db.query("UPDATE `players` SET `charmpoints` = `charmpoints` + " .. reward.count .. " WHERE `id` = " .. player:getGuid()) then
+			return false, "Could not add charm points."
+		end
+		return true
+	elseif definition.type == "xpBoost" then
+		if not player.getXpBoostTime or not player.setXpBoostTime or not player.setXpBoostPercent then
+			return false, "XP Boost is not available."
+		end
+		local duration = math.min(65535, reward.durationTime * 60 * 60)
+		player:setXpBoostPercent(math.max(player:getXpBoostPercent(), tonumber(definition.percent) or 50))
+		player:setXpBoostTime(math.min(65535, player:getXpBoostTime() + duration))
+		return true
+	elseif definition.type == "regeneration" then
+		local vocation = player:getVocation()
+		if not vocation then
+			return false, "You need a vocation to receive this reward."
+		end
+		local condition = Condition(CONDITION_REGENERATION, CONDITIONID_DEFAULT)
+		condition:setParameter(CONDITION_PARAM_SUBID, 43000 + reward.rewardId)
+		condition:setParameter(CONDITION_PARAM_TICKS, reward.durationTime * 60 * 60 * 1000)
+		condition:setParameter(CONDITION_PARAM_HEALTHGAIN, vocation:getHealthGainAmount())
+		condition:setParameter(CONDITION_PARAM_HEALTHTICKS, vocation:getHealthGainTicks())
+		condition:setParameter(CONDITION_PARAM_MANAGAIN, vocation:getManaGainAmount())
+		condition:setParameter(CONDITION_PARAM_MANATICKS, vocation:getManaGainTicks())
+		return player:addCondition(condition), "Could not add the regeneration reward."
+	elseif definition.type == "doubleSkill" then
+		local now = os.time()
+		local currentUntil = tonumber(player:getStorageValue(PlayerStorageKeys.battlePassDoubleSkillUntil)) or 0
+		player:setStorageValue(PlayerStorageKeys.battlePassDoubleSkillUntil, math.max(now, currentUntil) + reward.durationTime * 60 * 60)
+		return true
+	elseif definition.type == "extraSkill" then
+		local skillParameter = rewardSkillParameter(objectId)
+		if not skillParameter then
+			return false, "Choose a valid skill first."
+		end
+		local condition = Condition(CONDITION_ATTRIBUTES, CONDITIONID_DEFAULT)
+		condition:setParameter(CONDITION_PARAM_SUBID, 44000 + reward.rewardId)
+		condition:setParameter(CONDITION_PARAM_TICKS, reward.durationTime * 60 * 60 * 1000)
+		condition:setParameter(skillParameter, reward.count)
+		return player:addCondition(condition), "Could not add the skill reward."
 	end
 
 	return false, "Unsupported reward type."
@@ -736,6 +970,10 @@ function BattlePassSystem.rerollDailyMission(player, data)
 	end
 
 	local state, store, season, daily = loadState(player)
+	if state.completed or os.time() < season.beginTime or os.time() >= season.endTime then
+		player:sendCancelMessage("[Battle Pass] This season is not accepting mission progress.")
+		return false
+	end
 	getActiveDailyMissions(state, daily.key)
 
 	local slotKey = nil
@@ -750,32 +988,50 @@ function BattlePassSystem.rerollDailyMission(player, data)
 		player:sendCancelMessage("[Battle Pass] This daily mission is not active.")
 		return false
 	end
-
-	local cost = config.dailyRerollBasePrice * player:getLevel()
-	if cost > 0 and not player:removeMoneyBank(cost) then
-		player:sendCancelMessage("[Battle Pass] You do not have enough gold for this reroll.")
+	if slotKey == "2" and not isPremiumActive(state) then
+		player:sendCancelMessage("[Battle Pass] Deluxe Battle Pass is required for this mission.")
 		return false
 	end
 
-	state.rerollCounter = (tonumber(state.rerollCounter) or 0) + 1
+	local pool = slotKey == "1" and dailyFreeMissions or dailyDeluxeMissions
+	if #pool < 2 then
+		player:sendCancelMessage("[Battle Pass] This mission cannot be rerolled right now.")
+		return false
+	end
+
+	local nextRerollCounter = (tonumber(state.rerollCounter) or 0) + 1
 	local used = {}
 	for _, activeMissionId in pairs(state.dailySlots) do
 		used[activeMissionId] = true
 	end
 
-	local startIndex = ((state.rerollCounter + tonumber(slotKey)) % #dailyMissionPool) + 1
-	for offset = 0, #dailyMissionPool - 1 do
-		local index = ((startIndex + offset - 1) % #dailyMissionPool) + 1
-		local candidate = dailyMissionPool[index]
+	local replacement = nil
+	local startIndex = ((nextRerollCounter + tonumber(slotKey)) % #pool) + 1
+	for offset = 0, #pool - 1 do
+		local index = ((startIndex + offset - 1) % #pool) + 1
+		local candidate = pool[index]
 		if candidate and not used[candidate.id] then
-			state.dailySlots[slotKey] = candidate.id
-			state.dailyProgress[missionId] = nil
-			state.dailyAwarded[missionId] = nil
-			state.dailyProgress[candidate.id] = nil
-			state.dailyAwarded[candidate.id] = nil
+			replacement = candidate
 			break
 		end
 	end
+	if not replacement then
+		player:sendCancelMessage("[Battle Pass] There is no different mission available to reroll.")
+		return false
+	end
+
+	local cost = (tonumber(config.reroll.goldPerLevel) or 800) * player:getLevel()
+	if cost > 0 and not player:removeMoneyBank(cost) then
+		player:sendCancelMessage("[Battle Pass] You do not have enough gold for this reroll.")
+		return false
+	end
+
+	state.rerollCounter = nextRerollCounter
+	state.dailySlots[slotKey] = replacement.id
+	state.dailyProgress[missionId] = nil
+	state.dailyAwarded[missionId] = nil
+	state.dailyProgress[replacement.id] = nil
+	state.dailyAwarded[replacement.id] = nil
 
 	saveState(store, state)
 	sendMissionState(player, state, season, daily)
@@ -797,8 +1053,8 @@ local function updateMissionProgress(player, state, mission, daily, monsterName)
 
 	if current >= mission.maxProgress and not wasMissionAwarded(state, mission, daily) then
 		setMissionAwarded(state, mission, daily)
-		addBattlePassPoints(state, mission.rewardPoints)
-		player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "[Battle Pass] Mission completed: " .. mission.name .. " (+" .. mission.rewardPoints .. " points).")
+		addBattlePassPoints(state, mission.points)
+		player:sendTextMessage(MESSAGE_STATUS_DEFAULT, "[Battle Pass] Mission completed: " .. mission.name .. " (+" .. mission.points .. " points).")
 	end
 
 	return true
@@ -812,9 +1068,12 @@ function BattlePassSystem.onKill(player, target)
 	if target:getMaster() then
 		return true
 	end
+	if getRequirementError(player) then
+		return true
+	end
 
 	local state, store, season, daily = loadState(player)
-	if os.time() >= season.endTime then
+	if state.completed or os.time() < season.beginTime or os.time() >= season.endTime then
 		return true
 	end
 
@@ -822,12 +1081,18 @@ function BattlePassSystem.onKill(player, target)
 	local changed = false
 	local previousStep = getCurrentRewardStep(state.points)
 
-	for _, mission in ipairs(getActiveDailyMissions(state, daily.key)) do
-		changed = updateMissionProgress(player, state, mission, true, monsterName) or changed
+	local dailyMissions = getActiveDailyMissions(state, daily.key)
+	if not state.completed and dailyMissions[1] then
+		changed = updateMissionProgress(player, state, dailyMissions[1], true, monsterName) or changed
+	end
+	if not state.completed and isPremiumActive(state) and dailyMissions[2] then
+		changed = updateMissionProgress(player, state, dailyMissions[2], true, monsterName) or changed
 	end
 
 	for _, mission in ipairs(generalMissions) do
-		changed = updateMissionProgress(player, state, mission, false, monsterName) or changed
+		if not state.completed and isGeneralMissionUnlocked(mission, season) then
+			changed = updateMissionProgress(player, state, mission, false, monsterName) or changed
+		end
 	end
 
 	if changed then
@@ -841,12 +1106,19 @@ function BattlePassSystem.onKill(player, target)
 end
 
 function BattlePassSystem.purchasePremium(player, skipCoinCharge)
+	local requirementError = getRequirementError(player)
+	if requirementError then
+		return requirementError
+	end
 	local state, store, season, daily = loadState(player)
+	if os.time() < season.beginTime or os.time() >= season.endTime then
+		return "The Battle Pass season is not active."
+	end
 	if isPremiumActive(state) then
 		return "You already have the Deluxe Battle Pass for this season."
 	end
 
-	if not skipCoinCharge and not player:removeTibiaCoins(config.deluxePrice) then
+	if not skipCoinCharge and not player:removeTibiaCoins(config.deluxe.price) then
 		return "Not enough Tibia Coins."
 	end
 
@@ -856,6 +1128,39 @@ function BattlePassSystem.purchasePremium(player, skipCoinCharge)
 	sendMissionState(player, state, season, daily)
 	BattlePassSystem.sendRewards(player)
 	return nil
+end
+
+function BattlePassSystem.resetPlayer(player)
+	if not player then
+		return false, "Player not found."
+	end
+	getStore(player):remove("state")
+	player:setStorageValue(PlayerStorageKeys.battlePassSeasonEpoch, -1)
+	local state, store, season, daily = loadState(player)
+	saveState(store, state)
+	if supportsCustomNetwork(player) then
+		sendMissionState(player, state, season, daily)
+		BattlePassSystem.sendRewards(player)
+	end
+	return true
+end
+
+function BattlePassSystem.startNewSeason()
+	local seasonStore = getSeasonStore()
+	local currentEpoch = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonEpoch)) or 0
+	Game.setStorageValue(GlobalStorageKeys.battlePassSeasonEpoch, math.max(1, currentEpoch + 1))
+	Game.setStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt, os.time())
+	seasonStore:set("configId", tostring(config.season.id or "season"))
+
+	for _, onlinePlayer in ipairs(Game.getPlayers()) do
+		BattlePassSystem.resetPlayer(onlinePlayer)
+		onlinePlayer:sendTextMessage(MESSAGE_EVENT_ADVANCE, "[Battle Pass] A new season has started. Your Battle Pass progress was reset.")
+	end
+	return getSeason()
+end
+
+function BattlePassSystem.getSeasonInfo()
+	return getSeason()
 end
 
 local function isRateLimited(player, action)

--- a/data/scripts/network/battlepass/battlepass_double_skill.lua
+++ b/data/scripts/network/battlepass/battlepass_double_skill.lua
@@ -1,0 +1,21 @@
+-- Applies the temporary Double Skill reward granted by the Battle Pass.
+-- Artificial tries are excluded to avoid duplicating admin or scripted grants.
+local event = Event()
+
+function event.onGainSkillTries(player, skill, tries, artificial)
+	if artificial then
+		return tries
+	end
+
+	local untilTime = tonumber(player:getStorageValue(PlayerStorageKeys.battlePassDoubleSkillUntil)) or 0
+	if untilTime <= os.time() then
+		if untilTime > 0 then
+			player:setStorageValue(PlayerStorageKeys.battlePassDoubleSkillUntil, -1)
+		end
+		return tries
+	end
+
+	return tries * 2
+end
+
+event:register(50)

--- a/data/scripts/network/cyclopedia/ciclopedia.lua
+++ b/data/scripts/network/cyclopedia/ciclopedia.lua
@@ -17,6 +17,7 @@ local RESP_BESTIARY_DATA = 0x01
 local RESP_BESTIARY_OVERVIEW = 0x02
 local RESP_BESTIARY_MONSTER = 0x03
 local RESP_TRACKER = 0x05
+local RESP_BESTIARY_PROGRESS = 0x06
 
 local MAX_TRACKER_SLOTS = 5
 local CHARM_REMOVE_COST = 10000
@@ -557,12 +558,34 @@ local function sendBestiaryMonster(player, raceId)
 end
 
 local function sendBestiaryProgress(player, raceId, killCount)
-	local entry = CustomBestiary.getMonster(raceId)
-	if not entry then
-		return
+	if not supportsCustomNetwork(player) then
+		return false
 	end
 
-	sendBestiaryOverview(player, entry.class)
+	local entry = CustomBestiary.getMonster(raceId)
+	if not entry then
+		return false
+	end
+
+	local playerGuid = getPlayerGuid(player)
+	local kills = loadKillMap(playerGuid)
+	local charms = loadCharmMap(playerGuid)
+	killCount = tonumber(killCount) or kills[entry.raceId] or 0
+	local progress = CustomBestiary.getProgress(entry, killCount)
+
+	local out = NetworkMessage(player)
+	out:addByte(OPCODE_CYCLOPEDIA_SEND)
+	out:addByte(RESP_BESTIARY_PROGRESS)
+	out:addU16(entry.raceId)
+	out:addByte(clamp(progress, 0, 0xFF))
+	out:addU32(clamp(killCount, 0, 0xFFFFFFFF))
+	out:addU16(entry.firstUnlock)
+	out:addU16(entry.secondUnlock)
+	out:addU16(entry.toKill)
+	writeCreatureInfo(out, entry)
+	out:addU32(clamp(getStoredCharmBalance(playerGuid, kills, charms), 0, 0xFFFFFFFF))
+	out:addU32(clamp(getGoldBalance(player), 0, 0xFFFFFFFF))
+	return out:sendToPlayer(player)
 end
 
 local function sendTracker(player)

--- a/data/scripts/network/cyclopedia/ciclopedia.lua
+++ b/data/scripts/network/cyclopedia/ciclopedia.lua
@@ -443,11 +443,12 @@ local function sendBestiaryOverviewEntries(player, title, entries)
 		local progress = CustomBestiary.getProgress(entry, kills[entry.raceId] or 0)
 		out:addU16(entry.raceId)
 		if progress <= 0 then
-			-- Astra paints undiscovered creatures with the black outfit shader.
+			-- Astra still paints undiscovered creatures as "?" with the black
+			-- outfit shader, but it needs the real creature info cached so a
+			-- later unlock/progress event can resolve the race id and reveal it.
 			out:addByte(1)
 			out:addByte(0)
-			local masked = { name = "?", outfit = entry.outfit }
-			writeCreatureInfo(out, masked)
+			writeCreatureInfo(out, entry)
 		else
 			out:addByte(math.min(progress + 1, 0xFF))
 			out:addByte(math.min(progress, 0xFF))

--- a/data/scripts/talkactions/gm/server/battlepass_season.lua
+++ b/data/scripts/talkactions/gm/server/battlepass_season.lua
@@ -68,7 +68,8 @@ function talk.onSay(player, words, param)
 		elseif action == "sync" then
 			local missionsSent = BattlePassSystem.sendMissions(target)
 			local rewardsSent = missionsSent and BattlePassSystem.sendRewards(target)
-			if missionsSent and rewardsSent then
+			local shopSent = rewardsSent and BattlePassSystem.sendShop(target)
+			if missionsSent and rewardsSent and shopSent then
 				player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass sent to " .. target:getName() .. ".")
 			else
 				player:sendCancelMessage("Could not send Battle Pass to " .. target:getName() .. ".")

--- a/data/scripts/talkactions/gm/server/battlepass_season.lua
+++ b/data/scripts/talkactions/gm/server/battlepass_season.lua
@@ -2,7 +2,7 @@ local talk = TalkAction("/battlepass")
 
 local function usage(player)
 	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
-		"Usage: /battlepass status | newseason | reset <player> | sync <player> | shopcoins|coins <player> <amount>")
+		"Usage: /battlepass status | newseason | reset <player> | sync <player> | unlockshop <player> | shopcoins|coins <player> <amount>")
 end
 
 function talk.onSay(player, words, param)
@@ -18,6 +18,7 @@ function talk.onSay(player, words, param)
 	action = (action or "status"):lower()
 	targetName = (targetName or ""):trim()
 	local isShopCoinsAction = action == "shopcoins" or action == "coins" or action == "addcoins"
+	local isUnlockShopAction = action == "unlockshop" or action == "completeshop"
 
 	if action == "status" then
 		local season = BattlePassSystem.getSeasonInfo()
@@ -34,7 +35,7 @@ function talk.onSay(player, words, param)
 		return false
 	end
 
-	if action == "reset" or action == "sync" or isShopCoinsAction then
+	if action == "reset" or action == "sync" or isShopCoinsAction or isUnlockShopAction then
 		if targetName == "" then
 			usage(player)
 			return false
@@ -72,7 +73,7 @@ function talk.onSay(player, words, param)
 			else
 				player:sendCancelMessage("Could not send Battle Pass to " .. target:getName() .. ".")
 			end
-		else
+		elseif isShopCoinsAction then
 			local ok, balanceOrError = BattlePassSystem.addShopPoints(target, amount)
 			if not ok then
 				player:sendCancelMessage(balanceOrError or "Could not add Battle Pass shop points.")
@@ -80,6 +81,13 @@ function talk.onSay(player, words, param)
 			end
 			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
 				string.format("Added %d Battle Pass shop points to %s. New balance: %d.", amount, target:getName(), balanceOrError))
+		else
+			local ok, errorMessage = BattlePassSystem.unlockShop(target)
+			if not ok then
+				player:sendCancelMessage(errorMessage or "Could not unlock Battle Pass shop.")
+				return false
+			end
+			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass shop unlocked for " .. target:getName() .. ".")
 		end
 		return false
 	end

--- a/data/scripts/talkactions/gm/server/battlepass_season.lua
+++ b/data/scripts/talkactions/gm/server/battlepass_season.lua
@@ -1,0 +1,69 @@
+local talk = TalkAction("/battlepass")
+
+local function usage(player)
+	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
+		"Usage: /battlepass status | newseason | reset <player> | sync <player>")
+end
+
+function talk.onSay(player, words, param)
+	if not player:getGroup():getAccess() then
+		return true
+	end
+	if not BattlePassSystem then
+		player:sendCancelMessage("Battle Pass system is disabled.")
+		return false
+	end
+
+	local action, targetName = param:match("^(%S+)%s*(.*)$")
+	action = (action or "status"):lower()
+	targetName = (targetName or ""):trim()
+
+	if action == "status" then
+		local season = BattlePassSystem.getSeasonInfo()
+		player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
+			string.format("Battle Pass: %s (epoch %d), starts %s, ends %s.", season.id, season.epoch,
+				os.date("%Y-%m-%d %H:%M", season.beginTime), os.date("%Y-%m-%d %H:%M", season.endTime)))
+		return false
+	end
+
+	if action == "newseason" then
+		local season = BattlePassSystem.startNewSeason()
+		player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
+			string.format("New Battle Pass season started: %s.", season.id))
+		return false
+	end
+
+	if action == "reset" or action == "sync" then
+		if targetName == "" then
+			usage(player)
+			return false
+		end
+
+		local target = Player(targetName)
+		if not target then
+			player:sendCancelMessage("Player must be online.")
+			return false
+		end
+
+		if action == "reset" then
+			local ok, errorMessage = BattlePassSystem.resetPlayer(target)
+			if not ok then
+				player:sendCancelMessage(errorMessage or "Could not reset Battle Pass state.")
+				return false
+			end
+			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass state reset for " .. target:getName() .. ".")
+		else
+			BattlePassSystem.sendMissions(target)
+			BattlePassSystem.sendRewards(target)
+			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass sent to " .. target:getName() .. ".")
+		end
+		return false
+	end
+
+	usage(player)
+	return false
+end
+
+talk:separator(" ")
+talk:access(true)
+talk:register()

--- a/data/scripts/talkactions/gm/server/battlepass_season.lua
+++ b/data/scripts/talkactions/gm/server/battlepass_season.lua
@@ -67,7 +67,7 @@ function talk.onSay(player, words, param)
 			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass state reset for " .. target:getName() .. ".")
 		elseif action == "sync" then
 			local missionsSent = BattlePassSystem.sendMissions(target)
-			local rewardsSent = BattlePassSystem.sendRewards(target)
+			local rewardsSent = missionsSent and BattlePassSystem.sendRewards(target)
 			if missionsSent and rewardsSent then
 				player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass sent to " .. target:getName() .. ".")
 			else

--- a/data/scripts/talkactions/gm/server/battlepass_season.lua
+++ b/data/scripts/talkactions/gm/server/battlepass_season.lua
@@ -2,7 +2,7 @@ local talk = TalkAction("/battlepass")
 
 local function usage(player)
 	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
-		"Usage: /battlepass status | newseason | reset <player> | sync <player>")
+		"Usage: /battlepass status | newseason | reset <player> | sync <player> | shopcoins|coins <player> <amount>")
 end
 
 function talk.onSay(player, words, param)
@@ -17,6 +17,7 @@ function talk.onSay(player, words, param)
 	local action, targetName = param:match("^(%S+)%s*(.*)$")
 	action = (action or "status"):lower()
 	targetName = (targetName or ""):trim()
+	local isShopCoinsAction = action == "shopcoins" or action == "coins" or action == "addcoins"
 
 	if action == "status" then
 		local season = BattlePassSystem.getSeasonInfo()
@@ -33,10 +34,21 @@ function talk.onSay(player, words, param)
 		return false
 	end
 
-	if action == "reset" or action == "sync" then
+	if action == "reset" or action == "sync" or isShopCoinsAction then
 		if targetName == "" then
 			usage(player)
 			return false
+		end
+
+		local amount
+		if isShopCoinsAction then
+			targetName, amount = targetName:match("^(.-)%s+(%d+)$")
+			targetName = (targetName or ""):trim()
+			amount = tonumber(amount)
+			if targetName == "" or not amount then
+				usage(player)
+				return false
+			end
 		end
 
 		local target = Player(targetName)
@@ -52,10 +64,22 @@ function talk.onSay(player, words, param)
 				return false
 			end
 			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass state reset for " .. target:getName() .. ".")
+		elseif action == "sync" then
+			local missionsSent = BattlePassSystem.sendMissions(target)
+			local rewardsSent = BattlePassSystem.sendRewards(target)
+			if missionsSent and rewardsSent then
+				player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass sent to " .. target:getName() .. ".")
+			else
+				player:sendCancelMessage("Could not send Battle Pass to " .. target:getName() .. ".")
+			end
 		else
-			BattlePassSystem.sendMissions(target)
-			BattlePassSystem.sendRewards(target)
-			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Battle Pass sent to " .. target:getName() .. ".")
+			local ok, balanceOrError = BattlePassSystem.addShopPoints(target, amount)
+			if not ok then
+				player:sendCancelMessage(balanceOrError or "Could not add Battle Pass shop points.")
+				return false
+			end
+			player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE,
+				string.format("Added %d Battle Pass shop points to %s. New balance: %d.", amount, target:getName(), balanceOrError))
 		end
 		return false
 	end


### PR DESCRIPTION
Rebuilds the season-based Battle Pass. Season data, rewards, and shop catalog are configurable in reward_battlepass.lua. The pass has 80 levels; after level 80, daily missions continue until season end and award Battle Pass shop points. Shop purchases are validated server-side and delivered through the Store Inbox. The matching AstraClient UI is PR 86.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Season 02 Battle Pass with 80 reward steps including mounts, outfits, items, and skill enhancements.
  * Added Battle Pass shop system with purchasable seasonal items and currency (shop points).
  * Implemented daily and general missions organized by difficulty tiers and weekly unlock progression.
  * Added temporary Double Skill effect for Battle Pass progression.
  * Enhanced reward delivery with diverse reward types across free and deluxe tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->