### PR TITLE
fix(protocol): advertise OTCv8 tier features

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -709,13 +709,19 @@ bool Creature::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreatur
 						if (ConfigManager::getBoolean(ConfigManager::LOOT_GROUPING_ENABLED)) {
 							corpseOwner->addPendingLoot(getNameDescription(), corpseContainer);
 						}
+						const Monster* deadMonster = getMonster();
+						const bool canAutoQuickLootCorpse = deadMonster &&
+						                                   !deadMonster->getMonsterType()->info.isBoss &&
+						                                   !deadMonster->isRewardBoss();
 						if (ConfigManager::getBoolean(ConfigManager::QUICK_LOOT_ENABLED)) {
-							if (corpseOwner->isQuickLootAutoEnabled()) {
-								g_game.playerQuickLootCorpse(corpseOwner->getID(), corpseContainer);
-							} else {
-								corpseOwner->lootCorpse(corpseContainer);
+							if (canAutoQuickLootCorpse) {
+								if (corpseOwner->isQuickLootAutoEnabled()) {
+									g_game.playerQuickLootCorpse(corpseOwner->getID(), corpseContainer);
+								} else {
+									corpseOwner->lootCorpse(corpseContainer);
+								}
 							}
-						} else {
+						} else if (canAutoQuickLootCorpse) {
 							corpseOwner->lootCorpse(corpseContainer);
 						}
 					}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -198,18 +198,31 @@ struct QuickLootResult
 	ReturnValue failure = RETURNVALUE_NOERROR;
 };
 
+bool hasQuickLootDisabled(const Item* item)
+{
+	const auto* attribute = item ? item->getCustomAttribute("QuickLootDisabled") : nullptr;
+	const bool* disabled = attribute ? std::get_if<bool>(&attribute->value) : nullptr;
+	return disabled && *disabled;
+}
+
+bool shouldUseContainerInsteadOfQuickLoot(const Container* container)
+{
+	return container && (container->getRewardChest() || container->getID() == ITEM_REWARD_CONTAINER ||
+	                     container->isRewardCorpse() || hasQuickLootDisabled(container));
+}
+
 bool isQuickLootCorpseType(const Container* container)
 {
 	if (!container) {
 		return false;
 	}
 
-	if (container->isRewardCorpse()) {
-		return true;
+	if (shouldUseContainerInsteadOfQuickLoot(container)) {
+		return false;
 	}
 
 	const ItemType& type = Item::items[container->getID()];
-	return type.corpseType != RACE_NONE || container->getCorpseOwner() != 0;
+	return type.corpseType != RACE_NONE;
 }
 
 const Container* getQuickLootCorpseContainer(const Container* container)
@@ -3652,7 +3665,12 @@ void Game::playerSeekInContainer(uint32_t playerId, uint8_t containerId, uint16_
 	}
 
 	Container* container = player->getContainerByID(containerId);
-	if (!container || !container->hasPagination() || container->capacity() == 0) {
+	if (!container || container->capacity() == 0) {
+		return;
+	}
+
+	const bool canSeekContainer = container->hasPagination() || (player->isAstraClient() && container->getRewardChest());
+	if (!canSeekContainer) {
 		return;
 	}
 
@@ -3823,7 +3841,8 @@ void Game::playerQuickLoot(uint32_t playerId, const Position& pos, uint16_t item
 	if (lootAllCorpses && pos.x != 0xFFFF) {
 		if (Thing* clickedThing = internalGetThing(player, pos, stackPos, itemId, STACKPOS_USEITEM)) {
 			if (Item* clickedItem = clickedThing->getItem()) {
-				if (Container* clickedContainer = clickedItem->getContainer(); clickedContainer && clickedContainer->isRewardCorpse()) {
+				if (Container* clickedContainer = clickedItem->getContainer();
+				    shouldUseContainerInsteadOfQuickLoot(clickedContainer)) {
 					playerUseItem(playerId, pos, stackPos, 0, itemId);
 					return;
 				}
@@ -3869,7 +3888,7 @@ void Game::playerQuickLoot(uint32_t playerId, const Position& pos, uint16_t item
 	}
 
 	if (Container* container = item->getContainer()) {
-		if (container->isRewardCorpse()) {
+		if (shouldUseContainerInsteadOfQuickLoot(container)) {
 			playerUseItem(playerId, pos, stackPos, 0, itemId);
 			return;
 		}
@@ -3970,6 +3989,10 @@ void Game::playerQuickLootCorpse(uint32_t playerId, Container* container)
 	auto playerRef = getPlayerByID(playerId);
 	Player* player = playerRef.get();
 	if (!player || !container || !getBoolean(ConfigManager::QUICK_LOOT_ENABLED)) {
+		return;
+	}
+
+	if (!isQuickLootCorpseType(container)) {
 		return;
 	}
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2620,6 +2620,10 @@ std::shared_ptr<Item> Monster::getCorpse(Creature* lastHitCreature, Creature* mo
 	}
 
 	if (corpse) {
+		if (mType->info.isBoss || mType->info.isRewardBoss) {
+			corpse->setCustomAttribute("QuickLootDisabled", true);
+		}
+
 		if (mostDamageCreature) {
 			if (mostDamageCreature->getPlayer()) {
 				corpse->setCorpseOwner(mostDamageCreature->getID());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -547,8 +547,18 @@ bool ProtocolGame::shouldSendItemTierByte() const
 
 bool ProtocolGame::shouldSendThingUpgradeClassification() const
 {
-	return isMehah && getBoolean(ConfigManager::ITEM_TIER_DISPLAY) &&
-	       getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION);
+	if (!getBoolean(ConfigManager::ITEM_TIER_DISPLAY)) {
+		return false;
+	}
+
+	if (isMehah) {
+		return getBoolean(ConfigManager::ITEM_UPGRADE_CLASSIFICATION);
+	}
+
+	// OTCv8 Classic uses this feature as the Lua-side gate for drawing tier icons.
+	// Keep the actual item wire format tied to GameItemTierByte so CIP and
+	// non-tier-aware OTC clients never receive unexpected item bytes.
+	return isOTCv8 && !isAstraClient && shouldSendItemTierByte();
 }
 
 bool ProtocolGame::shouldSendItemTierData() const
@@ -4905,7 +4915,7 @@ void ProtocolGame::sendFeatures()
 		features[GameFeature::AstraItemMetadata] = true;
 	}
 	features[GameFeature::QuickLootFlags] = shouldSendQuickLootFlags();
-	features[GameFeature::ThingUpgradeClassification] = false;
+	features[GameFeature::ThingUpgradeClassification] = shouldSendThingUpgradeClassification();
 	features[GameFeature::ItemTierByte] = shouldSendItemTierByte();
 
 	if (features.empty()) return;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -524,6 +524,15 @@ bool ProtocolGame::shouldSendContainerPagination() const
 	return isOTCv8 || isAstraClient || isMehah;
 }
 
+bool ProtocolGame::shouldPaginateContainer(const Container* container) const
+{
+	if (!container) {
+		return false;
+	}
+
+	return container->hasPagination() || (isAstraClient && container->getRewardChest());
+}
+
 bool ProtocolGame::canSendAstraItemState() const
 {
 	if (!player || !player->client || !isAstraClient || isSpectator ||
@@ -2973,6 +2982,7 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const bool sendAstraItemState = canSendAstraItemState();
 	const bool sendAstraQuiverCountU16 = shouldSendAstraQuiverCountU16();
 	const bool sendContainerPagination = shouldSendContainerPagination();
+	const bool paginateContainer = shouldPaginateContainer(container);
 	if (container->getID() == ITEM_BROWSEFIELD) {
 		msg.addItem(ITEM_BAG, 1, sendItemTierData, sendItemTierByte, sendQuickLootFlags, sendAstraItemState,
 		            sendAstraQuiverCountU16);
@@ -2990,12 +3000,12 @@ void ProtocolGame::sendContainer(uint8_t cid, const Container* container, bool h
 	const uint32_t containerSize = container->size();
 	if (sendContainerPagination) {
 		msg.addByte(0x01); // drag and drop
-		msg.addByte(container->hasPagination() ? 0x01 : 0x00);
+		msg.addByte(paginateContainer ? 0x01 : 0x00);
 		msg.add<uint16_t>(static_cast<uint16_t>(std::min<uint32_t>(0xFFFF, containerSize)));
 		msg.add<uint16_t>(firstIndex);
 	}
 
-	const uint32_t maxItemsToSend = container->hasPagination() ? container->capacity() : 0xFF;
+	const uint32_t maxItemsToSend = paginateContainer ? container->capacity() : 0xFF;
 	const uint32_t itemCount = firstIndex >= containerSize ? 0 :
 	                           std::min<uint32_t>(maxItemsToSend, containerSize - firstIndex);
 	msg.addByte(static_cast<uint8_t>(std::min<uint32_t>(0xFF, itemCount)));

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -308,6 +308,7 @@ private:
 	void sendFeatures();
 	bool shouldSendQuickLootFlags() const;
 	bool shouldSendContainerPagination() const;
+	bool shouldPaginateContainer(const Container* container) const;
 	bool shouldSendItemTierByte() const;
 	bool shouldSendThingUpgradeClassification() const;
 	bool shouldSendItemTierData() const;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item upgrade classification is now sent/negotiated only when tier display and client compatibility settings allow it.
  * Containers may now automatically paginate based on container type and client context (e.g., certain reward chests).
* **Bug Fixes**
  * Refined corpse and container auto–quick-looting so bosses/reward cases are correctly excluded.
  * Added support for a “QuickLootDisabled” attribute to reliably bypass quick-loot for specific corpses/containers.
  * Improved quick-loot/seek validation for containers, preventing incorrect quick-loot and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related issues: it correctly advertises the `ThingUpgradeClassification` feature to OTCv8 (non-Astra) clients when item tier display is enabled, and it prevents boss/reward-boss corpses from being auto-quick-looted by introducing a `QuickLootDisabled` custom attribute and corresponding guards.

- `shouldSendThingUpgradeClassification()` now returns `true` for OTCv8 non-Astra clients when `ITEM_TIER_DISPLAY` is on and `shouldSendItemTierByte()` passes, replacing the previous hardcoded `false` in `sendFeatures()`.
- Boss/reward-boss corpses get a `QuickLootDisabled` attribute set in `Monster::getCorpse()`, checked by the refactored `shouldUseContainerInsteadOfQuickLoot()` helper in `game.cpp`; `creature.cpp` adds an early `canAutoQuickLootCorpse` guard so the call is skipped entirely at the corpse-drop site.
- `shouldPaginateContainer()` is extracted as a per-container predicate so that reward chests can be paginated for Astra clients without affecting the global `sendContainerPagination` flag.

<h3>Confidence Score: 5/5</h3>

Changes are safe to merge; logic is consistent across all three layers that gate boss quick-loot.

The ThingUpgradeClassification fix replaces a hardcoded false with a well-scoped predicate. Boss quick-loot prevention is layered at the wire format, game-logic helpers, and corpse-drop site — all three layers are mutually consistent with no missing guards.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/protocolgame.cpp | Core fix: `shouldSendThingUpgradeClassification()` now correctly returns `true` for OTCv8 non-Astra clients when item tier display is on; `shouldPaginateContainer()` extracted to handle Astra reward-chest pagination separately from the generic pagination flag. |
| src/protocolgame.h | Declaration for the new `shouldPaginateContainer(const Container*)` helper added alongside existing container-related predicates. |
| src/game.cpp | Introduces `hasQuickLootDisabled` and `shouldUseContainerInsteadOfQuickLoot` helpers; `isQuickLootCorpseType` correctly flips reward-corpse handling from true to false; `playerQuickLootCorpse` gains an early guard; Astra clients can now seek in reward chests. |
| src/monster.cpp | Boss and reward-boss corpses receive a `QuickLootDisabled` custom attribute immediately after creation, giving the quick-loot system a data-level gate independent of the class-level flags. |
| src/creature.cpp | `dropCorpse` now computes `canAutoQuickLootCorpse` before the quick-loot branches, preventing auto-loot (both auto-enabled and manual fallback) for boss/reward-boss corpses. |

<sub>Reviews (4): Last reviewed commit: ["fix(game): open boss rewards normally"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/4a8f69eef0f28c51a529537a1206211bb2bbce96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42803826)</sub>

<!-- /greptile_comment -->