### PR TITLE
Feat/readme badges

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,8 @@ cache:
 install:
   - cmd: git fetch --tags --force
   - cmd: choco install ninja -y
-  - cmd: cd "%VCPKG_ROOT%" && (git fetch --unshallow || git fetch) && cd "%APPVEYOR_BUILD_FOLDER%"
+  - cmd: set "PATH=C:\ProgramData\chocolatey\bin;%PATH%"
+  - cmd: cd "%VCPKG_ROOT%" && git reset --hard HEAD && git pull && .\bootstrap-vcpkg.bat && cd "%APPVEYOR_BUILD_FOLDER%"
   - cmd: call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cmd: cmake --version
   - cmd: ninja --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,8 @@ cache:
 
 install:
   - cmd: git fetch --tags --force
+  - cmd: choco install ninja -y
+  - cmd: cd "%VCPKG_ROOT%" && (git fetch --unshallow || git fetch) && cd "%APPVEYOR_BUILD_FOLDER%"
   - cmd: call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cmd: cmake --version
   - cmd: ninja --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cmd: git fetch --tags --force
   - cmd: choco install ninja -y
   - cmd: set "PATH=C:\ProgramData\chocolatey\bin;%PATH%"
-  - cmd: cd "%VCPKG_ROOT%" && git reset --hard HEAD && git pull && .\bootstrap-vcpkg.bat && cd "%APPVEYOR_BUILD_FOLDER%"
+  - cmd: cd "%VCPKG_ROOT%" && git fetch origin && git checkout cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 && .\bootstrap-vcpkg.bat && cd "%APPVEYOR_BUILD_FOLDER%"
   - cmd: call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cmd: cmake --version
   - cmd: ninja --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - cmd: call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cmd: cmake --version
   - cmd: ninja --version
-  - cmd: "%VCPKG_ROOT%\vcpkg.exe" version
+  - cmd: '"%VCPKG_ROOT%\vcpkg.exe" version'
 
 build_script:
   - cmd: call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-[![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/9ne5TZapd)
+[![Discord](https://img.shields.io/discord/1498442075442516120.svg?style=flat-square&logo=discord&label=Discord&color=5865F2)](https://discord.gg/9ne5TZapd)
 [![CI](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/actions/workflows/build.yml/badge.svg)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/actions/workflows/build.yml)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/Mateuzkl/forgottenserver-downgrade?branch=official&svg=true)](https://ci.appveyor.com/project/Mateuzkl/forgottenserver-downgrade)
 ![Repository size](https://img.shields.io/github/repo-size/Mateuzkl/forgottenserver-downgrade-1.8-8.60?style=flat-square)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Discord](https://img.shields.io/discord/1498442075442516120.svg?style=flat-square&logo=discord&label=Discord&color=5865F2)](https://discord.gg/9ne5TZapd)
 [![CI](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/actions/workflows/build.yml/badge.svg)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/actions/workflows/build.yml)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/Mateuzkl/forgottenserver-downgrade?branch=official&svg=true)](https://ci.appveyor.com/project/Mateuzkl/forgottenserver-downgrade)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/Mateuzkl/forgottenserver-downgrade-1.8-8.60?branch=main&svg=true)](https://ci.appveyor.com/project/Mateuzkl/forgottenserver-downgrade-1.8-8.60)
 ![Repository size](https://img.shields.io/github/repo-size/Mateuzkl/forgottenserver-downgrade-1.8-8.60?style=flat-square)
 [![License](https://img.shields.io/github/license/Mateuzkl/forgottenserver-downgrade-1.8-8.60.svg?style=flat-square)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/blob/main/LICENSE)
 [![Commits](https://img.shields.io/badge/commits-1000%2B-6a0dad?style=flat-square)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/commits)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 
 <div align="center">
 
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/9ne5TZapd)
+[![CI](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/actions/workflows/build.yml/badge.svg)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/actions/workflows/build.yml)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/Mateuzkl/forgottenserver-downgrade?branch=official&svg=true)](https://ci.appveyor.com/project/Mateuzkl/forgottenserver-downgrade)
-[![License](https://img.shields.io/badge/license-GPL--2.0-blue?style=flat-square)](LICENSE)
+![Repository size](https://img.shields.io/github/repo-size/Mateuzkl/forgottenserver-downgrade-1.8-8.60?style=flat-square)
+[![License](https://img.shields.io/github/license/Mateuzkl/forgottenserver-downgrade-1.8-8.60.svg?style=flat-square)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/blob/main/LICENSE)
 [![Commits](https://img.shields.io/badge/commits-1000%2B-6a0dad?style=flat-square)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/commits)
 [![Wiki](https://img.shields.io/badge/docs-wiki-8b5cf6?style=flat-square&logo=wikipedia&logoColor=white)](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/wiki)
 
@@ -26,7 +29,7 @@
 
 Developed and maintained by [Mateuzkl](https://github.com/Mateuzkl), based on [Nekiro's TFS 1.5 Downgrades](https://github.com/nekiro/TFS-1.5-Downgrades) and forked from [MillhioreBT's downgrade](https://github.com/MillhioreBT/forgottenserver-downgrade).
 
-[Discord Community](https://discord.com/invite/GxTm7DyXVe) · [Full Wiki](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/wiki) · [Issues](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/issues)
+[Discord Community](https://discord.gg/9ne5TZapd) · [Full Wiki](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/wiki) · [Issues](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/issues)
 
 </div>
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows CI setup to make builds more reliable and consistent.
  * Added missing tooling setup steps before version checks and build validation.

* **Documentation**
  * Refreshed the README badges and links.
  * Updated the community link to the current Discord invite format and improved license badge linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the README badges and updates the AppVeyor CI configuration to be more reliable. The `.appveyor.yml` changes install Ninja before version checks, pin vcpkg to a specific commit hash (replacing the former unpinned `git pull`), and fix quoting on the `vcpkg.exe version` command; the README adds Discord, GitHub Actions CI, and repo-size badges while correcting the AppVeyor project slug and branch filter to `main`.

- **`.appveyor.yml`**: Ninja is now installed via Chocolatey before `ninja --version` runs; vcpkg is pinned to commit `cd61e1e2` and re-bootstrapped on every run, replacing the previously unversioned `git pull`.
- **`README.md`**: Three new badges (Discord, GitHub Actions CI, repo size), corrected AppVeyor badge URL/branch, and an updated top-level Discord invite link — though one older invite URL remains in the Community & Support section at the bottom.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to README badge updates and CI config hardening with no impact on source code or runtime behavior.

Both changed files are documentation and CI configuration only. The AppVeyor changes are straightforward reliability improvements (Ninja install, vcpkg commit pin, quoting fix). The README changes are cosmetic badge additions and a link correction. A missed Discord URL in the Community section is a minor inconsistency with no functional consequence.

README.md — the old Discord invite URL at line 653 was not updated to match the new invite used in the badge and top navigation link.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds Discord, GitHub Actions CI, and repo-size badges; corrects the AppVeyor project slug and branch to `main`; updates the top Discord invite link — but misses one remaining occurrence of the old invite in the Community & Support section. |
| .appveyor.yml | Installs Ninja via Chocolatey before version checks, pins vcpkg to a specific commit hash instead of pulling latest, re-bootstraps it, and fixes quoting on the `vcpkg.exe version` command — all well-targeted CI reliability improvements. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AppVeyor CI Start] --> B[git fetch --tags --force]
    B --> C[choco install ninja]
    C --> D[set PATH with Chocolatey bin]
    D --> E[cd VCPKG_ROOT]
    E --> F[git fetch origin]
    F --> G[git checkout cd61e1e2 - pinned commit]
    G --> H[bootstrap-vcpkg.bat]
    H --> I[cd APPVEYOR_BUILD_FOLDER]
    I --> J[vcvars64.bat]
    J --> K[cmake --version]
    K --> L[ninja --version]
    L --> M[vcpkg.exe version]
    M --> N[Build Script]
    N --> O[vcvars64.bat]
    O --> P[cmake configure with Ninja + vcpkg]
    P --> Q[cmake build Release]
    Q --> R[Artifact: tfs.exe]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[AppVeyor CI Start] --> B[git fetch --tags --force]
    B --> C[choco install ninja]
    C --> D[set PATH with Chocolatey bin]
    D --> E[cd VCPKG_ROOT]
    E --> F[git fetch origin]
    F --> G[git checkout cd61e1e2 - pinned commit]
    G --> H[bootstrap-vcpkg.bat]
    H --> I[cd APPVEYOR_BUILD_FOLDER]
    I --> J[vcvars64.bat]
    J --> K[cmake --version]
    K --> L[ninja --version]
    L --> M[vcpkg.exe version]
    M --> N[Build Script]
    N --> O[vcvars64.bat]
    O --> P[cmake configure with Ninja + vcpkg]
    P --> Q[cmake build Release]
    Q --> R[Artifact: tfs.exe]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;feat/readme-badges&#39; of htt..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/ac79cf0d11454aa1bef5c46567237639ca24d62d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43042289)</sub>

<!-- /greptile_comment -->