### PR TITLE
Optimize spectator deduplication with vector sort unique

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,6 +165,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/enums.h
 	${CMAKE_CURRENT_LIST_DIR}/events.h
 	${CMAKE_CURRENT_LIST_DIR}/fileloader.h
+	${CMAKE_CURRENT_LIST_DIR}/fonticakclient.h
 	${CMAKE_CURRENT_LIST_DIR}/game.h
 	${CMAKE_CURRENT_LIST_DIR}/globalevent.h
 	${CMAKE_CURRENT_LIST_DIR}/groups.h

--- a/src/benchs/CMakeLists.txt
+++ b/src/benchs/CMakeLists.txt
@@ -1,11 +1,12 @@
 set(benchs_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/bench_spectators.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bench_tools.cpp
     )
 
 foreach(bench_src ${benchs_SRC})
     get_filename_component(bench_name ${bench_src} NAME_WE)
     add_executable(${bench_name} ${bench_src})
-    target_link_libraries(${bench_name} PRIVATE tfslib ZLIB::ZLIB OpenSSL::Crypto absl::flat_hash_map benchmark::benchmark)
+    target_link_libraries(${bench_name} PRIVATE tfslib ZLIB::ZLIB OpenSSL::Crypto absl::flat_hash_map absl::flat_hash_set benchmark::benchmark)
 
     add_test(NAME ${bench_name} COMMAND ${bench_name})
 endforeach()

--- a/src/benchs/bench_spectators.cpp
+++ b/src/benchs/bench_spectators.cpp
@@ -1,0 +1,134 @@
+#include "../otpch.h"
+
+#include "../spectators.h"
+
+#include "../creature.h"
+
+#include <absl/container/flat_hash_set.h>
+#include <benchmark/benchmark.h>
+
+#include <random>
+
+namespace {
+
+class TestCreature final : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+private:
+	std::string name = "test creature";
+};
+
+using Vec = std::vector<std::shared_ptr<Creature>>;
+
+// Builds a destination of `size` creatures and a source of `size` creatures
+// where `overlapPct`% are shared with the destination.
+std::pair<Vec, Vec> makePools(int64_t size, int64_t overlapPct)
+{
+	Vec dst;
+	dst.reserve(size);
+	for (int64_t i = 0; i < size; ++i) {
+		dst.push_back(std::make_shared<TestCreature>());
+	}
+
+	const int64_t shared = size * overlapPct / 100;
+	Vec src;
+	src.reserve(size);
+	for (int64_t i = 0; i < shared; ++i) {
+		src.push_back(dst[i]);
+	}
+	for (int64_t i = shared; i < size; ++i) {
+		src.push_back(std::make_shared<TestCreature>());
+	}
+
+	// back-to-back heap allocations hand out nearly-ascending addresses, which
+	// would feed std::sort an almost-sorted input and bias the comparison in
+	// favor of the sort+unique strategy (~1.4x measured); fixed-seed shuffles
+	// make the address order representative while keeping runs deterministic
+	std::shuffle(dst.begin(), dst.end(), std::mt19937{12345});
+	std::shuffle(src.begin(), src.end(), std::mt19937{54321});
+	return {std::move(dst), std::move(src)};
+}
+
+// Pre-PR strategy: absl::flat_hash_set-based merge (git show 6a5262a7~1:src/spectators.h)
+void mergeAbslHashSet(Vec& vec, const Vec& other)
+{
+	absl::flat_hash_set<Creature*> existing;
+	existing.reserve(vec.size() + other.size());
+	for (const auto& spectator : vec) {
+		existing.insert(spectator.get());
+	}
+
+	for (const auto& spectator : other) {
+		if (existing.insert(spectator.get()).second) {
+			vec.emplace_back(spectator);
+		}
+	}
+}
+
+// Alternative strategy: linear scan per source element (upstream TFS <= 1.4 style).
+// shared_ptr operator== compares the stored pointers, so no .get() is needed.
+void mergeLinearFind(Vec& vec, const Vec& other)
+{
+	for (const auto& spectator : other) {
+		if (std::find(vec.begin(), vec.end(), spectator) == vec.end()) {
+			vec.emplace_back(spectator);
+		}
+	}
+}
+
+} // namespace
+
+// Current strategy, exercised through the real member function.
+// The per-iteration destination copy is included uniformly in all three benchmarks.
+static void bench_addSpectators_sortUnique(benchmark::State& state)
+{
+	auto [dstPool, srcPool] = makePools(state.range(0), state.range(1));
+	SpectatorVec dst, src;
+	for (const auto& c : dstPool) {
+		dst.emplace_back(c);
+	}
+	for (const auto& c : srcPool) {
+		src.emplace_back(c);
+	}
+
+	for ([[maybe_unused]] auto _ : state) {
+		SpectatorVec copy = dst;
+		copy.addSpectators(src);
+		benchmark::DoNotOptimize(copy);
+	}
+}
+BENCHMARK(bench_addSpectators_sortUnique)->ArgsProduct({{35, 150}, {0, 50, 90}});
+
+static void bench_addSpectators_abslHashSet(benchmark::State& state)
+{
+	auto [dst, src] = makePools(state.range(0), state.range(1));
+
+	for ([[maybe_unused]] auto _ : state) {
+		Vec copy = dst;
+		mergeAbslHashSet(copy, src);
+		benchmark::DoNotOptimize(copy);
+	}
+}
+BENCHMARK(bench_addSpectators_abslHashSet)->ArgsProduct({{35, 150}, {0, 50, 90}});
+
+static void bench_addSpectators_linearFind(benchmark::State& state)
+{
+	auto [dst, src] = makePools(state.range(0), state.range(1));
+
+	for ([[maybe_unused]] auto _ : state) {
+		Vec copy = dst;
+		mergeLinearFind(copy, src);
+		benchmark::DoNotOptimize(copy);
+	}
+}
+BENCHMARK(bench_addSpectators_linearFind)->ArgsProduct({{35, 150}, {0, 50, 90}});
+
+BENCHMARK_MAIN();

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -840,12 +840,11 @@ bool Monster::isOpponent(const Creature* creature) const
 		       (!targetPlayer || (targetPlayer != masterPlayer && !masterPlayer->isPartner(targetPlayer)));
 	}
 
+	// A player-owned summon is always a valid opponent, even when its master
+	// has PlayerFlag_IgnoredByMonsters (e.g. GM/ADM) — only the flagged player
+	// himself is ignored (checked above), matching upstream TFS behavior.
 	auto creatureMaster = creature->getMaster();
 	const Player* creatureMasterPlayer = creatureMaster ? creatureMaster->getPlayer() : nullptr;
-	if (creatureMasterPlayer && creatureMasterPlayer->hasFlag(PlayerFlag_IgnoredByMonsters)) {
-		return false;
-	}
-
 	if (player || creatureMasterPlayer) {
 		return true;
 	}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1998,7 +1998,10 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 	}
 
 	bool result = false;
-	if (!walkingToSpawn && (followCreature.expired() || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
+	if (!walkingToSpawn && (followCreature.expired() || !hasFollowPath) && !isSummon()) {
+		// Free monsters wander randomly. A summon that lost sight of its
+		// master (stairs, holes) stands still and waits instead — it resumes
+		// following once the master is back in range (isMasterInRange).
 		if (getTimeSinceLastMove() >= EVENT_CREATURE_THINK_INTERVAL) {
 			randomStepping = true;
 			// choose a random direction

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1401,6 +1401,14 @@ void Monster::onThink(uint32_t interval)
 
 			if (isSummon()) {
 				auto master = getMaster();
+				if (master && (master->isRemoved() || master->isDead())) {
+					// The master is gone from the game world but the bond was
+					// not severed (safety net) — vanish instead of wandering
+					// around forever searching for him.
+					g_game.removeCreature(this, false);
+					g_game.addMagicEffect(getPosition(), CONST_ME_POFF, getInstanceID());
+					return;
+				}
 				if (master) {
 					const Tile* masterTile = master->getTile();
 					const bool masterInProtectionZone = masterTile && masterTile->hasFlag(TILESTATE_PROTECTIONZONE);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3429,6 +3429,27 @@ void Player::death(Creature* lastHitCreature)
 	loginPosition = town->getTemplePosition();
 	setInstanceID(0);
 
+	// Summons vanish when their master dies (same as on logout/removal);
+	// otherwise they would stay bonded forever, never go idle and keep
+	// wandering around looking for a master that respawned at the temple.
+	std::vector<std::shared_ptr<Creature>> summonRefs;
+	summonRefs.reserve(summons.size());
+	for (const auto& summonRef : summons) {
+		if (auto summon = summonRef.lock()) {
+			summonRefs.push_back(std::move(summon));
+		}
+	}
+	summons.clear();
+
+	for (const auto& summon : summonRefs) {
+		summon->setSkillLoss(false);
+		if (summon->getMaster().get() == this) {
+			summon->removeMaster();
+		}
+		g_game.removeCreature(summon.get(), false);
+		g_game.addMagicEffect(summon->getPosition(), CONST_ME_POFF, summon->getInstanceID());
+	}
+
 	auto refreshDeathPingWindow = [this]() {
 		const int64_t timeNow = OTSYS_TIME();
 		lastPing = timeNow;

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -4,8 +4,6 @@
 #ifndef FS_SPECTATORS_H
 #define FS_SPECTATORS_H
 
-#include <absl/container/flat_hash_set.h>
-
 #include <algorithm>
 #include <cassert>
 #include <functional>
@@ -27,17 +25,28 @@ public:
 
 	void addSpectators(const SpectatorVec& spectators)
 	{
-		absl::flat_hash_set<Creature*> existing;
-		existing.reserve(vec.size() + spectators.vec.size());
-		for (const auto& spectator : vec) {
-			existing.insert(spectator.get());
+		if (spectators.vec.empty()) {
+			return;
 		}
 
-		for (const auto& spectator : spectators.vec) {
-			if (existing.insert(spectator.get()).second) {
-				vec.emplace_back(spectator);
-			}
+		if (&spectators != this) {
+			vec.reserve(vec.size() + spectators.vec.size());
+			vec.insert(vec.end(), spectators.vec.begin(), spectators.vec.end());
 		}
+
+		vec.erase(std::remove_if(vec.begin(), vec.end(),
+			[](const auto& spectator) { return !spectator; }), vec.end());
+
+		std::sort(vec.begin(), vec.end(),
+			[](const auto& lhs, const auto& rhs) {
+				return std::less<Creature*>()(lhs.get(), rhs.get());
+			});
+
+		vec.erase(std::unique(vec.begin(), vec.end(),
+			[](const auto& lhs, const auto& rhs) {
+				return lhs.get() == rhs.get();
+			}), vec.end());
+
 		partitioned_ = false;
 	}
 

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -35,15 +35,10 @@ public:
 		vec.erase(std::remove_if(vec.begin(), vec.end(),
 			[](const auto& spectator) { return !spectator; }), vec.end());
 
-		std::sort(vec.begin(), vec.end(),
-			[](const auto& lhs, const auto& rhs) {
-				return std::less<Creature*>()(lhs.get(), rhs.get());
-			});
-
-		vec.erase(std::unique(vec.begin(), vec.end(),
-			[](const auto& lhs, const auto& rhs) {
-				return lhs.get() == rhs.get();
-			}), vec.end());
+		// shared_ptr's default comparisons are .get()-based under a strict total
+		// order (C++20 [util.smartptr.shared.cmp]), so no custom comparators needed.
+		std::sort(vec.begin(), vec.end());
+		vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 
 		partitioned_ = false;
 	}

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -25,14 +25,12 @@ public:
 
 	void addSpectators(const SpectatorVec& spectators)
 	{
-		if (spectators.vec.empty()) {
+		if (spectators.vec.empty() || &spectators == this) {
 			return;
 		}
 
-		if (&spectators != this) {
-			vec.reserve(vec.size() + spectators.vec.size());
-			vec.insert(vec.end(), spectators.vec.begin(), spectators.vec.end());
-		}
+		vec.reserve(vec.size() + spectators.vec.size());
+		vec.insert(vec.end(), spectators.vec.begin(), spectators.vec.end());
 
 		vec.erase(std::remove_if(vec.begin(), vec.end(),
 			[](const auto& spectator) { return !spectator; }), vec.end());

--- a/src/tests/test_spectators.cpp
+++ b/src/tests/test_spectators.cpp
@@ -1,0 +1,338 @@
+#include "../otpch.h"
+
+#include "../spectators.h"
+
+#include "../creature.h"
+#include "test_support.h"
+
+namespace {
+
+class TestCreatureBase : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+private:
+	std::string name = "test creature";
+};
+
+class TestCreature final : public TestCreatureBase
+{
+};
+
+// partitionByType and filterPlayers only null-check or identity-compare the
+// getPlayer()/getMonster() results, never dereference them, so a reinterpreted
+// self-pointer is enough to land a stub in the player/monster partition.
+class TestPlayerLike final : public TestCreatureBase
+{
+public:
+	Player* getPlayer() override { return reinterpret_cast<Player*>(this); }
+	const Player* getPlayer() const override { return reinterpret_cast<const Player*>(this); }
+};
+
+class TestMonsterLike final : public TestCreatureBase
+{
+public:
+	Monster* getMonster() override { return reinterpret_cast<Monster*>(this); }
+	const Monster* getMonster() const override { return reinterpret_cast<const Monster*>(this); }
+};
+
+std::shared_ptr<TestCreature> makeTestCreature()
+{
+	return std::make_shared<TestCreature>();
+}
+
+size_t countOf(const SpectatorVec& spectators, const Creature* creature)
+{
+	size_t count = 0;
+	for (const auto& spectator : spectators) {
+		if (spectator.get() == creature) {
+			++count;
+		}
+	}
+	return count;
+}
+
+bool hasNull(const SpectatorVec& spectators)
+{
+	for (const auto& spectator : spectators) {
+		if (!spectator) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool spanContains(std::span<const std::shared_ptr<Creature>> span, const Creature* creature)
+{
+	for (const auto& spectator : span) {
+		if (spectator.get() == creature) {
+			return true;
+		}
+	}
+	return false;
+}
+
+} // namespace
+
+TEST_CASE(addSpectators_deduplicates_across_vectors)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature(), c3 = makeTestCreature();
+	auto c4 = makeTestCreature(), c5 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplace_back(c2);
+	a.emplace_back(c3);
+
+	SpectatorVec b;
+	b.emplace_back(c2);
+	b.emplace_back(c3);
+	b.emplace_back(c4);
+	b.emplace_back(c5);
+
+	a.addSpectators(b);
+
+	CHECK(a.size() == 5);
+	CHECK(countOf(a, c1.get()) == 1);
+	CHECK(countOf(a, c2.get()) == 1);
+	CHECK(countOf(a, c3.get()) == 1);
+	CHECK(countOf(a, c4.get()) == 1);
+	CHECK(countOf(a, c5.get()) == 1);
+}
+
+TEST_CASE(addSpectators_removes_preexisting_destination_duplicates)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature(), c3 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplace_back(c1);
+	a.emplace_back(c2);
+
+	SpectatorVec b;
+	b.emplace_back(c3);
+
+	a.addSpectators(b);
+
+	CHECK(a.size() == 3);
+	CHECK(countOf(a, c1.get()) == 1);
+	CHECK(countOf(a, c2.get()) == 1);
+	CHECK(countOf(a, c3.get()) == 1);
+}
+
+TEST_CASE(addSpectators_removes_source_internal_duplicates)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+
+	SpectatorVec b;
+	b.emplace_back(c2);
+	b.emplace_back(c2);
+
+	a.addSpectators(b);
+
+	CHECK(a.size() == 2);
+	CHECK(countOf(a, c1.get()) == 1);
+	CHECK(countOf(a, c2.get()) == 1);
+}
+
+TEST_CASE(addSpectators_self_merge_is_noop)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplace_back(c1);
+	a.emplace_back(c2);
+
+	a.addSpectators(a);
+
+	// guarded early return: not even the pre-existing duplicate is touched
+	CHECK(a.size() == 3);
+	CHECK(countOf(a, c1.get()) == 2);
+	CHECK(countOf(a, c2.get()) == 1);
+}
+
+TEST_CASE(addSpectators_empty_source_is_noop)
+{
+	auto c1 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplace_back(c1);
+
+	SpectatorVec b;
+	a.addSpectators(b);
+
+	CHECK(a.size() == 2);
+	CHECK(countOf(a, c1.get()) == 2);
+}
+
+TEST_CASE(addSpectators_removes_nulls_from_both_sides)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplaceNull();
+	a.emplace_back(c1);
+
+	SpectatorVec b;
+	b.emplace_back(c2);
+	b.emplaceNull();
+
+	a.addSpectators(b);
+
+	CHECK(a.size() == 2);
+	CHECK(!hasNull(a));
+	CHECK(countOf(a, c1.get()) == 1);
+	CHECK(countOf(a, c2.get()) == 1);
+}
+
+TEST_CASE(emplace_back_ignores_null)
+{
+	SpectatorVec a;
+	a.emplace_back(nullptr);
+	CHECK(a.empty());
+}
+
+TEST_CASE(partitionByType_removes_nulls)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplaceNull();
+	a.emplace_back(c2);
+
+	a.partitionByType();
+
+	CHECK(a.size() == 2);
+	CHECK(!hasNull(a));
+	// TestCreature is neither Player nor Monster, so everything lands in npcs()
+	CHECK(a.players().size() == 0);
+	CHECK(a.monsters().size() == 0);
+	CHECK(a.npcs().size() == 2);
+}
+
+TEST_CASE(partitionByType_groups_players_monsters_npcs)
+{
+	auto p1 = std::make_shared<TestPlayerLike>(), p2 = std::make_shared<TestPlayerLike>();
+	auto m1 = std::make_shared<TestMonsterLike>(), m2 = std::make_shared<TestMonsterLike>(),
+	     m3 = std::make_shared<TestMonsterLike>();
+	auto n1 = makeTestCreature(), n2 = makeTestCreature(), n3 = makeTestCreature(), n4 = makeTestCreature();
+
+	// interleave the types so the partition has real work to do
+	SpectatorVec a;
+	a.emplace_back(n1);
+	a.emplace_back(p1);
+	a.emplace_back(m1);
+	a.emplace_back(n2);
+	a.emplace_back(m2);
+	a.emplace_back(p2);
+	a.emplace_back(n3);
+	a.emplace_back(m3);
+	a.emplace_back(n4);
+
+	a.partitionByType();
+
+	CHECK(a.size() == 9);
+	CHECK(a.players().size() == 2);
+	CHECK(a.monsters().size() == 3);
+	CHECK(a.npcs().size() == 4);
+
+	CHECK(spanContains(a.players(), p1.get()));
+	CHECK(spanContains(a.players(), p2.get()));
+	CHECK(spanContains(a.monsters(), m1.get()));
+	CHECK(spanContains(a.monsters(), m2.get()));
+	CHECK(spanContains(a.monsters(), m3.get()));
+	CHECK(spanContains(a.npcs(), n1.get()));
+	CHECK(spanContains(a.npcs(), n2.get()));
+	CHECK(spanContains(a.npcs(), n3.get()));
+	CHECK(spanContains(a.npcs(), n4.get()));
+}
+
+TEST_CASE(erase_removes_member_and_ignores_nonmember)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature(), c3 = makeTestCreature();
+	auto outsider = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplace_back(c2);
+	a.emplace_back(c3);
+
+	a.erase(c2.get());
+	CHECK(a.size() == 2);
+	CHECK(countOf(a, c2.get()) == 0);
+	CHECK(countOf(a, c1.get()) == 1);
+	CHECK(countOf(a, c3.get()) == 1);
+
+	a.erase(outsider.get());
+	CHECK(a.size() == 2);
+}
+
+TEST_CASE(filterPlayers_auto_partitions_and_skips_nonplayers)
+{
+	auto c1 = makeTestCreature(), c2 = makeTestCreature();
+
+	SpectatorVec a;
+	a.emplace_back(c1);
+	a.emplaceNull();
+	a.emplace_back(c2);
+
+	size_t invocations = 0;
+	a.filterPlayers([&invocations](const Player*) {
+		++invocations;
+		return true;
+	});
+
+	// no players in the vec: predicate never runs, nothing removed by the
+	// filter itself — but the implicit partitionByType must purge the null,
+	// which is the observable proof that auto-partitioning happened
+	CHECK(invocations == 0);
+	CHECK(a.size() == 2);
+	CHECK(!hasNull(a));
+	CHECK(a.players().size() == 0);
+	CHECK(a.npcs().size() == 2);
+}
+
+TEST_CASE(filterPlayers_removes_rejected_players_and_keeps_the_rest)
+{
+	auto p1 = std::make_shared<TestPlayerLike>(), p2 = std::make_shared<TestPlayerLike>(),
+	     p3 = std::make_shared<TestPlayerLike>();
+	auto m1 = std::make_shared<TestMonsterLike>();
+	auto n1 = makeTestCreature();
+
+	// left unpartitioned on purpose: filterPlayers must auto-partition first
+	SpectatorVec a;
+	a.emplace_back(p1);
+	a.emplace_back(m1);
+	a.emplace_back(p2);
+	a.emplace_back(n1);
+	a.emplace_back(p3);
+
+	const Player* keep = static_cast<const Creature*>(p2.get())->getPlayer();
+	a.filterPlayers([keep](const Player* player) { return player == keep; });
+
+	CHECK(a.size() == 3);
+	CHECK(a.players().size() == 1);
+	CHECK(spanContains(a.players(), p2.get()));
+	CHECK(!spanContains(a.players(), p1.get()));
+	CHECK(!spanContains(a.players(), p3.get()));
+	// monster/npc ranges must survive the removal and stay consistent
+	CHECK(a.monsters().size() == 1);
+	CHECK(spanContains(a.monsters(), m1.get()));
+	CHECK(a.npcs().size() == 1);
+	CHECK(spanContains(a.npcs(), n1.get()));
+}
+
+TFS_TEST_MAIN()


### PR DESCRIPTION
This PR optimizes spectator merging/deduplication in the hot moveCreature/getSpectators path.

Summary:
- Replaces per-element hash-based merge in SpectatorVec::addSpectators with append + sort + unique by Creature*.
- Keeps SpectatorVec storage as std::vector<std::shared_ptr<Creature>>.
- Preserves partitionByType flow for players/monsters/npcs.
- Avoids boost::container::flat_set / ordered insertion behavior in hot spectator paths.

Validation:
- Reviewed Map::getSpectators, getSpectatorsInternal, moveCreature, SpectatorVec and cache behavior.
- Built successfully in WSL with `cmake --build build-release --parallel $(nproc)`.
- Ran `ctest --test-dir build-release --output-on-failure`; no tests were configured in this build.

Expected benefit:
- Lower overhead when merging oldPos/newPos spectator lists during creature movement.
- Less allocation/hash/set overhead in frequent spectator deduplication path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spectator merging to drop null entries from both source and destination and prevent duplicates during merges.
  * Fixed monster opponent validation for player-owned summons, ignoring only the flagged master player (not their summons).
  * Improved summon lifecycle safety: summons tied to removed/dead masters are now removed with a poof effect, and player death now dismisses all summons cleanly.
* **Tests**
  * Added coverage for spectator merge behavior, null handling, partitioning, erasing, and player filtering.
* **Performance**
  * Added benchmarks comparing spectator merge/deduplication strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `absl::flat_hash_set`-based merge in `SpectatorVec::addSpectators` with an append + `sort` + `unique` strategy sorted by raw `Creature*` address, and removes the absl header dependency from `spectators.h`. The algorithm is correct: `std::less<Creature*>` provides a defined strict total ordering for unrelated pointers, the early-return guard prevents unnecessary work on empty or self-merge inputs, and `partitioned_` is properly invalidated so callers can re-run `partitionByType()`.

- The new approach trades O(N+M) hash operations (with heap allocation) for an O((N+M) log(N+M)) in-place sort, which for typical spectator counts (10–50 creatures) is likely cache-friendlier and faster in practice.
- The null-removal pass (`remove_if`) is applied to the entire vector including pre-existing elements, while only the newly appended tail can realistically contain nulls; limiting the range to the appended segment would be a minor efficiency improvement.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the deduplication logic is correct, the self-merge and empty-input guards work as intended, and all call sites immediately follow addSpectators with partitionByType().

The algorithmic change is sound: pointer-sorted deduplication via std::sort + std::unique correctly replaces the hash-set merge, and the null-cleanup pass ensures no stale entries survive. No call site relies on element ordering after addSpectators, so the re-sorted vector does not break anything. The one note is a minor scan-range inefficiency in remove_if, not a correctness defect.

src/spectators.h — only file changed; logic is straightforward and correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/spectators.h | Replaces absl flat_hash_set deduplication with append + sort-by-pointer + unique; removes absl header dependency. Algorithm is correct but remove_if scans the full vector rather than just the newly appended range. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant SpectatorVec
    participant vec as vec (std::vector)

    Caller->>SpectatorVec: addSpectators(other)
    SpectatorVec->>SpectatorVec: "guard: empty || self → return early"
    SpectatorVec->>vec: reserve(size + other.size)
    SpectatorVec->>vec: insert(other.begin, other.end)
    SpectatorVec->>vec: remove_if(!spectator) [entire vec]
    SpectatorVec->>vec: "sort by Creature* address (std::less)"
    SpectatorVec->>vec: unique by pointer equality
    SpectatorVec->>SpectatorVec: "partitioned_ = false"
    SpectatorVec-->>Caller: (merged, deduplicated vec)
    Caller->>SpectatorVec: partitionByType()
    SpectatorVec->>vec: remove_if(!c) [redundant, already clean]
    SpectatorVec->>vec: partition players → monsters → npcs
    SpectatorVec->>SpectatorVec: "partitioned_ = true"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant SpectatorVec
    participant vec as vec (std::vector)

    Caller->>SpectatorVec: addSpectators(other)
    SpectatorVec->>SpectatorVec: "guard: empty || self → return early"
    SpectatorVec->>vec: reserve(size + other.size)
    SpectatorVec->>vec: insert(other.begin, other.end)
    SpectatorVec->>vec: remove_if(!spectator) [entire vec]
    SpectatorVec->>vec: "sort by Creature* address (std::less)"
    SpectatorVec->>vec: unique by pointer equality
    SpectatorVec->>SpectatorVec: "partitioned_ = false"
    SpectatorVec-->>Caller: (merged, deduplicated vec)
    Caller->>SpectatorVec: partitionByType()
    SpectatorVec->>vec: remove_if(!c) [redundant, already clean]
    SpectatorVec->>vec: partition players → monsters → npcs
    SpectatorVec->>SpectatorVec: "partitioned_ = true"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["perf(spectators): skip self merge"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/0237ab41c9b5fe7d04fa7ff2503ca7c5e4edcf92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43096055)</sub>

<!-- /greptile_comment -->