### PR TITLE
Add FlameGraph profiling tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sh text eol=lf
 
 # Custom for Visual Studio
 *.sln     merge=union

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,14 @@ ipch/
 *.vsp
 *.vspx
 
+# Linux perf / FlameGraph profiling output
+profiling-output/
+perf.data
+perf.data.*
+*.perf
+*.folded
+*.collapsed
+
 # Guidance Automation Toolkit
 *.gpState
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build/
 build-release/
 build-debug/
 build-asan*/
+build-callgrind/
 [Bb]in/
 [Oo]bj/
 cmake-build-*/
@@ -213,6 +214,8 @@ tfs
 # Others
 *.emmyrc.jsondata/scripts/meus/
 build-valgrind-linux/
+tfs-valgrind
+callgrind.out.*
 build-analysis/
 analysis-reports/
 compile_commands.json

--- a/docs/performance/flamegraph.md
+++ b/docs/performance/flamegraph.md
@@ -1,0 +1,182 @@
+# Profiling com Linux perf e FlameGraph
+
+Este guia mostra como medir CPU e stacks do TFS com `perf` e gerar SVGs com
+Brendan Gregg FlameGraph. Use isto para comparar antes/depois em caminhos
+quentes como `Map::getSpectators`, `Map::getSpectatorsInternal`,
+`Map::moveCreature`, `SpectatorVec::addSpectators`, `SpectatorVec::partitionByType`,
+`std::shared_ptr`, `std::sort`, `std::unique` e, em branches antigas,
+`boost::container::flat_set`.
+
+## O que cada ferramenta faz
+
+- `perf record` coleta amostras de CPU e call stacks do processo.
+- `perf script` converte `perf.data` para texto.
+- `stackcollapse-perf.pl` converte o texto do perf para folded stacks.
+- `flamegraph.pl` gera o SVG final.
+
+## Instalar dependencias
+
+No Ubuntu ou WSL:
+
+```bash
+sudo apt update
+sudo apt install -y git perl linux-tools-common linux-tools-generic linux-tools-$(uname -r)
+```
+
+Em alguns kernels de WSL, `linux-tools-$(uname -r)` pode nao existir no apt.
+Nesse caso, instale `linux-tools-common` e `linux-tools-generic`, confira se
+`perf` ficou disponivel, e use uma distro/kernel com suporte a perf se ainda
+faltar.
+
+Instale ou atualize o FlameGraph:
+
+```bash
+git clone https://github.com/brendangregg/FlameGraph ~/FlameGraph
+```
+
+Se a pasta ja existir:
+
+```bash
+git -C ~/FlameGraph pull --ff-only
+```
+
+Tambem ha um helper no repo:
+
+```bash
+./scripts/profiling/setup_flamegraph.sh
+```
+
+## Compilar com simbolos
+
+Para flamegraphs uteis, compile com simbolos e frame pointers:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g -fno-omit-frame-pointer"
+
+cmake --build build -j$(nproc)
+```
+
+Se voce usar o build helper do projeto, confirme que o binario foi compilado
+com `-g` e sem omitir frame pointer quando for fazer comparacao fina.
+
+## Capturar usando PID
+
+Descubra o PID:
+
+```bash
+pidof crystalserver
+```
+
+Capture por 60 segundos:
+
+```bash
+sudo perf record -F 99 -p $(pidof crystalserver) -g -- sleep 60
+```
+
+Gere os arquivos intermediarios e o SVG:
+
+```bash
+mkdir -p profiling-output
+sudo perf script > profiling-output/tfs-before.perf
+
+~/FlameGraph/stackcollapse-perf.pl profiling-output/tfs-before.perf \
+  > profiling-output/tfs-before.folded
+
+~/FlameGraph/flamegraph.pl --title="TFS before getSpectators" \
+  profiling-output/tfs-before.folded > profiling-output/tfs-before.svg
+```
+
+## Captura com script
+
+Captura completa por nome de processo:
+
+```bash
+./scripts/profiling/capture_flamegraph.sh \
+  --process crystalserver \
+  --duration 60 \
+  --title "TFS before getSpectators" \
+  --output profiling-output/tfs-before.svg
+```
+
+Captura por PID:
+
+```bash
+./scripts/profiling/capture_flamegraph.sh \
+  --pid 12345 \
+  --duration 60 \
+  --title "TFS after getSpectators" \
+  --output profiling-output/tfs-after.svg
+```
+
+## Flamegraph filtrado para spectators
+
+Depois de uma captura, voce pode gerar um SVG somente com stacks relevantes:
+
+```bash
+grep -Ei "getSpectators|moveCreature|SpectatorVec|shared_ptr|sort|unique|flat_set" \
+  profiling-output/tfs-before.folded \
+  | ~/FlameGraph/flamegraph.pl --title="TFS spectators only" \
+  > profiling-output/spectators-only.svg
+```
+
+Ou use o script diretamente:
+
+```bash
+./scripts/profiling/capture_flamegraph.sh \
+  --process crystalserver \
+  --duration 60 \
+  --title "TFS spectators only" \
+  --output profiling-output/spectators-only.svg \
+  --filter "getSpectators|moveCreature|SpectatorVec|shared_ptr|sort|unique|flat_set"
+```
+
+## Comparar before/after
+
+1. Compile o branch base com simbolos.
+2. Rode um cenario reproduzivel: muitos monstros andando, spells em area,
+   teleportes e players se movendo perto de muitos spectators.
+3. Gere `profiling-output/tfs-before.svg`.
+4. Troque para o branch otimizado, recompile do mesmo jeito.
+5. Rode o mesmo cenario e gere `profiling-output/tfs-after.svg`.
+6. Compare visualmente a largura dos frames.
+
+Funcoes para procurar no SVG:
+
+- `Map::getSpectators`
+- `Map::getSpectatorsInternal`
+- `Map::moveCreature`
+- `SpectatorVec::addSpectators`
+- `SpectatorVec::partitionByType`
+- `std::shared_ptr`
+- `std::sort`
+- `std::unique`
+- `boost::container::flat_set`
+
+Se `std::sort` ou `std::unique` aparecerem maiores que o custo removido, a
+otimizacao deve ser reavaliada.
+
+## Permissao do perf
+
+Se o `perf` falhar com erro de permissao:
+
+```bash
+sudo sysctl kernel.perf_event_paranoid=1
+sudo sysctl kernel.kptr_restrict=0
+```
+
+Essas alteracoes duram ate reiniciar. Para persistir, configure em
+`/etc/sysctl.d/`, mas faca isso so em ambiente de desenvolvimento.
+
+## Arquivos gerados
+
+Os arquivos de profiling devem ficar fora do git:
+
+- `profiling-output/`
+- `perf.data`
+- `perf.data.*`
+- `*.perf`
+- `*.folded`
+- `*.collapsed`
+
+Nao commite SVGs de teste, logs grandes, caches ou binarios de build.

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -1,0 +1,22 @@
+# Profiling scripts
+
+Helpers for Linux perf and Brendan Gregg FlameGraph.
+
+Start here:
+
+```bash
+./scripts/profiling/setup_flamegraph.sh
+```
+
+Then capture a full flamegraph:
+
+```bash
+./scripts/profiling/capture_flamegraph.sh \
+  --process crystalserver \
+  --duration 60 \
+  --title "TFS before getSpectators" \
+  --output profiling-output/tfs-before.svg
+```
+
+See `docs/performance/flamegraph.md` for the full PT-BR guide, including
+filtered spectator flamegraphs and before/after comparison notes.

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -17,6 +17,14 @@ The wrapper selects a compatible versioned `perf` binary on WSL when the
 `/usr/bin/perf` launcher does not support the running kernel. Extra capture
 options are forwarded to `capture_flamegraph.sh`.
 
+For a Callgrind-friendly build with separate translation units and debug
+symbols, run:
+
+```bash
+bash tools/build-callgrind.sh
+valgrind --tool=callgrind --callgrind-out-file=callgrind.out.%p ./tfs-valgrind
+```
+
 Start here:
 
 ```bash

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -8,6 +8,11 @@ For the default `tfs` process, run:
 bash tools/run-flamegraph.sh
 ```
 
+If `tfs` is not already running, the wrapper starts `build-release/tfs`, waits
+for the server to become online, captures it, and stops that instance when the
+capture finishes. An existing `tfs` process is only attached to and remains
+running.
+
 The wrapper selects a compatible versioned `perf` binary on WSL when the
 `/usr/bin/perf` launcher does not support the running kernel. Extra capture
 options are forwarded to `capture_flamegraph.sh`.

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -2,6 +2,16 @@
 
 Helpers for Linux perf and Brendan Gregg FlameGraph.
 
+For the default `tfs` process, run:
+
+```bash
+bash tools/run-flamegraph.sh
+```
+
+The wrapper selects a compatible versioned `perf` binary on WSL when the
+`/usr/bin/perf` launcher does not support the running kernel. Extra capture
+options are forwarded to `capture_flamegraph.sh`.
+
 Start here:
 
 ```bash

--- a/scripts/profiling/capture_flamegraph.sh
+++ b/scripts/profiling/capture_flamegraph.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  capture_flamegraph.sh --pid PID [options]
+  capture_flamegraph.sh --process NAME [options]
+
+Options:
+  --pid PID              Target process id.
+  --process NAME         Resolve PID with pidof.
+  --duration SECONDS     Capture duration. Default: 60.
+  --freq HZ              Sampling frequency. Default: 99.
+  --title TITLE          FlameGraph title. Default: TFS flamegraph.
+  --output PATH          Output SVG. Default: profiling-output/tfs.svg.
+  --filter REGEX         Filter folded stacks before rendering.
+  -h, --help             Show this help.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+pid=""
+process_name=""
+duration="60"
+freq="99"
+title="TFS flamegraph"
+output="profiling-output/tfs.svg"
+filter=""
+
+while (($# > 0)); do
+  case "$1" in
+    --pid)
+      [[ $# -ge 2 ]] || die "--pid requires a value"
+      pid="$2"
+      shift 2
+      ;;
+    --process)
+      [[ $# -ge 2 ]] || die "--process requires a value"
+      process_name="$2"
+      shift 2
+      ;;
+    --duration)
+      [[ $# -ge 2 ]] || die "--duration requires a value"
+      duration="$2"
+      shift 2
+      ;;
+    --freq)
+      [[ $# -ge 2 ]] || die "--freq requires a value"
+      freq="$2"
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || die "--title requires a value"
+      title="$2"
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || die "--output requires a value"
+      output="$2"
+      shift 2
+      ;;
+    --filter)
+      [[ $# -ge 2 ]] || die "--filter requires a value"
+      filter="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "${pid}" || -n "${process_name}" ]] || die "use --pid or --process"
+[[ -z "${pid}" || -z "${process_name}" ]] || die "use only one of --pid or --process"
+[[ "${duration}" =~ ^[0-9]+$ ]] || die "--duration must be an integer"
+[[ "${freq}" =~ ^[0-9]+$ ]] || die "--freq must be an integer"
+
+if [[ -n "${process_name}" ]]; then
+  command -v pidof >/dev/null 2>&1 || die "pidof not found"
+  pid="$(pidof -s "${process_name}" || true)"
+  [[ -n "${pid}" ]] || die "process not found: ${process_name}"
+fi
+
+[[ "${pid}" =~ ^[0-9]+$ ]] || die "invalid PID: ${pid}"
+kill -0 "${pid}" 2>/dev/null || die "PID is not running or cannot be inspected: ${pid}"
+
+command -v perf >/dev/null 2>&1 || die "perf not found. Run scripts/profiling/setup_flamegraph.sh first."
+command -v perl >/dev/null 2>&1 || die "perl not found"
+
+flamegraph_dir="${FLAMEGRAPH_DIR:-${HOME}/FlameGraph}"
+stackcollapse="${flamegraph_dir}/stackcollapse-perf.pl"
+flamegraph="${flamegraph_dir}/flamegraph.pl"
+
+[[ -f "${stackcollapse}" ]] || die "missing ${stackcollapse}. Run setup_flamegraph.sh first."
+[[ -f "${flamegraph}" ]] || die "missing ${flamegraph}. Run setup_flamegraph.sh first."
+
+output_dir="$(dirname -- "${output}")"
+output_file="$(basename -- "${output}")"
+base_name="${output_file%.svg}"
+intermediate_dir="profiling-output"
+
+mkdir -p "${output_dir}" "${intermediate_dir}"
+
+perf_data="${intermediate_dir}/${base_name}.perf.data"
+perf_script="${intermediate_dir}/${base_name}.perf"
+folded="${intermediate_dir}/${base_name}.folded"
+filtered_folded="${intermediate_dir}/${base_name}.filtered.folded"
+
+use_sudo=0
+record_cmd=(perf record -F "${freq}" -p "${pid}" -g -o "${perf_data}" -- sleep "${duration}")
+if [[ "${PERF_USE_SUDO:-1}" != "0" && "${EUID}" -ne 0 ]]; then
+  command -v sudo >/dev/null 2>&1 || die "sudo not found. Set PERF_USE_SUDO=0 if perf is allowed without sudo."
+  use_sudo=1
+  record_cmd=(sudo "${record_cmd[@]}")
+fi
+
+printf 'Capturing PID %s for %ss at %s Hz...\n' "${pid}" "${duration}" "${freq}"
+"${record_cmd[@]}"
+
+printf 'Writing perf script: %s\n' "${perf_script}"
+if [[ "${use_sudo}" -eq 1 ]]; then
+  sudo perf script -i "${perf_data}" > "${perf_script}"
+else
+  perf script -i "${perf_data}" > "${perf_script}"
+fi
+
+printf 'Writing folded stacks: %s\n' "${folded}"
+perl "${stackcollapse}" "${perf_script}" > "${folded}"
+
+render_input="${folded}"
+if [[ -n "${filter}" ]]; then
+  printf 'Filtering folded stacks with regex: %s\n' "${filter}"
+  if ! grep -Ei "${filter}" "${folded}" > "${filtered_folded}"; then
+    die "no folded stacks matched filter: ${filter}"
+  fi
+  render_input="${filtered_folded}"
+fi
+
+printf 'Writing flamegraph SVG: %s\n' "${output}"
+perl "${flamegraph}" --title="${title}" "${render_input}" > "${output}"
+
+printf 'Done.\n'
+printf 'Intermediate files:\n'
+printf '  %s\n' "${perf_data}" "${perf_script}" "${folded}"
+if [[ -n "${filter}" ]]; then
+  printf '  %s\n' "${filtered_folded}"
+fi

--- a/scripts/profiling/capture_flamegraph.sh
+++ b/scripts/profiling/capture_flamegraph.sh
@@ -92,7 +92,8 @@ fi
 
 [[ "${pid}" =~ ^[0-9]+$ ]] || die "invalid PID: ${pid}"
 
-command -v perf >/dev/null 2>&1 || die "perf not found. Run scripts/profiling/setup_flamegraph.sh first."
+perf_bin="$(command -v "${PERF_BIN:-perf}" || true)"
+[[ -n "${perf_bin}" ]] || die "perf not found. Run scripts/profiling/setup_flamegraph.sh first."
 command -v perl >/dev/null 2>&1 || die "perl not found"
 
 flamegraph_dir="${FLAMEGRAPH_DIR:-${HOME}/FlameGraph}"
@@ -115,7 +116,7 @@ folded="${intermediate_dir}/${base_name}.folded"
 filtered_folded="${intermediate_dir}/${base_name}.filtered.folded"
 
 use_sudo=0
-record_cmd=(perf record -F "${freq}" -p "${pid}" -g -o "${perf_data}" -- sleep "${duration}")
+record_cmd=("${perf_bin}" record -F "${freq}" -p "${pid}" -g -o "${perf_data}" -- sleep "${duration}")
 if [[ "${PERF_USE_SUDO:-1}" != "0" && "${EUID}" -ne 0 ]]; then
   command -v sudo >/dev/null 2>&1 || die "sudo not found. Set PERF_USE_SUDO=0 if perf is allowed without sudo."
   use_sudo=1
@@ -127,9 +128,9 @@ printf 'Capturing PID %s for %ss at %s Hz...\n' "${pid}" "${duration}" "${freq}"
 
 printf 'Writing perf script: %s\n' "${perf_script}"
 if [[ "${use_sudo}" -eq 1 ]]; then
-  sudo perf script -i "${perf_data}" > "${perf_script}"
+  sudo "${perf_bin}" script -i "${perf_data}" > "${perf_script}"
 else
-  perf script -i "${perf_data}" > "${perf_script}"
+  "${perf_bin}" script -i "${perf_data}" > "${perf_script}"
 fi
 
 printf 'Writing folded stacks: %s\n' "${folded}"

--- a/scripts/profiling/capture_flamegraph.sh
+++ b/scripts/profiling/capture_flamegraph.sh
@@ -81,8 +81,8 @@ done
 
 [[ -n "${pid}" || -n "${process_name}" ]] || die "use --pid or --process"
 [[ -z "${pid}" || -z "${process_name}" ]] || die "use only one of --pid or --process"
-[[ "${duration}" =~ ^[0-9]+$ ]] || die "--duration must be an integer"
-[[ "${freq}" =~ ^[0-9]+$ ]] || die "--freq must be an integer"
+[[ "${duration}" =~ ^[0-9]+$ && "${duration}" -ge 1 ]] || die "--duration must be a positive integer"
+[[ "${freq}" =~ ^[0-9]+$ && "${freq}" -ge 1 ]] || die "--freq must be a positive integer"
 
 if [[ -n "${process_name}" ]]; then
   command -v pidof >/dev/null 2>&1 || die "pidof not found"
@@ -91,7 +91,6 @@ if [[ -n "${process_name}" ]]; then
 fi
 
 [[ "${pid}" =~ ^[0-9]+$ ]] || die "invalid PID: ${pid}"
-kill -0 "${pid}" 2>/dev/null || die "PID is not running or cannot be inspected: ${pid}"
 
 command -v perf >/dev/null 2>&1 || die "perf not found. Run scripts/profiling/setup_flamegraph.sh first."
 command -v perl >/dev/null 2>&1 || die "perl not found"
@@ -106,9 +105,9 @@ flamegraph="${flamegraph_dir}/flamegraph.pl"
 output_dir="$(dirname -- "${output}")"
 output_file="$(basename -- "${output}")"
 base_name="${output_file%.svg}"
-intermediate_dir="profiling-output"
+intermediate_dir="${output_dir}"
 
-mkdir -p "${output_dir}" "${intermediate_dir}"
+mkdir -p "${output_dir}"
 
 perf_data="${intermediate_dir}/${base_name}.perf.data"
 perf_script="${intermediate_dir}/${base_name}.perf"

--- a/scripts/profiling/setup_flamegraph.sh
+++ b/scripts/profiling/setup_flamegraph.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+info() {
+  printf '%s\n' "$*"
+}
+
+sudo_cmd=()
+if [[ "${EUID}" -ne 0 ]]; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo_cmd=(sudo)
+  else
+    warn "sudo nao encontrado; pulando instalacao apt. Rode como root ou instale sudo."
+  fi
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  if ((${#sudo_cmd[@]} > 0)) || [[ "${EUID}" -eq 0 ]]; then
+    info "Atualizando apt..."
+    "${sudo_cmd[@]}" apt-get update
+
+    info "Instalando dependencias basicas..."
+    "${sudo_cmd[@]}" apt-get install -y git perl linux-tools-common linux-tools-generic || \
+      warn "Nao consegui instalar todos os pacotes basicos."
+
+    if ! command -v perf >/dev/null 2>&1; then
+      kernel_tools="linux-tools-$(uname -r)"
+      info "Tentando instalar ${kernel_tools}..."
+      "${sudo_cmd[@]}" apt-get install -y "${kernel_tools}" || \
+        warn "${kernel_tools} nao existe para este kernel. Em WSL, use linux-tools-generic ou uma distro/kernel com perf disponivel."
+    fi
+  fi
+else
+  warn "apt-get nao encontrado; instale git, perl e perf manualmente."
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  warn "git nao encontrado. Instale git e rode este script novamente."
+  exit 1
+fi
+
+flamegraph_dir="${HOME}/FlameGraph"
+if [[ ! -d "${flamegraph_dir}/.git" ]]; then
+  info "Clonando FlameGraph em ${flamegraph_dir}..."
+  git clone https://github.com/brendangregg/FlameGraph "${flamegraph_dir}"
+else
+  info "Atualizando FlameGraph em ${flamegraph_dir}..."
+  git -C "${flamegraph_dir}" pull --ff-only || \
+    warn "Nao consegui atualizar FlameGraph com git pull; mantendo copia local."
+fi
+
+if ! command -v perf >/dev/null 2>&1; then
+  warn "perf ainda nao esta no PATH. Verifique linux-tools do kernel ou suporte do WSL."
+else
+  info "perf encontrado: $(command -v perf)"
+fi
+
+info "FlameGraph pronto em ${flamegraph_dir}"
+info "Se o perf falhar por permissao, veja docs/performance/flamegraph.md."

--- a/src/admin.cpp
+++ b/src/admin.cpp
@@ -6,6 +6,7 @@
 #include "admin.h"
 #include "configmanager.h"
 #include "connection.h"
+#include "game.h"
 #include "iologindata.h"
 #include "logger.h"
 #include "pugicast.h"
@@ -117,5 +118,4 @@ bool Admin::allow(uint32_t ip) const
 
 	return false;
 }
-
 

--- a/tools/build-callgrind.sh
+++ b/tools/build-callgrind.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/build-callgrind"
+OUTPUT_BIN="${ROOT_DIR}/tfs-valgrind"
+JOBS="${JOBS:-$(nproc)}"
+
+source "${ROOT_DIR}/tools/cmake-linux-env.sh"
+
+cd "${ROOT_DIR}"
+
+echo "Iniciando a preparacao do ambiente..."
+[[ "${BUILD_DIR}" == "${ROOT_DIR}/build-callgrind" ]] || {
+	echo "Diretorio de build invalido: ${BUILD_DIR}" >&2
+	exit 1
+}
+rm -rf -- "${BUILD_DIR}"
+
+if ! command -v cmake >/dev/null 2>&1; then
+	echo "cmake not found" >&2
+	exit 1
+fi
+
+if ! command -v ninja >/dev/null 2>&1; then
+	echo "ninja not found" >&2
+	exit 1
+fi
+
+tfs_check_lua55_paths
+
+echo "Configurando o CMake..."
+cmake_args=(
+	-S .
+	-B "${BUILD_DIR}"
+	-G Ninja
+	-DCMAKE_BUILD_TYPE=RelWithDebInfo
+	-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2\ -g\ -fno-omit-frame-pointer
+	-DENABLE_NATIVE_OPTIMIZATIONS=OFF
+	-DENABLE_SLOW_TASK_DETECTION=OFF
+	-DUSE_MIMALLOC=OFF
+	-DENABLE_UNITY_BUILD=OFF
+	-DBUILD_TESTING=OFF
+	-DBUILD_BENCHMARKING=OFF
+)
+tfs_append_linux_cmake_cache_args cmake_args
+cmake "${cmake_args[@]}"
+
+echo "Compilando..."
+cmake --build "${BUILD_DIR}" --parallel "${JOBS}"
+
+if [[ ! -x "${BUILD_DIR}/tfs" ]]; then
+	echo "Binario Callgrind nao encontrado: ${BUILD_DIR}/tfs" >&2
+	exit 1
+fi
+
+echo "Copiando executavel..."
+cp "${BUILD_DIR}/tfs" "${OUTPUT_BIN}"
+chmod +x "${OUTPUT_BIN}"
+
+echo "Build finalizada! ${OUTPUT_BIN} esta pronto para uso."

--- a/tools/run-flamegraph.sh
+++ b/tools/run-flamegraph.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CAPTURE_SCRIPT="${ROOT_DIR}/scripts/profiling/capture_flamegraph.sh"
+PROCESS_NAME="${TFS_FLAMEGRAPH_PROCESS:-tfs}"
+
+find_perf() {
+	local requested_perf="${PERF_BIN:-}"
+	local candidate=""
+	local index=0
+
+	if [[ -n "${requested_perf}" ]]; then
+		candidate="$(command -v "${requested_perf}" || true)"
+		[[ -n "${candidate}" ]] || return 1
+		printf '%s\n' "${candidate}"
+		return 0
+	fi
+
+	candidate="$(command -v perf || true)"
+	if [[ -n "${candidate}" ]] && "${candidate}" --version >/dev/null 2>&1; then
+		printf '%s\n' "${candidate}"
+		return 0
+	fi
+
+	local candidates=()
+	shopt -s nullglob
+	candidates=(/usr/lib/linux-tools-*/perf)
+	shopt -u nullglob
+
+	for ((index = ${#candidates[@]} - 1; index >= 0; --index)); do
+		candidate="${candidates[index]}"
+		if [[ -x "${candidate}" ]] && "${candidate}" --version >/dev/null 2>&1; then
+			printf '%s\n' "${candidate}"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+[[ -f "${CAPTURE_SCRIPT}" ]] || {
+	echo "FlameGraph capture script not found: ${CAPTURE_SCRIPT}" >&2
+	exit 1
+}
+
+perf_bin="$(find_perf)" || {
+	echo "Compatible perf not found. Run: bash scripts/profiling/setup_flamegraph.sh" >&2
+	exit 1
+}
+export PERF_BIN="${perf_bin}"
+
+capture_args=("$@")
+has_target=0
+for arg in "$@"; do
+	case "${arg}" in
+		--pid|--process)
+			has_target=1
+			break
+			;;
+	esac
+done
+
+if [[ "${has_target}" -eq 0 ]]; then
+	capture_args=(--process "${PROCESS_NAME}" "${capture_args[@]}")
+fi
+
+cd "${ROOT_DIR}"
+printf 'Using perf: %s\n' "${PERF_BIN}"
+printf 'Starting TFS FlameGraph capture...\n'
+bash "${CAPTURE_SCRIPT}" "${capture_args[@]}"

--- a/tools/run-flamegraph.sh
+++ b/tools/run-flamegraph.sh
@@ -4,6 +4,62 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CAPTURE_SCRIPT="${ROOT_DIR}/scripts/profiling/capture_flamegraph.sh"
 PROCESS_NAME="${TFS_FLAMEGRAPH_PROCESS:-tfs}"
+SERVER_BIN="${TFS_FLAMEGRAPH_BIN:-${ROOT_DIR}/build-release/tfs}"
+SERVER_LOG="${ROOT_DIR}/profiling-output/tfs-flamegraph-server.log"
+START_TIMEOUT="${TFS_FLAMEGRAPH_START_TIMEOUT:-120}"
+server_pid=""
+
+die() {
+	echo "$*" >&2
+	exit 1
+}
+
+cleanup() {
+	local pid="${server_pid}"
+	server_pid=""
+
+	if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+		printf 'Stopping FlameGraph TFS process %s...\n' "${pid}"
+		kill -INT "${pid}" 2>/dev/null || true
+		wait "${pid}" 2>/dev/null || true
+	fi
+}
+
+start_server() {
+	[[ -x "${SERVER_BIN}" ]] || die "TFS binary not found: ${SERVER_BIN}. Build build-release first."
+	[[ "${START_TIMEOUT}" =~ ^[0-9]+$ && "${START_TIMEOUT}" -ge 1 ]] || die "TFS_FLAMEGRAPH_START_TIMEOUT must be a positive integer"
+
+	mkdir -p "$(dirname "${SERVER_LOG}")"
+	: > "${SERVER_LOG}"
+
+	printf 'Starting TFS: %s\n' "${SERVER_BIN}"
+	"${SERVER_BIN}" > "${SERVER_LOG}" 2>&1 &
+	server_pid=$!
+	printf 'Waiting for TFS startup (PID %s)...\n' "${server_pid}"
+
+	local elapsed=0
+	while ((elapsed < START_TIMEOUT)); do
+		if grep -Fq "Forgotten Server Online!" "${SERVER_LOG}"; then
+			printf 'TFS is online. Server log: %s\n' "${SERVER_LOG}"
+			return 0
+		fi
+
+		if ! kill -0 "${server_pid}" 2>/dev/null; then
+			wait "${server_pid}" 2>/dev/null || true
+			server_pid=""
+			tail -n 50 "${SERVER_LOG}" >&2 || true
+			die "TFS stopped before becoming online"
+		fi
+
+		sleep 1
+		((++elapsed))
+	done
+
+	tail -n 50 "${SERVER_LOG}" >&2 || true
+	die "TFS did not become online within ${START_TIMEOUT}s"
+}
+
+trap cleanup EXIT
 
 find_perf() {
 	local requested_perf="${PERF_BIN:-}"
@@ -54,7 +110,7 @@ capture_args=("$@")
 has_target=0
 for arg in "$@"; do
 	case "${arg}" in
-		--pid|--process)
+		--pid|--process|-h|--help)
 			has_target=1
 			break
 			;;
@@ -62,7 +118,14 @@ for arg in "$@"; do
 done
 
 if [[ "${has_target}" -eq 0 ]]; then
-	capture_args=(--process "${PROCESS_NAME}" "${capture_args[@]}")
+	existing_pid="$(pidof -s "${PROCESS_NAME}" 2>/dev/null || true)"
+	if [[ -n "${existing_pid}" ]]; then
+		printf 'Using running TFS process: %s\n' "${existing_pid}"
+		capture_args=(--pid "${existing_pid}" "${capture_args[@]}")
+	else
+		start_server
+		capture_args=(--pid "${server_pid}" "${capture_args[@]}")
+	fi
 fi
 
 cd "${ROOT_DIR}"

--- a/tools/run-flamegraph.sh
+++ b/tools/run-flamegraph.sh
@@ -117,6 +117,8 @@ for arg in "$@"; do
 	esac
 done
 
+cd "${ROOT_DIR}"
+
 if [[ "${has_target}" -eq 0 ]]; then
 	existing_pid="$(pidof -s "${PROCESS_NAME}" 2>/dev/null || true)"
 	if [[ -n "${existing_pid}" ]]; then
@@ -128,7 +130,6 @@ if [[ "${has_target}" -eq 0 ]]; then
 	fi
 fi
 
-cd "${ROOT_DIR}"
 printf 'Using perf: %s\n' "${PERF_BIN}"
 printf 'Starting TFS FlameGraph capture...\n'
 bash "${CAPTURE_SCRIPT}" "${capture_args[@]}"


### PR DESCRIPTION
Adds documentation and helper scripts for capturing Linux perf samples and generating Brendan Gregg FlameGraph SVGs.

Summary:
- Adds setup script for perf/FlameGraph dependencies.
- Adds capture script for process/PID-based flamegraph generation.
- Adds PT-BR documentation for before/after performance profiling.
- Adds gitignore entries for generated perf/flamegraph outputs.

Usage examples include full flamegraphs and filtered spectator hot paths:
getSpectators, getSpectatorsInternal, moveCreature, SpectatorVec, shared_ptr, sort, unique, flat_set.

This PR does not change gameplay or server logic.

Validation:
- `bash -n scripts/profiling/setup_flamegraph.sh`
- `bash -n scripts/profiling/capture_flamegraph.sh`
- `git diff --check -- .gitignore docs/performance/flamegraph.md scripts/profiling/setup_flamegraph.sh scripts/profiling/capture_flamegraph.sh scripts/profiling/README.md`
- `shellcheck` was not installed in WSL, so syntax validation used `bash -n`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Linux `perf` + FlameGraph profiling tooling for CPU hot-path analysis of the TFS game server, along with a PT-BR developer guide and `.gitignore`/`.gitattributes` housekeeping. No gameplay code is intended to be changed.

- `scripts/profiling/setup_flamegraph.sh` installs `perf` and clones/updates the FlameGraph repo; `capture_flamegraph.sh` handles full capture + SVG generation with optional stack filtering.
- `tools/run-flamegraph.sh` orchestrates the end-to-end flow: it detects or starts a TFS process, resolves a WSL-compatible `perf` binary, then delegates to `capture_flamegraph.sh`.
- `tools/build-callgrind.sh` adds a Callgrind-optimised build variant using the shared `cmake-linux-env.sh` helpers.
- `src/admin.cpp` contains an unexplained `#include "game.h"` addition with no corresponding usage in the diff, contradicting the PR's stated scope.

<h3>Confidence Score: 4/5</h3>

Safe to merge after the stray `#include "game.h"` in `src/admin.cpp` is removed or explained — all other changes are additive tooling with no effect on the running server.

The only C++ source change in the PR — adding `#include "game.h"` to `admin.cpp` — has no corresponding usage anywhere in the diff and directly contradicts the author's stated goal of touching only tooling. It looks like an accidental carry-over from a separate branch. Leaving an unreferenced heavyweight header in a core server file is a real, present issue even if the runtime behaviour appears unchanged today.

`src/admin.cpp` — the stray `game.h` include needs to be justified or dropped before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/admin.cpp | Adds `#include "game.h"` with no corresponding usage in the diff — likely a stray commit from another branch; contradicts the PR's stated scope of "no gameplay changes". |
| scripts/profiling/capture_flamegraph.sh | Well-structured capture script with solid argument validation, sudo handling, and filter support; intermediate files now correctly co-located with the SVG output. |
| tools/run-flamegraph.sh | Orchestration wrapper with good WSL perf-version fallback and cleanup trap; `has_target` argument-scanning loop is subtly unsafe when flag values happen to match target-flag names. |
| tools/build-callgrind.sh | Callgrind build helper that sources the shared cmake-linux-env.sh; CMake flags use backslash-escaped spaces that work but are fragile. |
| scripts/profiling/setup_flamegraph.sh | Installs perf/FlameGraph dependencies with graceful fallbacks for missing sudo, non-APT systems, and WSL kernel packages. |
| .gitignore | Adds entries for perf/FlameGraph output artifacts and Callgrind files; all patterns are appropriate and non-overlapping. |
| .gitattributes | Adds `*.sh text eol=lf` to ensure shell scripts retain LF line endings across platforms. |
| scripts/profiling/README.md | Short English README pointing to the scripts and the full PT-BR guide; accurate and consistent with the actual script interfaces. |
| docs/performance/flamegraph.md | PT-BR guide covering installation, compilation with frame pointers, capture, filtering, and before/after comparison; accurate and complete. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([run-flamegraph.sh]) --> B[find_perf: resolve perf binary]
    B --> C{Target flag passed?}
    C -- Yes --> G
    C -- No --> D{pidof tfs running?}
    D -- Yes --> E[Use existing PID]
    D -- No --> F[start_server\nbuild-release/tfs]
    F --> F2{Online within timeout?}
    F2 -- Yes --> E2[Use server_pid]
    F2 -- No --> ERR1([die])
    E --> G([capture_flamegraph.sh])
    E2 --> G
    G --> H[Validate args\npid / process / freq / duration]
    H --> I[sudo perf record\n-F freq -p pid -g]
    I --> J[sudo perf script\n→ .perf file]
    J --> K[stackcollapse-perf.pl\n→ .folded]
    K --> L{--filter set?}
    L -- Yes --> M[grep -Ei filter\n→ .filtered.folded]
    L -- No --> N[flamegraph.pl\n→ SVG]
    M --> N
    N --> OUT([SVG output])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([run-flamegraph.sh]) --> B[find_perf: resolve perf binary]
    B --> C{Target flag passed?}
    C -- Yes --> G
    C -- No --> D{pidof tfs running?}
    D -- Yes --> E[Use existing PID]
    D -- No --> F[start_server\nbuild-release/tfs]
    F --> F2{Online within timeout?}
    F2 -- Yes --> E2[Use server_pid]
    F2 -- No --> ERR1([die])
    E --> G([capture_flamegraph.sh])
    E2 --> G
    G --> H[Validate args\npid / process / freq / duration]
    H --> I[sudo perf record\n-F freq -p pid -g]
    I --> J[sudo perf script\n→ .perf file]
    J --> K[stackcollapse-perf.pl\n→ .folded]
    K --> L{--filter set?}
    L -- Yes --> M[grep -Ei filter\n→ .filtered.folded]
    L -- No --> N[flamegraph.pl\n→ SVG]
    M --> N
    N --> OUT([SVG output])
```

</a>

<sub>Reviews (5): Last reviewed commit: ["fix(tools): launch flamegraph from root"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/3b67a7f4446d58eef9cba79852f987baf3fff22d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43097408)</sub>

<!-- /greptile_comment -->