### PR TITLE
fix(bot): keepalive de bots, registry testável, hardening, testes e benchmarks (refino da #159)

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -140,7 +140,7 @@ exhaustItemAtUsePotion = true
 -- Quick Loot defaults to true because the Astra managed-loot UI expects it.
 forgeSystemEnabled = false
 imbuementSystemEnabled = false
-botSystemEnabled = true
+botSystemEnabled = false
 monkVocationEnabled = false
 familiarSystemEnabled = false
 wheelSystemEnabled = false

--- a/data/scripts/bot/README.md
+++ b/data/scripts/bot/README.md
@@ -16,8 +16,10 @@ The Canary engine is much larger and tied to Canary-only APIs. This port keeps t
 - bots are spawned as real `Player` objects loaded through `IOLoginData`;
 - active bots are held by `std::shared_ptr<Player>` in `BotManager`;
 - despawn uses the normal `Game::removeCreature` path, so logout hooks and player saving still run;
-- cast uses the existing `ProtocolSpectator` system, so a bot can be watched through the normal cast list.
-- `BotBrain` equips starter gear without dropping it to the floor, disables loot/skill loss for bots, looks for nearby monsters, follows/attacks them, and wanders while idle.
+- cast uses the existing `ProtocolSpectator` system, so a bot can be watched through the normal cast list;
+- socketless bots refresh their own pong inside `Player::sendPing`, so the `noPongKickTime` logout and the 7s attack-target drop never fire for them (spectator pings keep flowing);
+- `BotBrain` equips starter gear without dropping it to the floor, disables loot/skill loss for bots, looks for nearby monsters, follows/attacks them, and wanders while idle;
+- pure decision logic lives in `data/scripts/lib/bot_core.lua` and is covered by engine-free tests (`bash tests/lua/run.sh`).
 
 ## Config
 
@@ -25,7 +27,15 @@ The Canary engine is much larger and tied to Canary-only APIs. This port keeps t
 botSystemEnabled = true
 ```
 
-Set it to `false` to disable registration, spawn, auto-spawn, and the Lua brain loop.
+The system ships **disabled** (`botSystemEnabled = false` is the default); set it to `true` in `config.lua` to enable registration, spawn, auto-spawn, and the Lua brain loop.
+
+Brain behaviour can be tuned from any script before startup, e.g.:
+
+```lua
+BotBrain.config = { tickInterval = 250, heal = { enabled = false } }
+```
+
+Missing keys are filled from `BotCore.defaults`.
 
 ## Commands
 
@@ -52,6 +62,8 @@ Example:
 ```
 
 `vocation` is optional. When omitted, a new bot is created as a knight.
+
+Auto-spawned bots always open their cast on spawn; use `/bot cast name, off` to close it afterwards.
 
 ## SQL
 

--- a/data/scripts/globalevents/bot_manager.lua
+++ b/data/scripts/globalevents/bot_manager.lua
@@ -1,6 +1,11 @@
 local startup = GlobalEvent("BotManagerStartup")
 
 function startup.onStartup()
+	if not BotSystem or not BotSystem.isAvailable() then
+		logInfo("[BotManager] Bot system bindings are not available in this build.")
+		return true
+	end
+
 	if not BotSystem.isEnabled() then
 		logInfo("[BotManager] Bot system disabled by config.")
 		return true
@@ -28,9 +33,17 @@ startup:register()
 local shutdown = GlobalEvent("BotManagerShutdown")
 
 function shutdown.onShutdown()
-	local despawned = Game.despawnAllBots(true)
-	if despawned > 0 then
-		logInfo(string.format("[BotManager] Despawned %d bot(s).", despawned))
+	-- Quiesce the brain before despawning so an already-queued tick exits at
+	-- its guard instead of touching players mid-despawn or rescheduling.
+	if BotBrain and BotBrain.stop then
+		BotBrain.stop()
+	end
+
+	if Game.despawnAllBots then
+		local despawned = Game.despawnAllBots(true)
+		if despawned > 0 then
+			logInfo(string.format("[BotManager] Despawned %d bot(s).", despawned))
+		end
 	end
 	return true
 end

--- a/data/scripts/lib/bot_brain.lua
+++ b/data/scripts/lib/bot_brain.lua
@@ -1,86 +1,50 @@
+-- BotBrain: engine adapter for the managed bot AI tick loop.
+-- Decision logic lives in BotCore (data/scripts/lib/bot_core.lua); this file
+-- only touches engine APIs, and never at file scope, so it loads under a bare
+-- Lua interpreter regardless of lib load order.
 BotBrain = BotBrain or {}
-
-BotBrain.config = {
-	tickInterval = 500,
-	idleMoveInterval = 850,
-	combatMoveInterval = 700,
-	searchRangeX = 7,
-	searchRangeY = 5,
-	wanderRadius = 5
-}
 
 BotBrain.state = BotBrain.state or {}
 BotBrain.running = BotBrain.running or false
+BotBrain.eventId = BotBrain.eventId or nil
 
-local cardinalDirections = {
-	DIRECTION_NORTH,
-	DIRECTION_EAST,
-	DIRECTION_SOUTH,
-	DIRECTION_WEST
-}
+local slotMap
 
-local starterEquipment = {
-	common = {
-		{ slot = CONST_SLOT_BACKPACK, itemId = 2854 },
-		{ slot = CONST_SLOT_ARMOR, itemId = 3359 },
-		{ slot = CONST_SLOT_LEGS, itemId = 3372 },
-		{ slot = CONST_SLOT_FEET, itemId = 3552 }
-	},
-	vocations = {
-		[1] = {
-			{ slot = CONST_SLOT_LEFT, itemId = 3074 }
-		},
-		[2] = {
-			{ slot = CONST_SLOT_LEFT, itemId = 3066 }
-		},
-		[3] = {
-			{ slot = CONST_SLOT_LEFT, itemId = 3277 },
-			{ slot = CONST_SLOT_RIGHT, itemId = 3411 }
-		},
-		[4] = {
-			{ slot = CONST_SLOT_LEFT, itemId = 3271 },
-			{ slot = CONST_SLOT_RIGHT, itemId = 3411 }
+local function getConfig()
+	BotBrain.config = BotCore.mergeDefaults(BotBrain.config, BotCore.defaults)
+	return BotBrain.config
+end
+
+local function getSlotId(name)
+	if not slotMap then
+		slotMap = {
+			backpack = CONST_SLOT_BACKPACK,
+			armor = CONST_SLOT_ARMOR,
+			legs = CONST_SLOT_LEGS,
+			feet = CONST_SLOT_FEET,
+			left = CONST_SLOT_LEFT,
+			right = CONST_SLOT_RIGHT
 		}
-	}
-}
+	end
+	return slotMap[name]
+end
 
 local function logWarning(message)
 	if logger and logger.warn then
 		logger.warn(message)
-	else
+	elseif logInfo then
 		logInfo(message)
+	else
+		print(message)
 	end
 end
 
-local function distance(a, b)
-	if not a or not b or a.z ~= b.z then
-		return 999
-	end
-	return math.max(math.abs(a.x - b.x), math.abs(a.y - b.y))
-end
-
-local function vocationBase(player)
-	local vocation = player:getVocation()
-	if not vocation or not vocation.getId then
-		return 4
-	end
-
-	local id = vocation:getId()
-	if id > 4 then
-		id = id - 4
-	end
-	if id < 1 or id > 4 then
-		return 4
-	end
-	return id
-end
-
-local function addToSlot(player, slot, itemId, count)
+local function addToSlot(player, slot, itemId)
 	if player:getSlotItem(slot) then
 		return true
 	end
 
-	local item = player:addItem(itemId, count or 1, false, count or 1, slot)
+	local item = player:addItem(itemId, 1, false, 1, slot)
 	return item ~= nil
 end
 
@@ -106,56 +70,64 @@ local function configureBot(player)
 		player:setFightMode(FIGHTMODE_ATTACK, false, true)
 	end
 
-	for _, entry in ipairs(starterEquipment.common) do
-		addToSlot(player, entry.slot, entry.itemId, entry.count)
-	end
-	for _, entry in ipairs(starterEquipment.vocations[vocationBase(player)] or starterEquipment.vocations[4]) do
-		addToSlot(player, entry.slot, entry.itemId, entry.count)
+	local vocation = player:getVocation()
+	local vocationBase = BotCore.vocationBase(vocation and vocation.getId and vocation:getId() or 4)
+	for _, entry in ipairs(BotCore.equipmentFor(vocationBase)) do
+		local slot = getSlotId(entry.slot)
+		if slot then
+			addToSlot(player, slot, entry.itemId)
+		end
 	end
 
 	local pos = player:getPosition()
 	state.home = { x = pos.x, y = pos.y, z = pos.z }
 	state.nextMoveAt = 0
-	state.nextSayAt = os.time() + math.random(40, 120)
+	state.nextSayAt = os.time() + BotCore.firstSayDelay()
 	state.configured = true
 	return state
 end
 
-local function healIfNeeded(player)
-	local missingHealth = player:getMaxHealth() - player:getHealth()
-	if missingHealth > 0 and player:getHealth() * 100 <= player:getMaxHealth() * 65 then
-		player:addHealth(math.min(missingHealth, math.max(25, math.floor(player:getMaxHealth() * 0.15))))
+local function healIfNeeded(player, config)
+	if not config.heal.enabled then
+		return
+	end
+
+	local healthAmount = BotCore.computeHeal(player:getHealth(), player:getMaxHealth(), config.heal.health)
+	if healthAmount then
+		player:addHealth(healthAmount)
 	end
 
 	if player.getMana and player.getMaxMana and player.addMana then
-		local maxMana = player:getMaxMana()
-		local missingMana = maxMana - player:getMana()
-		if missingMana > 0 and player:getMana() * 100 <= maxMana * 50 then
-			player:addMana(math.min(missingMana, math.max(20, math.floor(maxMana * 0.20))))
+		local manaAmount = BotCore.computeHeal(player:getMana(), player:getMaxMana(), config.heal.mana)
+		if manaAmount then
+			player:addMana(manaAmount)
 		end
 	end
 end
 
 local function validMonster(creature)
-	return creature and not creature:isRemoved() and creature.isMonster and creature:isMonster() and creature:getHealth() > 0
+	return creature and not creature:isRemoved() and creature.isMonster and creature:isMonster() and
+		creature:getHealth() > 0
 end
 
-local function findTarget(player)
+local function findTarget(player, config)
 	local position = player:getPosition()
-	local spectators = Game.getSpectators(position, false, false, BotBrain.config.searchRangeX, BotBrain.config.searchRangeX, BotBrain.config.searchRangeY, BotBrain.config.searchRangeY)
-	local closest
-	local closestDistance = 999
+	local spectators = Game.getSpectators(position, false, false, config.searchRangeX, config.searchRangeX,
+		config.searchRangeY, config.searchRangeY)
 
-	for _, creature in ipairs(spectators) do
+	local candidates = {}
+	for index, creature in ipairs(spectators) do
 		if validMonster(creature) and player:canSeeCreature(creature) then
-			local creatureDistance = distance(position, creature:getPosition())
-			if creatureDistance < closestDistance then
-				closest = creature
-				closestDistance = creatureDistance
-			end
+			local creaturePosition = creature:getPosition()
+			candidates[#candidates + 1] = {
+				index = index,
+				position = { x = creaturePosition.x, y = creaturePosition.y, z = creaturePosition.z }
+			}
 		end
 	end
-	return closest, closestDistance
+
+	local chosen = BotCore.selectTarget({ x = position.x, y = position.y, z = position.z }, candidates)
+	return chosen and spectators[chosen.index] or nil
 end
 
 local function walkPath(player, targetPos, minDistance, maxDistance)
@@ -164,43 +136,25 @@ local function walkPath(player, targetPos, minDistance, maxDistance)
 		return false
 	end
 
-	local ret = player:move(path[1])
-	return ret == RETURNVALUE_NOERROR or ret == true or ret == 0
+	return player:move(path[1]) == RETURNVALUE_NOERROR
 end
 
-local function randomNearbyPosition(pos, radius)
-	local dx = math.random(-radius, radius)
-	local dy = math.random(-radius, radius)
-	if dx == 0 and dy == 0 then
-		local direction = cardinalDirections[math.random(#cardinalDirections)]
-		if direction == DIRECTION_NORTH then
-			dy = -1
-		elseif direction == DIRECTION_SOUTH then
-			dy = 1
-		elseif direction == DIRECTION_EAST then
-			dx = 1
-		else
-			dx = -1
-		end
-	end
-	return Position(pos.x + dx, pos.y + dy, pos.z)
-end
-
-local function wander(player, state, nowMs)
+local function wander(player, state, config, nowMs)
 	if nowMs < (state.nextMoveAt or 0) then
 		return
 	end
-	state.nextMoveAt = nowMs + BotBrain.config.idleMoveInterval + math.random(0, 300)
+	state.nextMoveAt = nowMs + config.idleMoveInterval + math.random(0, 300)
 
 	local pos = player:getPosition()
-	local target = randomNearbyPosition(state.home or pos, BotBrain.config.wanderRadius)
-	walkPath(player, target, 0, 1)
+	local home = state.home or { x = pos.x, y = pos.y, z = pos.z }
+	local dx, dy = BotCore.pickWanderOffset(config.wanderRadius)
+	walkPath(player, Position(home.x + dx, home.y + dy, home.z), 0, 1)
 end
 
-local function handleCombat(player, state, nowMs)
+local function handleCombat(player, state, config, nowMs)
 	local target = player:getTarget()
 	if not validMonster(target) then
-		target = findTarget(player)
+		target = findTarget(player, config)
 	end
 
 	if not target then
@@ -211,9 +165,13 @@ local function handleCombat(player, state, nowMs)
 
 	player:setTarget(target)
 
-	if nowMs >= (state.nextMoveAt or 0) and distance(player:getPosition(), target:getPosition()) > 1 then
-		state.nextMoveAt = nowMs + BotBrain.config.combatMoveInterval
-		walkPath(player, target:getPosition(), 1, 1)
+	local playerPosition = player:getPosition()
+	local targetPosition = target:getPosition()
+	if nowMs >= (state.nextMoveAt or 0) and
+		BotCore.chebyshevDistance({ x = playerPosition.x, y = playerPosition.y, z = playerPosition.z },
+			{ x = targetPosition.x, y = targetPosition.y, z = targetPosition.z }) > 1 then
+		state.nextMoveAt = nowMs + config.combatMoveInterval
+		walkPath(player, targetPosition, 1, 1)
 	end
 	return true
 end
@@ -223,15 +181,8 @@ local function maybeSay(player, state)
 		return
 	end
 
-	state.nextSayAt = os.time() + math.random(90, 240)
-	local phrases = {
-		"hi",
-		"hunt?",
-		"need cap",
-		"refill soon",
-		"exura"
-	}
-	player:say(phrases[math.random(#phrases)], TALKTYPE_SAY)
+	state.nextSayAt = os.time() + BotCore.nextSayDelay()
+	player:say(BotCore.pickPhrase(), TALKTYPE_SAY)
 end
 
 function BotBrain.activate(player)
@@ -244,23 +195,43 @@ function BotBrain.activate(player)
 	return true
 end
 
+function BotBrain.forget(guid)
+	BotBrain.state[guid] = nil
+end
+
 function BotBrain.run()
+	local config = getConfig()
 	local bots = Game.getBots()
 	local nowMs = os.mtime and os.mtime() or (os.time() * 1000)
 
+	local seen = {}
 	for _, player in ipairs(bots) do
 		if player and not player:isRemoved() and player:isBot() then
-			local state = configureBot(player)
-			healIfNeeded(player)
-			if not handleCombat(player, state, nowMs) then
-				wander(player, state, nowMs)
-				maybeSay(player, state)
+			seen[player:getGuid()] = true
+			-- One broken bot must not starve the rest of the fleet.
+			local ok, err = pcall(function()
+				local state = configureBot(player)
+				healIfNeeded(player, config)
+				if not handleCombat(player, state, config, nowMs) then
+					wander(player, state, config, nowMs)
+					maybeSay(player, state)
+				end
+			end)
+			if not ok then
+				logWarning("[BotBrain] bot tick failed: " .. tostring(err))
 			end
+		end
+	end
+
+	for guid in pairs(BotBrain.state) do
+		if not seen[guid] then
+			BotBrain.state[guid] = nil
 		end
 	end
 end
 
 function BotBrain.tick()
+	BotBrain.eventId = nil
 	if not BotBrain.running then
 		return
 	end
@@ -275,9 +246,7 @@ function BotBrain.tick()
 		logWarning("[BotBrain] tick failed: " .. tostring(err))
 	end
 
-	addEvent(function()
-		BotBrain.tick()
-	end, BotBrain.config.tickInterval)
+	BotBrain.eventId = addEvent(BotBrain.tick, getConfig().tickInterval)
 end
 
 function BotBrain.start()
@@ -289,11 +258,13 @@ function BotBrain.start()
 	end
 
 	BotBrain.running = true
-	addEvent(function()
-		BotBrain.tick()
-	end, BotBrain.config.tickInterval)
+	BotBrain.eventId = addEvent(BotBrain.tick, getConfig().tickInterval)
 end
 
 function BotBrain.stop()
 	BotBrain.running = false
+	if BotBrain.eventId then
+		stopEvent(BotBrain.eventId)
+		BotBrain.eventId = nil
+	end
 end

--- a/data/scripts/lib/bot_core.lua
+++ b/data/scripts/lib/bot_core.lua
@@ -1,0 +1,218 @@
+-- BotCore: pure decision logic for the managed bot system.
+-- This file must stay loadable under a bare Lua 5.5 interpreter: no engine
+-- globals may be read at file scope or inside these functions, so the logic
+-- is unit-testable without the server (see tests/lua/).
+BotCore = BotCore or {}
+
+BotCore.defaults = {
+	tickInterval = 500,
+	idleMoveInterval = 850,
+	combatMoveInterval = 700,
+	searchRangeX = 7,
+	searchRangeY = 5,
+	wanderRadius = 5,
+	heal = {
+		enabled = true,
+		health = { thresholdPercent = 65, restorePercent = 15, restoreMin = 25 },
+		mana = { thresholdPercent = 50, restorePercent = 20, restoreMin = 20 }
+	}
+}
+
+-- Starter gear uses symbolic slot names; the engine adapter (bot_brain.lua)
+-- maps them to CONST_SLOT_* at call time.
+local starterEquipment = {
+	common = {
+		{ slot = "backpack", itemId = 2854 },
+		{ slot = "armor", itemId = 3359 },
+		{ slot = "legs", itemId = 3372 },
+		{ slot = "feet", itemId = 3552 }
+	},
+	vocations = {
+		[1] = {
+			{ slot = "left", itemId = 3074 }
+		},
+		[2] = {
+			{ slot = "left", itemId = 3066 }
+		},
+		[3] = {
+			{ slot = "left", itemId = 3277 },
+			{ slot = "right", itemId = 3411 }
+		},
+		[4] = {
+			{ slot = "left", itemId = 3271 },
+			{ slot = "right", itemId = 3411 }
+		}
+	}
+}
+
+local idlePhrases = { "hi", "hunt?", "need cap", "refill soon", "exura" }
+
+local vocationNames = {
+	sorcerer = 1,
+	druid = 2,
+	paladin = 3,
+	knight = 4,
+	ms = 1,
+	ed = 2,
+	rp = 3,
+	ek = 4
+}
+
+function BotCore.trim(value)
+	value = tostring(value or "")
+	return (value:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+function BotCore.splitList(value, separator)
+	separator = separator or ","
+	local parts = {}
+	for part in tostring(value or ""):gmatch("([^" .. separator .. "]+)") do
+		parts[#parts + 1] = BotCore.trim(part)
+	end
+	return parts
+end
+
+function BotCore.parseToggle(value)
+	value = tostring(value or ""):lower()
+	return value == "on" or value == "true" or value == "1" or value == "yes" or value == "auto"
+end
+
+-- Splits "/bot <action> <rest>" params into a lowercased action plus the
+-- comma-separated argument list.
+function BotCore.parseCommand(param)
+	param = BotCore.trim(param)
+	if param == "" then
+		return "", {}
+	end
+
+	local action, rest = param:match("^(%S+)%s*(.*)$")
+	return (action or ""):lower(), BotCore.splitList(rest or "")
+end
+
+-- Accepts numeric ids (5-8 fold to their 1-4 base) and vocation names or
+-- abbreviations; anything unrecognized falls back to knight (4).
+function BotCore.normalizeVocation(value)
+	value = tostring(value or ""):lower()
+	if value == "" then
+		return 4
+	end
+
+	local numeric = tonumber(value)
+	if numeric then
+		numeric = math.floor(numeric)
+		if numeric > 4 then
+			numeric = numeric - 4
+		end
+		if numeric >= 1 and numeric <= 4 then
+			return numeric
+		end
+		return 4
+	end
+
+	return vocationNames[value] or 4
+end
+
+-- Folds a raw vocation id (possibly promoted, 5-8) to the 1-4 base used for
+-- equipment lookup.
+function BotCore.vocationBase(id)
+	id = tonumber(id) or 4
+	if id > 4 then
+		id = id - 4
+	end
+	if id < 1 or id > 4 then
+		return 4
+	end
+	return id
+end
+
+function BotCore.chebyshevDistance(a, b)
+	if not a or not b or a.z ~= b.z then
+		return math.huge
+	end
+	return math.max(math.abs(a.x - b.x), math.abs(a.y - b.y))
+end
+
+-- candidates: array of { index = <any>, position = {x, y, z} }. Returns the
+-- closest record and its distance, or nil when nothing is reachable.
+function BotCore.selectTarget(origin, candidates)
+	local closest, closestDistance
+	for _, candidate in ipairs(candidates or {}) do
+		local distance = BotCore.chebyshevDistance(origin, candidate.position)
+		if distance < math.huge and (not closestDistance or distance < closestDistance) then
+			closest = candidate
+			closestDistance = distance
+		end
+	end
+	return closest, closestDistance
+end
+
+-- Returns the amount to restore (clamped to what is missing), or nil when the
+-- current value is above the threshold. cfg = { thresholdPercent,
+-- restorePercent, restoreMin }.
+function BotCore.computeHeal(current, max, cfg)
+	if not cfg or max <= 0 then
+		return nil
+	end
+
+	local missing = max - current
+	if missing <= 0 or current * 100 > max * cfg.thresholdPercent then
+		return nil
+	end
+
+	local restore = math.max(cfg.restoreMin, math.floor(max * cfg.restorePercent / 100))
+	return math.min(missing, restore)
+end
+
+-- Never returns (0, 0); rng is injectable for deterministic tests and must
+-- follow math.random(lo, hi) semantics.
+function BotCore.pickWanderOffset(radius, rng)
+	rng = rng or math.random
+	local dx = rng(-radius, radius)
+	local dy = rng(-radius, radius)
+	if dx == 0 and dy == 0 then
+		local fallbacks = { { 0, -1 }, { 1, 0 }, { 0, 1 }, { -1, 0 } }
+		local pick = fallbacks[rng(1, #fallbacks)]
+		dx, dy = pick[1], pick[2]
+	end
+	return dx, dy
+end
+
+function BotCore.equipmentFor(vocationBase)
+	local set = {}
+	for _, entry in ipairs(starterEquipment.common) do
+		set[#set + 1] = entry
+	end
+	for _, entry in ipairs(starterEquipment.vocations[vocationBase] or starterEquipment.vocations[4]) do
+		set[#set + 1] = entry
+	end
+	return set
+end
+
+function BotCore.pickPhrase(rng)
+	rng = rng or math.random
+	return idlePhrases[rng(1, #idlePhrases)]
+end
+
+function BotCore.nextSayDelay(rng)
+	rng = rng or math.random
+	return rng(90, 240)
+end
+
+function BotCore.firstSayDelay(rng)
+	rng = rng or math.random
+	return rng(40, 120)
+end
+
+-- Shallow-recursive fill-in of missing keys so server owners can pre-seed
+-- partial configs from any script.
+function BotCore.mergeDefaults(target, defaults)
+	target = target or {}
+	for key, value in pairs(defaults) do
+		if type(value) == "table" then
+			target[key] = BotCore.mergeDefaults(target[key], value)
+		elseif target[key] == nil then
+			target[key] = value
+		end
+	end
+	return target
+end

--- a/data/scripts/lib/bot_system.lua
+++ b/data/scripts/lib/bot_system.lua
@@ -1,3 +1,8 @@
+-- BotSystem: registry and spawn wrapper for the managed bot system.
+-- Registration/spawn/despawn are implemented once, in C++ (BotManager); this
+-- file intentionally has no SQL fallbacks for those paths so the logic cannot
+-- drift. SQL remains only where it is the canonical implementation (registry
+-- listing and per-bot flags). No engine global is read at file scope.
 BotSystem = BotSystem or {}
 
 local tablesReady = false
@@ -6,43 +11,25 @@ local function boolToNumber(value)
 	return value and 1 or 0
 end
 
-local function normalizeName(name)
-	name = tostring(name or "")
-	name = name:gsub("^%s+", ""):gsub("%s+$", "")
-	return name
-end
+local DISABLED_MESSAGE = "Bot system is disabled in config.lua (botSystemEnabled = false)."
+local UNAVAILABLE_MESSAGE = "Bot system requires a server build with BotManager (Game.spawnBot missing)."
 
-local function parseVocation(value)
-	value = tostring(value or ""):lower()
-	if value == "" then
-		return 4
-	end
-
-	local vocation = tonumber(value)
-	if vocation then
-		return math.floor(vocation)
-	end
-
-	local names = {
-		sorcerer = 1,
-		druid = 2,
-		paladin = 3,
-		knight = 4,
-		ms = 5,
-		ed = 6,
-		rp = 7,
-		ek = 8
-	}
-	return names[value] or 4
+function BotSystem.isAvailable()
+	return Game.spawnBot ~= nil and Game.registerBot ~= nil and Game.despawnBot ~= nil and
+		Game.ensureBotTables ~= nil and Game.isBotSystemEnabled ~= nil
 end
 
 function BotSystem.isEnabled()
-	if Game.isBotSystemEnabled then
-		return Game.isBotSystemEnabled()
-	end
+	return BotSystem.isAvailable() and Game.isBotSystemEnabled()
+end
 
-	if configManager and configKeys and configKeys.BOT_SYSTEM_ENABLED then
-		return configManager.getBoolean(configKeys.BOT_SYSTEM_ENABLED)
+-- Returns false plus the reason when the system cannot act.
+local function guard()
+	if not BotSystem.isAvailable() then
+		return false, UNAVAILABLE_MESSAGE
+	end
+	if not Game.isBotSystemEnabled() then
+		return false, DISABLED_MESSAGE
 	end
 	return true
 end
@@ -52,27 +39,17 @@ function BotSystem.ensureTables()
 		return true
 	end
 
-	if not BotSystem.isEnabled() then
+	local ok = guard()
+	if not ok then
 		return false
 	end
 
-	if Game.ensureBotTables then
-		tablesReady = Game.ensureBotTables()
-		return tablesReady
-	end
-
-	local resultId = db.storeQuery("SHOW TABLES LIKE " .. db.escapeString("bot_players"))
-	if not resultId then
-		return false
-	end
-
-	result.free(resultId)
-	tablesReady = true
-	return true
+	tablesReady = Game.ensureBotTables()
+	return tablesReady
 end
 
 function BotSystem.getPlayerId(nameOrGuid)
-	local value = normalizeName(nameOrGuid)
+	local value = BotCore.trim(nameOrGuid)
 	if value == "" then
 		return nil, nil
 	end
@@ -82,7 +59,8 @@ function BotSystem.getPlayerId(nameOrGuid)
 	if numeric and numeric > 0 then
 		query = "SELECT `id`, `name` FROM `players` WHERE `id` = " .. math.floor(numeric) .. " LIMIT 1"
 	else
-		query = "SELECT `id`, `name` FROM `players` WHERE LOWER(`name`) = LOWER(" .. db.escapeString(value) .. ") LIMIT 1"
+		query = "SELECT `id`, `name` FROM `players` WHERE LOWER(`name`) = LOWER(" .. db.escapeString(value) ..
+			") LIMIT 1"
 	end
 
 	local resultId = db.storeQuery(query)
@@ -101,7 +79,8 @@ function BotSystem.isRegistered(playerId)
 		return false
 	end
 
-	local resultId = db.storeQuery("SELECT `player_id` FROM `bot_players` WHERE `player_id` = " .. playerId .. " LIMIT 1")
+	local resultId = db.storeQuery(
+		"SELECT `player_id` FROM `bot_players` WHERE `player_id` = " .. playerId .. " LIMIT 1")
 	if not resultId then
 		return false
 	end
@@ -111,45 +90,39 @@ function BotSystem.isRegistered(playerId)
 end
 
 function BotSystem.register(nameOrGuid, autoSpawn, vocation)
-	if not BotSystem.isEnabled() then
-		return false, "Bot system is disabled in config.lua (botSystemEnabled = false)."
+	local ok, message = guard()
+	if not ok then
+		return false, message
 	end
 
 	if not BotSystem.ensureTables() then
 		return false, "Could not create bot tables."
 	end
 
-	local normalized = normalizeName(nameOrGuid)
+	local normalized = BotCore.trim(nameOrGuid)
 	if normalized == "" then
 		return false, "Bot name is required."
 	end
 
-	if Game.registerBot and not tonumber(normalized) then
-		local ok, message = Game.registerBot(normalized, autoSpawn == true, true, parseVocation(vocation), PLAYERSEX_MALE)
-		return ok, message
+	-- Numeric input refers to an existing player id; resolve it to the name
+	-- so the single C++ registration path handles both forms.
+	if tonumber(normalized) then
+		local playerId, playerName = BotSystem.getPlayerId(normalized)
+		if not playerId then
+			return false, "Player not found."
+		end
+		normalized = playerName
 	end
 
-	local playerId, playerName = BotSystem.getPlayerId(nameOrGuid)
-	if not playerId then
-		return false, "Player not found."
-	end
-
-	local now = os.time()
-	local query = string.format(
-		"INSERT INTO `bot_players` (`player_id`, `enabled`, `auto_spawn`, `created_at`, `updated_at`) VALUES (%d, 1, %d, %d, %d) " ..
-		"ON DUPLICATE KEY UPDATE `enabled` = 1, `auto_spawn` = VALUES(`auto_spawn`), `updated_at` = VALUES(`updated_at`)",
-		playerId, boolToNumber(autoSpawn), now, now
-	)
-
-	if not db.query(query) then
-		return false, "Could not register bot."
-	end
-	return true, string.format("Bot '%s' registered%s.", playerName, autoSpawn and " with auto-spawn" or "")
+	local registered, registerMessage = Game.registerBot(normalized, autoSpawn == true, true,
+		BotCore.normalizeVocation(vocation), PLAYERSEX_MALE)
+	return registered, registerMessage
 end
 
 function BotSystem.unregister(nameOrGuid)
-	if not BotSystem.isEnabled() then
-		return false, "Bot system is disabled in config.lua (botSystemEnabled = false)."
+	local ok, message = guard()
+	if not ok then
+		return false, message
 	end
 
 	if not BotSystem.ensureTables() then
@@ -170,9 +143,10 @@ function BotSystem.unregister(nameOrGuid)
 	return true, string.format("Bot '%s' unregistered.", playerName)
 end
 
-function BotSystem.setEnabled(nameOrGuid, enabled)
-	if not BotSystem.isEnabled() then
-		return false, "Bot system is disabled in config.lua (botSystemEnabled = false)."
+local function setRegistryFlag(nameOrGuid, column, enabled, label)
+	local ok, message = guard()
+	if not ok then
+		return false, message
 	end
 
 	if not BotSystem.ensureTables() then
@@ -187,58 +161,55 @@ function BotSystem.setEnabled(nameOrGuid, enabled)
 		return false, "Bot is not registered. Use /bot add first."
 	end
 
-	local query = string.format("UPDATE `bot_players` SET `enabled` = %d, `updated_at` = %d WHERE `player_id` = %d",
-		boolToNumber(enabled), os.time(), playerId)
+	local query = string.format("UPDATE `bot_players` SET `%s` = %d, `updated_at` = %d WHERE `player_id` = %d",
+		column, boolToNumber(enabled), os.time(), playerId)
 	if not db.query(query) then
-		return false, "Could not update bot."
+		return false, string.format("Could not update bot %s.", label)
 	end
-	return true, string.format("Bot '%s' %s.", playerName, enabled and "enabled" or "disabled")
+	return true, string.format("Bot '%s' %s %s.", playerName, label, enabled and "enabled" or "disabled")
+end
+
+function BotSystem.setEnabled(nameOrGuid, enabled)
+	return setRegistryFlag(nameOrGuid, "enabled", enabled, "status")
 end
 
 function BotSystem.setAutoSpawn(nameOrGuid, enabled)
-	if not BotSystem.isEnabled() then
-		return false, "Bot system is disabled in config.lua (botSystemEnabled = false)."
-	end
-
-	if not BotSystem.ensureTables() then
-		return false, "Could not create bot tables."
-	end
-
-	local playerId, playerName = BotSystem.getPlayerId(nameOrGuid)
-	if not playerId then
-		return false, "Player not found."
-	end
-	if not BotSystem.isRegistered(playerId) then
-		return false, "Bot is not registered. Use /bot add first."
-	end
-
-	local query = string.format("UPDATE `bot_players` SET `auto_spawn` = %d, `updated_at` = %d WHERE `player_id` = %d",
-		boolToNumber(enabled), os.time(), playerId)
-	if not db.query(query) then
-		return false, "Could not update bot auto-spawn."
-	end
-	return true, string.format("Bot '%s' auto-spawn %s.", playerName, enabled and "enabled" or "disabled")
+	return setRegistryFlag(nameOrGuid, "auto_spawn", enabled, "auto-spawn")
 end
 
 function BotSystem.spawn(nameOrGuid, broadcast, requireMarked)
-	if not BotSystem.isEnabled() then
-		return false, "Bot system is disabled in config.lua (botSystemEnabled = false)."
+	local ok, message = guard()
+	if not ok then
+		return false, message
 	end
 
-	local player, message = Game.spawnBot(nameOrGuid, broadcast == true, requireMarked ~= false)
+	local player, spawnMessage = Game.spawnBot(nameOrGuid, broadcast == true, requireMarked ~= false)
 	if player and BotBrain and BotBrain.activate then
 		BotBrain.activate(player)
 	end
-	return player ~= nil, message, player
+	return player ~= nil, spawnMessage, player
 end
 
 function BotSystem.despawn(nameOrGuid, save)
+	if not BotSystem.isAvailable() then
+		return false, UNAVAILABLE_MESSAGE
+	end
+
+	-- Despawn stays allowed while the system is disabled so operators can
+	-- always clean up; only spawn/register are gated.
+	if BotBrain and BotBrain.forget then
+		local playerId = BotSystem.getPlayerId(nameOrGuid)
+		if playerId then
+			BotBrain.forget(playerId)
+		end
+	end
 	return Game.despawnBot(nameOrGuid, save ~= false)
 end
 
 function BotSystem.setCast(nameOrGuid, enabled)
-	if not BotSystem.isEnabled() then
-		return false, "Bot system is disabled in config.lua (botSystemEnabled = false)."
+	local ok, message = guard()
+	if not ok then
+		return false, message
 	end
 
 	return Game.setBotBroadcast(nameOrGuid, enabled == true)
@@ -255,8 +226,7 @@ function BotSystem.spawnAuto()
 
 	local resultId = db.storeQuery(
 		"SELECT p.`name` FROM `bot_players` bp INNER JOIN `players` p ON p.`id` = bp.`player_id` " ..
-		"WHERE bp.`enabled` = 1 AND bp.`auto_spawn` = 1 ORDER BY p.`name` ASC"
-	)
+		"WHERE bp.`enabled` = 1 AND bp.`auto_spawn` = 1 ORDER BY p.`name` ASC")
 	if not resultId then
 		return 0
 	end
@@ -264,6 +234,8 @@ function BotSystem.spawnAuto()
 	local spawned = 0
 	repeat
 		local name = result.getString(resultId, "name")
+		-- Auto-spawned bots always open their cast; use "/bot cast <name>, off"
+		-- to close it after spawn.
 		local ok = BotSystem.spawn(name, true, true)
 		if ok then
 			spawned = spawned + 1
@@ -280,8 +252,7 @@ function BotSystem.getRegistered()
 
 	local resultId = db.storeQuery(
 		"SELECT bp.`player_id`, bp.`enabled`, bp.`auto_spawn`, bp.`last_spawn`, bp.`last_despawn`, p.`name`, p.`level` " ..
-		"FROM `bot_players` bp INNER JOIN `players` p ON p.`id` = bp.`player_id` ORDER BY p.`name` ASC"
-	)
+		"FROM `bot_players` bp INNER JOIN `players` p ON p.`id` = bp.`player_id` ORDER BY p.`name` ASC")
 	if not resultId then
 		return {}
 	end

--- a/data/scripts/talkactions/god/bot.lua
+++ b/data/scripts/talkactions/god/bot.lua
@@ -4,28 +4,9 @@ local function send(player, message)
 	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, message)
 end
 
-local function splitCommand(param)
-	param = tostring(param or ""):gsub("^%s+", ""):gsub("%s+$", "")
-	if param == "" then
-		return "", ""
-	end
-
-	local action, rest = param:match("^(%S+)%s*(.*)$")
-	return (action or ""):lower(), rest or ""
-end
-
-local function splitArgs(rest)
-	return rest:splitTrimmed(",")
-end
-
-local function parseToggle(value)
-	value = tostring(value or ""):lower()
-	return value == "on" or value == "true" or value == "1" or value == "yes" or value == "auto"
-end
-
 local function parseAddAutoSpawn(value)
 	value = tostring(value or ""):lower()
-	return value == "auto" or parseToggle(value)
+	return value == "auto" or BotCore.parseToggle(value)
 end
 
 local function showHelp(player)
@@ -46,55 +27,56 @@ end
 function talkaction.onSay(player, words, param)
 	logCommand(player, words, param)
 
-	local action, rest = splitCommand(param)
+	if not BotSystem or not BotCore then
+		send(player, "Bot system libraries are not loaded.")
+		return false
+	end
+
+	local action, args = BotCore.parseCommand(param)
 	if action == "" or action == "help" then
 		showHelp(player)
 		return false
 	end
 
 	if action == "add" or action == "register" then
-		local args = splitArgs(rest)
 		local ok, message = BotSystem.register(args[1], args[2] and parseAddAutoSpawn(args[2]), args[3])
 		send(player, message)
 		return false
 	end
 
 	if action == "remove" or action == "unregister" then
-		local ok, message = BotSystem.unregister(rest)
+		local ok, message = BotSystem.unregister(args[1])
 		send(player, message)
 		return false
 	end
 
 	if action == "enable" or action == "disable" then
-		local ok, message = BotSystem.setEnabled(rest, action == "enable")
+		local ok, message = BotSystem.setEnabled(args[1], action == "enable")
 		send(player, message)
 		return false
 	end
 
 	if action == "autospawn" then
-		local args = splitArgs(rest)
-		local ok, message = BotSystem.setAutoSpawn(args[1], parseToggle(args[2]))
+		local ok, message = BotSystem.setAutoSpawn(args[1], BotCore.parseToggle(args[2]))
 		send(player, message)
 		return false
 	end
 
 	if action == "spawn" then
-		local args = splitArgs(rest)
-		local broadcast = args[2] and (args[2]:lower() == "cast" or parseToggle(args[2]))
+		local broadcast = args[2] and (args[2]:lower() == "cast" or BotCore.parseToggle(args[2]))
 		local ok, message = BotSystem.spawn(args[1], broadcast, true)
 		send(player, message)
 		return false
 	end
 
 	if action == "despawn" or action == "kick" then
-		local ok, message = BotSystem.despawn(rest, true)
+		local ok, message = BotSystem.despawn(args[1], true)
 		send(player, message)
 		return false
 	end
 
 	if action == "cast" then
-		local args = splitArgs(rest)
-		local ok, message = BotSystem.setCast(args[1], parseToggle(args[2]))
+		local ok, message = BotSystem.setCast(args[1], BotCore.parseToggle(args[2]))
 		send(player, message)
 		return false
 	end
@@ -135,6 +117,6 @@ function talkaction.onSay(player, words, param)
 end
 
 talkaction:separator(" ")
-talkaction:accountType(6)
+talkaction:accountType(ACCOUNT_TYPE_GOD)
 talkaction:access(true)
 talkaction:register()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/bestiary_charm.h
 	${CMAKE_CURRENT_LIST_DIR}/bed.h
 	${CMAKE_CURRENT_LIST_DIR}/botmanager.h
+	${CMAKE_CURRENT_LIST_DIR}/botregistry.h
 	${CMAKE_CURRENT_LIST_DIR}/chat.h
 	${CMAKE_CURRENT_LIST_DIR}/character_bazaar.h
 	${CMAKE_CURRENT_LIST_DIR}/combat.h
@@ -167,6 +168,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/enums.h
 	${CMAKE_CURRENT_LIST_DIR}/events.h
 	${CMAKE_CURRENT_LIST_DIR}/fileloader.h
+	${CMAKE_CURRENT_LIST_DIR}/fonticakclient.h
 	${CMAKE_CURRENT_LIST_DIR}/game.h
 	${CMAKE_CURRENT_LIST_DIR}/globalevent.h
 	${CMAKE_CURRENT_LIST_DIR}/groups.h

--- a/src/benchs/CMakeLists.txt
+++ b/src/benchs/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(benchs_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/bench_botmanager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bench_tools.cpp
     )
 

--- a/src/benchs/bench_botmanager.cpp
+++ b/src/benchs/bench_botmanager.cpp
@@ -1,0 +1,138 @@
+#include "../otpch.h"
+
+#include "../botregistry.h"
+#include "../item.h"
+#include "../player.h"
+
+#include <benchmark/benchmark.h>
+#include <cstdlib>
+
+namespace {
+
+// Lightweight stand-in for Player so the registry benches measure container
+// behaviour, not Player construction. The active-bots map in BotManager (and
+// the equivalent private map on the PR branch) has exactly this shape, so
+// these numbers model both variants' algorithmic cost.
+struct StubPlayer
+{
+	bool removed = false;
+	bool isRemoved() const { return removed; }
+};
+
+tfs::bot::Registry<StubPlayer> makeRegistry(int64_t count, double removedRatio = 0.0)
+{
+	tfs::bot::Registry<StubPlayer> registry;
+	const auto removedEvery =
+	    removedRatio > 0.0 ? static_cast<int64_t>(1.0 / removedRatio) : std::numeric_limits<int64_t>::max();
+	for (int64_t i = 1; i <= count; ++i) {
+		auto stub = std::make_shared<StubPlayer>();
+		stub->removed = (i % removedEvery) == 0;
+		registry.insert(static_cast<uint32_t>(i), std::move(stub));
+	}
+	return registry;
+}
+
+bool ensureItemsLoaded()
+{
+	static int state = -1;
+	if (state != -1) {
+		return state == 1;
+	}
+
+	std::vector<std::string> candidates;
+	if (const char* dataDir = std::getenv("TFS_DATA_DIR")) {
+		candidates.push_back(std::string(dataDir) + "/items/items.otb");
+	}
+	candidates.emplace_back("data/items/items.otb");
+	candidates.emplace_back("../data/items/items.otb");
+	candidates.emplace_back("../../data/items/items.otb");
+	candidates.emplace_back("../../../data/items/items.otb");
+
+	for (const auto& path : candidates) {
+		if (Item::items.loadFromOtb(path)) {
+			state = 1;
+			return true;
+		}
+	}
+	state = 0;
+	return false;
+}
+
+} // namespace
+
+static void bench_parseGuid(benchmark::State& state)
+{
+	for ([[maybe_unused]] auto _ : state) {
+		auto numeric = tfs::bot::parseGuid("1234567");
+		benchmark::DoNotOptimize(numeric);
+		auto rejected = tfs::bot::parseGuid("Test Bot");
+		benchmark::DoNotOptimize(rejected);
+	}
+}
+BENCHMARK(bench_parseGuid);
+
+// Per-bot fixed allocation cost of a spawn: one socketless Player.
+static void bench_playerConstructDestruct(benchmark::State& state)
+{
+	if (!ensureItemsLoaded()) {
+		state.SkipWithError("items.otb not found (set TFS_DATA_DIR)");
+		return;
+	}
+
+	for ([[maybe_unused]] auto _ : state) {
+		auto player = std::make_shared<Player>(nullptr);
+		benchmark::DoNotOptimize(player);
+	}
+}
+BENCHMARK(bench_playerConstructDestruct);
+
+static void bench_registryInsertErase(benchmark::State& state)
+{
+	auto registry = makeRegistry(state.range(0));
+	auto stub = std::make_shared<StubPlayer>();
+	const uint32_t guid = static_cast<uint32_t>(state.range(0)) + 1;
+
+	for ([[maybe_unused]] auto _ : state) {
+		registry.insert(guid, stub);
+		benchmark::DoNotOptimize(registry.erase(guid));
+	}
+}
+BENCHMARK(bench_registryInsertErase)->Range(8, 4096);
+
+// The sweep runs at the top of every spawn/despawn/setBroadcast call, so a
+// burst spawn of N bots pays N sweeps of up to N entries — this is the
+// quadratic-shape cost the run matrix quantifies end to end.
+static void bench_registrySweepAllLive(benchmark::State& state)
+{
+	auto registry = makeRegistry(state.range(0));
+	for ([[maybe_unused]] auto _ : state) {
+		auto swept = registry.sweepRemoved();
+		benchmark::DoNotOptimize(swept);
+	}
+}
+BENCHMARK(bench_registrySweepAllLive)->Range(8, 4096);
+
+static void bench_registrySweepTenPercentRemoved(benchmark::State& state)
+{
+	for ([[maybe_unused]] auto _ : state) {
+		state.PauseTiming();
+		auto registry = makeRegistry(state.range(0), 0.10);
+		state.ResumeTiming();
+		auto swept = registry.sweepRemoved();
+		benchmark::DoNotOptimize(swept);
+	}
+}
+BENCHMARK(bench_registrySweepTenPercentRemoved)->Range(8, 4096);
+
+// Game.getBots() copies the live set every BotBrain tick (500 ms).
+static void bench_registrySnapshot(benchmark::State& state)
+{
+	auto registry = makeRegistry(state.range(0));
+	for ([[maybe_unused]] auto _ : state) {
+		auto bots = registry.snapshot();
+		benchmark::DoNotOptimize(bots);
+	}
+}
+BENCHMARK(bench_registrySnapshot)->Range(8, 4096);
+
+BENCHMARK_MAIN();

--- a/src/botmanager.cpp
+++ b/src/botmanager.cpp
@@ -8,6 +8,7 @@
 #include "character_bazaar.h"
 #include "configmanager.h"
 #include "database.h"
+#include "databasetasks.h"
 #include "game.h"
 #include "iologindata.h"
 #include "logger.h"
@@ -22,7 +23,28 @@
 
 extern Game g_game;
 extern Dispatcher g_dispatcher;
+extern DatabaseTasks g_databaseTasks;
 extern Vocations g_vocations;
+
+namespace tfs::bot {
+
+std::optional<uint32_t> parseGuid(std::string_view text)
+{
+	if (text.empty()) {
+		return std::nullopt;
+	}
+
+	uint32_t guid = 0;
+	const char* first = text.data();
+	const char* last = text.data() + text.size();
+	const auto [ptr, ec] = std::from_chars(first, last, guid);
+	if (ec == std::errc() && ptr == last && guid != 0) {
+		return guid;
+	}
+	return std::nullopt;
+}
+
+} // namespace tfs::bot
 
 namespace {
 constexpr std::string_view BOT_ACCOUNT_NAME = "botaccount";
@@ -48,22 +70,6 @@ private:
 	uint32_t guid = 0;
 	bool active = false;
 };
-
-std::optional<uint32_t> parseGuid(std::string_view text)
-{
-	if (text.empty()) {
-		return std::nullopt;
-	}
-
-	uint32_t guid = 0;
-	const char* first = text.data();
-	const char* last = text.data() + text.size();
-	const auto [ptr, ec] = std::from_chars(first, last, guid);
-	if (ec == std::errc() && ptr == last && guid != 0) {
-		return guid;
-	}
-	return std::nullopt;
-}
 
 std::optional<uint32_t> getAccountIdByName(std::string_view name)
 {
@@ -175,7 +181,7 @@ std::optional<uint32_t> BotManager::getGuidByName(std::string_view name) const
 		return std::nullopt;
 	}
 
-	if (auto guid = parseGuid(trimmed)) {
+	if (auto guid = tfs::bot::parseGuid(trimmed)) {
 		return guid;
 	}
 
@@ -248,28 +254,31 @@ BotManager::RegistrationResult BotManager::registerByName(std::string_view rawNa
 		                 autoSpawn ? " with auto-spawn" : "") };
 }
 
-bool BotManager::isMarkedBot(uint32_t guid, bool* enabled /* = nullptr */)
+std::optional<BotManager::MarkedState> BotManager::isMarkedBot(uint32_t guid)
 {
-	if (enabled) {
-		*enabled = false;
+	if (guid == 0) {
+		return MarkedState{};
 	}
 
-	if (guid == 0 || !ensureTables()) {
-		return false;
+	if (!ensureTables()) {
+		return std::nullopt;
 	}
 
+	// COUNT(*) always yields exactly one row, so a null result unambiguously
+	// means a database error rather than "no such registration" (storeQuery
+	// returns null both on error and on an empty result set).
 	Database& db = Database::getInstance();
-	DBResult_ptr result =
-	    db.storeQuery(fmt::format("SELECT `enabled` FROM `bot_players` WHERE `player_id` = {:d} LIMIT 1", guid));
+	DBResult_ptr result = db.storeQuery(fmt::format(
+	    "SELECT COUNT(*) AS `c`, COALESCE(MAX(`enabled`), 0) AS `e` FROM `bot_players` WHERE `player_id` = {:d}",
+	    guid));
 	if (!result) {
-		return false;
+		return std::nullopt;
 	}
 
-	const bool isEnabled = result->getNumber<uint16_t>("enabled") != 0;
-	if (enabled) {
-		*enabled = isEnabled;
-	}
-	return true;
+	MarkedState state;
+	state.marked = result->getNumber<uint64_t>("c") > 0;
+	state.enabled = state.marked && result->getNumber<uint16_t>("e") != 0;
+	return state;
 }
 
 BotManager::Result BotManager::spawnByName(std::string_view name, bool broadcast /* = false */,
@@ -293,18 +302,20 @@ BotManager::Result BotManager::spawnByGuid(uint32_t guid, bool broadcast /* = fa
 		return { false, "Bot spawn must run on the dispatcher thread.", nullptr };
 	}
 
-	cleanupRemoved();
+	sweepRemoved();
 
 	if (guid == 0) {
 		return { false, "Invalid bot player id.", nullptr };
 	}
 
-	bool enabled = false;
-	const bool marked = isMarkedBot(guid, &enabled);
-	if (requireMarked && !marked) {
+	const auto marked = isMarkedBot(guid);
+	if (!marked) {
+		return { false, "Bot registry is unavailable (database error).", nullptr };
+	}
+	if (requireMarked && !marked->marked) {
 		return { false, fmt::format("Player {:d} is not registered in bot_players.", guid), nullptr };
 	}
-	if (marked && !enabled) {
+	if (marked->marked && !marked->enabled) {
 		return { false, fmt::format("Bot player {:d} is disabled.", guid), nullptr };
 	}
 
@@ -341,22 +352,22 @@ BotManager::Result BotManager::spawnByGuid(uint32_t guid, bool broadcast /* = fa
 	}
 	IOLoginData::loadPlayerWorldData(player.get());
 	player->setBot(true);
-	player->client->setBroadcast(broadcast);
 
-	activeBots[guid] = player;
+	// The local shared_ptr keeps the player alive through placement; the
+	// registry entry (and the tile) take over ownership only on success, so
+	// the failure path needs no rollback.
 	const Position loginPosition = player->getLoginPosition();
 	if (!g_game.placeCreature(player.get(), loginPosition)) {
 		if (!g_game.placeCreature(player.get(), player->getTemplePosition(), false, true)) {
-			activeBots.erase(guid);
-			player->client->setBroadcast(false);
-			player->setBot(false);
 			return { false, fmt::format("Could not place bot '{}' at login or temple position.", player->getName()),
 				     nullptr };
 		}
 	}
 
+	player->client->setBroadcast(broadcast);
+	registry.insert(guid, player);
 	player->resetIdleTime();
-	touchRuntime(guid, true);
+	touchRuntimeAsync(guid, true);
 	LOG_INFO(fmt::format("[BotManager] Spawned bot '{}' (guid={}, cast={})", player->getName(), guid,
 	                     broadcast ? "on" : "off"));
 	return { true, fmt::format("Bot '{}' is online.", player->getName()), player };
@@ -383,30 +394,30 @@ bool BotManager::despawnByGuid(uint32_t guid, bool save, std::string* message /*
 		return false;
 	}
 
-	cleanupRemoved();
+	sweepRemoved();
 
-	auto it = activeBots.find(guid);
-	if (it == activeBots.end()) {
+	// Keep the bot alive through removal; forget() is triggered exactly once
+	// by Player::onRemoveCreature and is the single bookkeeping sink.
+	std::shared_ptr<Player> player = registry.find(guid);
+	if (!player) {
 		if (message) {
 			*message = fmt::format("Bot {:d} is not online.", guid);
 		}
 		return false;
 	}
 
-	std::shared_ptr<Player> player = it->second;
-	const std::string name = player ? player->getName() : std::to_string(guid);
-	if (player && !player->isRemoved()) {
-		const bool oldSaveFlag = player->getSaveFlag();
-		if (!save) {
-			player->setSaveFlag(false);
-		}
-		player->client->clear();
-		g_game.removeCreature(player.get(), true);
-		player->setSaveFlag(oldSaveFlag);
+	const std::string name = player->getName();
+	if (!save) {
+		player->setSaveFlag(false);
+	}
+	player->client->clear();
+	g_game.removeCreature(player.get(), true);
+	if (registry.erase(guid)) {
+		// removeCreature runs onRemoveCreature synchronously, so this only
+		// fires if the removal path skipped forget(); keep bookkeeping tight.
+		touchRuntimeAsync(guid, false);
 	}
 
-	activeBots.erase(guid);
-	touchRuntime(guid, false);
 	if (message) {
 		*message = fmt::format("Bot '{}' is offline.", name);
 	}
@@ -416,37 +427,35 @@ bool BotManager::despawnByGuid(uint32_t guid, bool save, std::string* message /*
 
 size_t BotManager::despawnAll(bool save)
 {
-	std::vector<uint32_t> guids;
-	guids.reserve(activeBots.size());
-	for (const auto& [guid, player] : activeBots) {
-		if (player && !player->isRemoved()) {
-			guids.push_back(guid);
-		}
-	}
-
 	size_t count = 0;
-	for (uint32_t guid : guids) {
+	for (uint32_t guid : registry.guids()) {
 		if (despawnByGuid(guid, save)) {
 			++count;
 		}
 	}
-	cleanupRemoved();
+	sweepRemoved();
 	return count;
 }
 
 bool BotManager::setBroadcast(uint32_t guid, bool enabled, std::string* message /* = nullptr */)
 {
-	cleanupRemoved();
+	if (!isEnabled()) {
+		if (message) {
+			*message = "Bot system is disabled in config.lua (botSystemEnabled = false).";
+		}
+		return false;
+	}
 
-	auto it = activeBots.find(guid);
-	if (it == activeBots.end() || !it->second || it->second->isRemoved()) {
+	sweepRemoved();
+
+	auto player = registry.find(guid);
+	if (!player) {
 		if (message) {
 			*message = fmt::format("Bot {:d} is not online.", guid);
 		}
 		return false;
 	}
 
-	auto& player = it->second;
 	player->client->setBroadcast(enabled);
 	IOLoginData::updateOnlineStatus(guid, true, player->client->isBroadcasting(), player->client->password(),
 	                                player->client->description(), player->client->spectatorList().size());
@@ -468,55 +477,36 @@ bool BotManager::setBroadcast(std::string_view name, bool enabled, std::string* 
 	return setBroadcast(*guid, enabled, message);
 }
 
-bool BotManager::isManagedBot(uint32_t guid) const
-{
-	auto it = activeBots.find(guid);
-	return it != activeBots.end() && it->second && !it->second->isRemoved();
-}
+bool BotManager::isManagedBot(uint32_t guid) const { return registry.contains(guid); }
 
-std::vector<std::shared_ptr<Player>> BotManager::getActiveBots() const
-{
-	std::vector<std::shared_ptr<Player>> bots;
-	bots.reserve(activeBots.size());
-	for (const auto& [guid, player] : activeBots) {
-		if (player && !player->isRemoved()) {
-			bots.push_back(player);
-		}
-	}
-	return bots;
-}
+std::vector<std::shared_ptr<Player>> BotManager::getActiveBots() const { return registry.snapshot(); }
 
 void BotManager::forget(uint32_t guid)
 {
-	auto it = activeBots.find(guid);
-	if (it != activeBots.end()) {
-		activeBots.erase(it);
-		touchRuntime(guid, false);
+	if (registry.erase(guid)) {
+		touchRuntimeAsync(guid, false);
 	}
 }
 
-void BotManager::cleanupRemoved()
+void BotManager::sweepRemoved()
 {
-	for (auto it = activeBots.begin(); it != activeBots.end();) {
-		if (!it->second || it->second->isRemoved()) {
-			const uint32_t guid = it->first;
-			it = activeBots.erase(it);
-			touchRuntime(guid, false);
-		} else {
-			++it;
-		}
+	for (uint32_t guid : registry.sweepRemoved()) {
+		touchRuntimeAsync(guid, false);
 	}
 }
 
-void BotManager::touchRuntime(uint32_t guid, bool spawned)
+void BotManager::touchRuntimeAsync(uint32_t guid, bool spawned)
 {
 	if (guid == 0 || !ensureTables()) {
 		return;
 	}
 
+	// Telemetry only; nothing reads these back in-process. DatabaseTasks is a
+	// single FIFO worker and its shutdown() flushes the queue, so ordering and
+	// shutdown persistence hold.
 	const std::time_t now = std::time(nullptr);
 	const char* column = spawned ? "last_spawn" : "last_despawn";
-	Database& db = Database::getInstance();
-	db.executeQuery(fmt::format("UPDATE `bot_players` SET `{:s}` = {:d}, `updated_at` = {:d} WHERE `player_id` = {:d}",
-	                            column, static_cast<uint64_t>(now), static_cast<uint64_t>(now), guid));
+	g_databaseTasks.addTask(
+	    fmt::format("UPDATE `bot_players` SET `{:s}` = {:d}, `updated_at` = {:d} WHERE `player_id` = {:d}", column,
+	                static_cast<uint64_t>(now), static_cast<uint64_t>(now), guid));
 }

--- a/src/botmanager.h
+++ b/src/botmanager.h
@@ -4,11 +4,12 @@
 #ifndef FS_BOTMANAGER_H
 #define FS_BOTMANAGER_H
 
+#include "botregistry.h"
+
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 class Player;
@@ -30,6 +31,12 @@ public:
 		uint32_t guid = 0;
 		std::string name;
 		std::string message;
+	};
+
+	struct MarkedState
+	{
+		bool marked = false;
+		bool enabled = false;
 	};
 
 	static BotManager& getInstance();
@@ -55,17 +62,19 @@ public:
 
 	bool isEnabled() const;
 	bool ensureTables();
-	bool isMarkedBot(uint32_t guid, bool* enabled = nullptr);
+	// nullopt means the registry could not be read (database error), which is
+	// distinct from "not registered" (marked == false).
+	std::optional<MarkedState> isMarkedBot(uint32_t guid);
 	std::optional<uint32_t> getGuidByName(std::string_view name) const;
 
 private:
 	BotManager() = default;
 
-	void cleanupRemoved();
-	void touchRuntime(uint32_t guid, bool spawned);
+	void sweepRemoved();
+	void touchRuntimeAsync(uint32_t guid, bool spawned);
 
 	bool tablesReady = false;
-	std::unordered_map<uint32_t, std::shared_ptr<Player>> activeBots;
+	tfs::bot::Registry<Player> registry;
 };
 
 #endif

--- a/src/botregistry.h
+++ b/src/botregistry.h
@@ -1,0 +1,98 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_BOTREGISTRY_H
+#define FS_BOTREGISTRY_H
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace tfs::bot {
+
+// Parses a strictly numeric, non-zero player guid. Returns nullopt for empty
+// input, non-digit characters, zero, or values that overflow uint32_t.
+std::optional<uint32_t> parseGuid(std::string_view text);
+
+// In-memory bookkeeping for active bot players. The registry holds the owning
+// shared_ptr that keeps a socketless bot Player alive while it is placed on
+// the map (Game only keeps weak_ptr entries for players). Templated on the
+// player type so tests and benchmarks can exercise it with lightweight stubs
+// that only provide isRemoved().
+template <typename PlayerT>
+class Registry
+{
+public:
+	bool insert(uint32_t guid, std::shared_ptr<PlayerT> player)
+	{
+		if (guid == 0 || !player) {
+			return false;
+		}
+		return bots.emplace(guid, std::move(player)).second;
+	}
+
+	std::shared_ptr<PlayerT> find(uint32_t guid) const
+	{
+		auto it = bots.find(guid);
+		if (it == bots.end() || !it->second || it->second->isRemoved()) {
+			return nullptr;
+		}
+		return it->second;
+	}
+
+	bool contains(uint32_t guid) const { return find(guid) != nullptr; }
+
+	bool erase(uint32_t guid) { return bots.erase(guid) != 0; }
+
+	// Drops entries whose player is gone or already removed from the game and
+	// returns their guids so the caller can persist the despawn timestamps.
+	std::vector<uint32_t> sweepRemoved()
+	{
+		std::vector<uint32_t> swept;
+		for (auto it = bots.begin(); it != bots.end();) {
+			if (!it->second || it->second->isRemoved()) {
+				swept.push_back(it->first);
+				it = bots.erase(it);
+			} else {
+				++it;
+			}
+		}
+		return swept;
+	}
+
+	std::vector<std::shared_ptr<PlayerT>> snapshot() const
+	{
+		std::vector<std::shared_ptr<PlayerT>> out;
+		out.reserve(bots.size());
+		for (const auto& [guid, player] : bots) {
+			if (player && !player->isRemoved()) {
+				out.push_back(player);
+			}
+		}
+		return out;
+	}
+
+	std::vector<uint32_t> guids() const
+	{
+		std::vector<uint32_t> out;
+		out.reserve(bots.size());
+		for (const auto& [guid, player] : bots) {
+			if (player && !player->isRemoved()) {
+				out.push_back(guid);
+			}
+		}
+		return out;
+	}
+
+	size_t size() const noexcept { return bots.size(); }
+
+private:
+	std::unordered_map<uint32_t, std::shared_ptr<PlayerT>> bots;
+};
+
+} // namespace tfs::bot
+
+#endif // FS_BOTREGISTRY_H

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -513,7 +513,7 @@ bool ConfigManager::load()
 	booleans[Boolean::STRESS_TEST_SHUTDOWN_SEND] = getGlobalBoolean(L, "stressTestShutdownSend", true);
 	booleans[Boolean::CLEAVE_SYSTEM_ENABLED] = getGlobalBoolean(L, "cleavesystem", true);
 	booleans[Boolean::CHARACTER_BAZAAR_ENABLED] = getGlobalBoolean(L, "characterBazaarEnabled", false);
-	booleans[Boolean::BOT_SYSTEM_ENABLED] = getGlobalBoolean(L, "botSystemEnabled", true);
+	booleans[Boolean::BOT_SYSTEM_ENABLED] = getGlobalBoolean(L, "botSystemEnabled", false);
 
 	integers[Integer::CLEAVE_DEFAULT_PERCENT] = std::clamp<int64_t>(getGlobalInteger(L, "cleaveDefaultPercent", 30), 0, 100);
 	integers[Integer::CLEAVE_FIST_PERCENT] = std::clamp<int64_t>(getGlobalInteger(L, "cleaveFistPercent", 20), 0, 100);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1887,6 +1887,15 @@ void Player::sendPing()
 {
 	int64_t timeNow = OTSYS_TIME();
 
+	if (bot) {
+		// Socketless bots never pong (receivePing only fires from a client
+		// packet, and a cast spectator's pong refreshes lastPong only while
+		// someone is watching). Refresh synthetically so the noPongKickTime
+		// logout and the 7s attack-target drop below never fire for bots,
+		// while the ping fan-out to cast spectators stays intact.
+		lastPong = timeNow;
+	}
+
 	bool hasLostConnection = false;
 	if ((timeNow - lastPing) >= 5000) {
 		lastPing = timeNow;

--- a/src/tests/test_botmanager.cpp
+++ b/src/tests/test_botmanager.cpp
@@ -1,0 +1,192 @@
+#include "../otpch.h"
+
+#include "../botmanager.h"
+
+#include "../configmanager.h"
+#include "../database.h"
+#include "../item.h"
+#include "../player.h"
+
+#include <cstdlib>
+
+#include "test_support.h"
+
+namespace {
+
+// Player construction touches Items::getItemType (StoreInbox), which indexes
+// an empty item vector unless items.otb has been loaded. Resolve the data dir
+// from TFS_DATA_DIR or common relative locations; returns false when no OTB
+// could be found so callers can skip Player-dependent checks gracefully.
+bool ensureItemsLoaded()
+{
+	static int state = -1;
+	if (state != -1) {
+		return state == 1;
+	}
+
+	std::vector<std::string> candidates;
+	if (const char* dataDir = std::getenv("TFS_DATA_DIR")) {
+		candidates.push_back(std::string(dataDir) + "/items/items.otb");
+	}
+	candidates.emplace_back("data/items/items.otb");
+	candidates.emplace_back("../data/items/items.otb");
+	candidates.emplace_back("../../data/items/items.otb");
+	candidates.emplace_back("../../../data/items/items.otb");
+
+	for (const auto& path : candidates) {
+		if (Item::items.loadFromOtb(path)) {
+			state = 1;
+			return true;
+		}
+	}
+
+	state = 0;
+	std::cerr << "[skip] items.otb not found; set TFS_DATA_DIR to enable Player-based checks\n";
+	return false;
+}
+
+} // namespace
+
+// --- Gate behaviour (no database, no dispatcher thread) -------------------
+
+TEST_CASE(spawn_rejected_when_bot_system_disabled)
+{
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, false);
+
+	const auto result = BotManager::getInstance().spawnByGuid(1);
+	CHECK(!result.success);
+	CHECK(result.message.find("disabled") != std::string::npos);
+}
+
+TEST_CASE(register_rejected_when_bot_system_disabled)
+{
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, false);
+
+	const auto result = BotManager::getInstance().registerByName("Some Bot");
+	CHECK(!result.success);
+	CHECK(result.message.find("botSystemEnabled") != std::string::npos);
+}
+
+TEST_CASE(set_broadcast_rejected_when_bot_system_disabled)
+{
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, false);
+
+	std::string message;
+	CHECK(!BotManager::getInstance().setBroadcast(uint32_t(1), true, &message));
+	CHECK(message.find("disabled") != std::string::npos);
+}
+
+TEST_CASE(spawn_rejected_off_dispatcher_thread)
+{
+	// The enabled gate is checked first, so enabling isolates the thread gate.
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, true);
+
+	const auto result = BotManager::getInstance().spawnByGuid(1);
+	CHECK(!result.success);
+	CHECK(result.message.find("dispatcher thread") != std::string::npos);
+
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, false);
+}
+
+TEST_CASE(despawn_rejected_off_dispatcher_thread)
+{
+	// Despawn is deliberately not gated on the enabled flag (operators must
+	// always be able to clean up); the thread gate is its first statement.
+	std::string message;
+	CHECK(!BotManager::getInstance().despawnByGuid(1, true, &message));
+	CHECK(message.find("dispatcher thread") != std::string::npos);
+}
+
+// --- Guid parsing through the public API ----------------------------------
+
+TEST_CASE(get_guid_by_name_parses_numeric_input_without_sql)
+{
+	std::vector<std::string> captured;
+	QueryCaptureScope capture(captured);
+
+	const auto& manager = BotManager::getInstance();
+	CHECK(manager.getGuidByName("123") == 123U);
+	CHECK(manager.getGuidByName("  123  ") == 123U);
+	CHECK(manager.getGuidByName("4294967295") == 4294967295U);
+	CHECK(captured.empty());
+}
+
+TEST_CASE(get_guid_by_name_rejects_empty_and_whitespace_without_sql)
+{
+	std::vector<std::string> captured;
+	QueryCaptureScope capture(captured);
+
+	const auto& manager = BotManager::getInstance();
+	CHECK(!manager.getGuidByName(""));
+	CHECK(!manager.getGuidByName("   "));
+	CHECK(captured.empty());
+}
+
+// --- Registry views on the empty registry ----------------------------------
+
+TEST_CASE(unknown_guid_is_not_a_managed_bot)
+{
+	CHECK(!BotManager::getInstance().isManagedBot(99999));
+	CHECK(BotManager::getInstance().getActiveBots().empty());
+}
+
+TEST_CASE(forget_unknown_guid_writes_nothing)
+{
+	std::vector<std::string> captured;
+	QueryCaptureScope capture(captured);
+
+	BotManager::getInstance().forget(99999);
+	CHECK(captured.empty());
+}
+
+// --- Player bot flag --------------------------------------------------------
+
+TEST_CASE(player_bot_flag_roundtrip)
+{
+	if (!ensureItemsLoaded()) {
+		return;
+	}
+
+	auto player = std::make_shared<Player>(nullptr);
+	CHECK(!player->isBot());
+	player->setBot(true);
+	CHECK(player->isBot());
+	CHECK(player->client != nullptr);
+}
+
+// --- SQL-capture cases (sticky singleton state; keep these LAST) -----------
+
+TEST_CASE(ensure_tables_emits_create_table_once)
+{
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, true);
+
+	std::vector<std::string> captured;
+	QueryCaptureScope capture(captured);
+
+	auto& manager = BotManager::getInstance();
+	CHECK(manager.ensureTables());
+	CHECK(manager.ensureTables());
+	CHECK(captured.size() == 1U);
+	CHECK(captured[0].find("CREATE TABLE IF NOT EXISTS `bot_players`") != std::string::npos);
+
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, false);
+}
+
+TEST_CASE(register_rejects_invalid_name_without_registry_writes)
+{
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, true);
+
+	std::vector<std::string> captured;
+	QueryCaptureScope capture(captured);
+
+	const auto result = BotManager::getInstance().registerByName("!!bad name!!");
+	CHECK(!result.success);
+	CHECK(result.message == "Invalid player name.");
+	for (const auto& query : captured) {
+		CHECK(query.find("INSERT") == std::string::npos);
+	}
+
+	ConfigManager::setBoolean(ConfigManager::BOT_SYSTEM_ENABLED, false);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_botregistry.cpp
+++ b/src/tests/test_botregistry.cpp
@@ -1,0 +1,118 @@
+#include "../otpch.h"
+
+#include "../botregistry.h"
+
+#include "test_support.h"
+
+namespace {
+
+struct StubPlayer
+{
+	bool removed = false;
+	bool isRemoved() const { return removed; }
+};
+
+std::shared_ptr<StubPlayer> makeStub(bool removed = false)
+{
+	auto stub = std::make_shared<StubPlayer>();
+	stub->removed = removed;
+	return stub;
+}
+
+} // namespace
+
+TEST_CASE(parse_guid_accepts_numeric_ids)
+{
+	CHECK(tfs::bot::parseGuid("123") == 123U);
+	CHECK(tfs::bot::parseGuid("1") == 1U);
+	CHECK(tfs::bot::parseGuid("4294967295") == 4294967295U);
+}
+
+TEST_CASE(parse_guid_rejects_invalid_input)
+{
+	CHECK(!tfs::bot::parseGuid(""));
+	CHECK(!tfs::bot::parseGuid("0"));
+	CHECK(!tfs::bot::parseGuid("abc"));
+	CHECK(!tfs::bot::parseGuid("12ab"));
+	CHECK(!tfs::bot::parseGuid("-5"));
+	CHECK(!tfs::bot::parseGuid("4294967296")); // overflows uint32_t
+	CHECK(!tfs::bot::parseGuid(" 123"));       // callers trim before parsing
+}
+
+TEST_CASE(registry_insert_rejects_null_zero_and_duplicates)
+{
+	tfs::bot::Registry<StubPlayer> registry;
+	auto player = makeStub();
+
+	CHECK(!registry.insert(0, player));
+	CHECK(!registry.insert(1, nullptr));
+	CHECK(registry.insert(1, player));
+	CHECK(!registry.insert(1, makeStub()));
+	CHECK(registry.size() == 1U);
+}
+
+TEST_CASE(registry_find_filters_removed_players)
+{
+	tfs::bot::Registry<StubPlayer> registry;
+	auto alive = makeStub();
+	auto dead = makeStub(true);
+
+	CHECK(registry.insert(1, alive));
+	CHECK(registry.insert(2, dead));
+
+	CHECK(registry.find(1) == alive);
+	CHECK(registry.find(2) == nullptr);
+	CHECK(registry.contains(1));
+	CHECK(!registry.contains(2));
+	CHECK(!registry.contains(99));
+}
+
+TEST_CASE(registry_erase_is_idempotent)
+{
+	// The despawn bookkeeping (F3 fix) relies on erase reporting the removal
+	// exactly once so the runtime timestamp is written exactly once.
+	tfs::bot::Registry<StubPlayer> registry;
+	CHECK(registry.insert(7, makeStub()));
+
+	CHECK(registry.erase(7));
+	CHECK(!registry.erase(7));
+	CHECK(!registry.erase(7));
+	CHECK(registry.size() == 0U);
+}
+
+TEST_CASE(registry_sweep_returns_swept_guids_and_keeps_live_entries)
+{
+	tfs::bot::Registry<StubPlayer> registry;
+	auto alive = makeStub();
+	CHECK(registry.insert(1, alive));
+	CHECK(registry.insert(2, makeStub(true)));
+	CHECK(registry.insert(3, makeStub(true)));
+
+	auto swept = registry.sweepRemoved();
+	CHECK(swept.size() == 2U);
+	CHECK((swept[0] == 2U || swept[0] == 3U));
+	CHECK((swept[1] == 2U || swept[1] == 3U));
+	CHECK(swept[0] != swept[1]);
+
+	CHECK(registry.size() == 1U);
+	CHECK(registry.contains(1));
+	CHECK(registry.sweepRemoved().empty());
+}
+
+TEST_CASE(registry_snapshot_and_guids_skip_removed_entries)
+{
+	tfs::bot::Registry<StubPlayer> registry;
+	auto alive = makeStub();
+	CHECK(registry.insert(1, alive));
+	CHECK(registry.insert(2, makeStub(true)));
+
+	auto snapshot = registry.snapshot();
+	CHECK(snapshot.size() == 1U);
+	CHECK(snapshot[0] == alive);
+
+	auto guids = registry.guids();
+	CHECK(guids.size() == 1U);
+	CHECK(guids[0] == 1U);
+}
+
+TFS_TEST_MAIN()

--- a/tests/lua/harness.lua
+++ b/tests/lua/harness.lua
@@ -1,0 +1,52 @@
+-- Minimal test harness for the standalone (engine-free) Lua tests.
+-- Usage: dofile("tests/lua/harness.lua") from the repo root.
+local H = {}
+
+H.failures = 0
+H.checks = 0
+
+function H.check(condition, message)
+	H.checks = H.checks + 1
+	if not condition then
+		H.failures = H.failures + 1
+		io.stderr:write("[FAIL] " .. (message or "check failed") .. "\n")
+	end
+end
+
+function H.eq(actual, expected, message)
+	H.check(actual == expected,
+		(message or "eq") .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual))
+end
+
+function H.finish(name)
+	if H.failures > 0 then
+		io.stderr:write(string.format("%s: %d/%d check(s) failed\n", name, H.failures, H.checks))
+		os.exit(1)
+	end
+	print(string.format("%s: %d check(s) passed", name, H.checks))
+end
+
+-- Deterministic rng following math.random(lo, hi) semantics: consumes the
+-- given sequence of values and clamps them into the requested range.
+function H.makeRng(sequence)
+	local index = 0
+	return function(lo, hi)
+		index = index + 1
+		local value = sequence[((index - 1) % #sequence) + 1]
+		if value < lo then
+			return lo
+		end
+		if value > hi then
+			return hi
+		end
+		return value
+	end
+end
+
+function H.loadCore()
+	dofile("data/scripts/lib/bot_core.lua")
+	assert(BotCore, "bot_core.lua must define the BotCore global")
+	return BotCore
+end
+
+return H

--- a/tests/lua/run.sh
+++ b/tests/lua/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Runs the standalone (engine-free) Lua tests with a plain Lua 5.5 interpreter.
+# Usage: bash tests/lua/run.sh [path-to-lua]
+set -u
+
+cd "$(dirname "$0")/../.."
+
+LUA_BIN="${1:-${LUA_BIN:-lua}}"
+if ! command -v "$LUA_BIN" >/dev/null 2>&1; then
+	if [ -x /usr/local/bin/lua ]; then
+		LUA_BIN=/usr/local/bin/lua
+	else
+		echo "error: no lua interpreter found (set LUA_BIN or pass one as argument)" >&2
+		exit 2
+	fi
+fi
+
+status=0
+for test in tests/lua/test_*.lua; do
+	if ! "$LUA_BIN" "$test"; then
+		status=1
+	fi
+done
+exit $status

--- a/tests/lua/test_bot_core.lua
+++ b/tests/lua/test_bot_core.lua
@@ -1,0 +1,132 @@
+-- Pure-function coverage for BotCore. Runs under a bare Lua 5.5 interpreter
+-- from the repo root: lua tests/lua/test_bot_core.lua
+local H = dofile("tests/lua/harness.lua")
+local BotCore = H.loadCore()
+
+-- trim / splitList
+H.eq(BotCore.trim("  hello  "), "hello", "trim strips both ends")
+H.eq(BotCore.trim(nil), "", "trim tolerates nil")
+H.eq(BotCore.trim(42), "42", "trim stringifies input")
+
+local parts = BotCore.splitList(" a , b ,c ")
+H.eq(#parts, 3, "splitList count")
+H.eq(parts[1], "a", "splitList trims first")
+H.eq(parts[2], "b", "splitList trims middle")
+H.eq(parts[3], "c", "splitList trims last")
+H.eq(#BotCore.splitList(""), 0, "splitList empty input")
+
+-- parseToggle
+for _, on in ipairs({ "on", "true", "1", "yes", "auto", "ON", "Yes" }) do
+	H.check(BotCore.parseToggle(on), "parseToggle accepts " .. on)
+end
+for _, off in ipairs({ "off", "false", "0", "no", "", nil, "banana" }) do
+	H.check(not BotCore.parseToggle(off), "parseToggle rejects " .. tostring(off))
+end
+
+-- parseCommand
+local action, args = BotCore.parseCommand("")
+H.eq(action, "", "parseCommand empty action")
+H.eq(#args, 0, "parseCommand empty args")
+
+action, args = BotCore.parseCommand("  ADD  Test Bot, auto, ek ")
+H.eq(action, "add", "parseCommand lowercases action")
+H.eq(#args, 3, "parseCommand arg count")
+H.eq(args[1], "Test Bot", "parseCommand keeps spaces inside names")
+H.eq(args[2], "auto", "parseCommand second arg")
+H.eq(args[3], "ek", "parseCommand third arg")
+
+action, args = BotCore.parseCommand("list")
+H.eq(action, "list", "parseCommand action only")
+H.eq(#args, 0, "parseCommand action-only args")
+
+-- normalizeVocation
+H.eq(BotCore.normalizeVocation("ek"), 4, "normalizeVocation ek")
+H.eq(BotCore.normalizeVocation("ms"), 1, "normalizeVocation ms")
+H.eq(BotCore.normalizeVocation("ed"), 2, "normalizeVocation ed")
+H.eq(BotCore.normalizeVocation("rp"), 3, "normalizeVocation rp")
+H.eq(BotCore.normalizeVocation("Sorcerer"), 1, "normalizeVocation name case-insensitive")
+H.eq(BotCore.normalizeVocation("7"), 3, "normalizeVocation folds promoted numeric")
+H.eq(BotCore.normalizeVocation("2"), 2, "normalizeVocation base numeric")
+H.eq(BotCore.normalizeVocation(""), 4, "normalizeVocation empty defaults to knight")
+H.eq(BotCore.normalizeVocation("garbage"), 4, "normalizeVocation garbage defaults to knight")
+H.eq(BotCore.normalizeVocation("99"), 4, "normalizeVocation out-of-range defaults to knight")
+
+-- vocationBase
+H.eq(BotCore.vocationBase(8), 4, "vocationBase folds 8 to 4")
+H.eq(BotCore.vocationBase(5), 1, "vocationBase folds 5 to 1")
+H.eq(BotCore.vocationBase(3), 3, "vocationBase keeps base ids")
+H.eq(BotCore.vocationBase(0), 4, "vocationBase invalid defaults to 4")
+H.eq(BotCore.vocationBase(nil), 4, "vocationBase nil defaults to 4")
+
+-- chebyshevDistance
+H.eq(BotCore.chebyshevDistance({ x = 0, y = 0, z = 7 }, { x = 3, y = -2, z = 7 }), 3, "chebyshev max axis")
+H.eq(BotCore.chebyshevDistance({ x = 0, y = 0, z = 7 }, { x = 1, y = 1, z = 8 }), math.huge, "z mismatch is huge")
+H.eq(BotCore.chebyshevDistance(nil, { x = 0, y = 0, z = 0 }), math.huge, "nil origin is huge")
+H.eq(BotCore.chebyshevDistance({ x = 5, y = 5, z = 1 }, { x = 5, y = 5, z = 1 }), 0, "same position")
+
+-- selectTarget
+local origin = { x = 10, y = 10, z = 7 }
+local target, distance = BotCore.selectTarget(origin, {
+	{ index = "far", position = { x = 16, y = 10, z = 7 } },
+	{ index = "near", position = { x = 11, y = 11, z = 7 } },
+	{ index = "wrongz", position = { x = 10, y = 10, z = 6 } }
+})
+H.eq(target and target.index, "near", "selectTarget picks closest")
+H.eq(distance, 1, "selectTarget distance")
+H.eq(BotCore.selectTarget(origin, {}), nil, "selectTarget empty candidates")
+H.eq(BotCore.selectTarget(origin, { { index = 1, position = { x = 0, y = 0, z = 1 } } }), nil,
+	"selectTarget all unreachable")
+
+-- computeHeal
+local cfg = { thresholdPercent = 65, restorePercent = 15, restoreMin = 25 }
+H.eq(BotCore.computeHeal(100, 100, cfg), nil, "computeHeal full health")
+H.eq(BotCore.computeHeal(70, 100, cfg), nil, "computeHeal above threshold")
+H.eq(BotCore.computeHeal(65, 100, cfg), 25, "computeHeal restoreMin floor")
+H.eq(BotCore.computeHeal(50, 1000, cfg), 150, "computeHeal restorePercent")
+H.eq(BotCore.computeHeal(999, 1000, cfg), nil, "computeHeal missing clamped by threshold first")
+H.eq(BotCore.computeHeal(640, 1000, cfg), 150, "computeHeal below threshold restores percent")
+H.eq(BotCore.computeHeal(5, 12, cfg), 7, "computeHeal clamps to missing")
+H.eq(BotCore.computeHeal(5, 0, cfg), nil, "computeHeal zero max")
+H.eq(BotCore.computeHeal(5, 100, nil), nil, "computeHeal nil cfg")
+
+-- pickWanderOffset
+local rngZero = H.makeRng({ 0, 0, 2 })
+local dx, dy = BotCore.pickWanderOffset(5, rngZero)
+H.check(not (dx == 0 and dy == 0), "pickWanderOffset never (0,0)")
+H.eq(dx, 1, "pickWanderOffset fallback east dx")
+H.eq(dy, 0, "pickWanderOffset fallback east dy")
+
+for i = 1, 50 do
+	local ox, oy = BotCore.pickWanderOffset(3)
+	H.check(math.abs(ox) <= 3 and math.abs(oy) <= 3, "pickWanderOffset within radius (iter " .. i .. ")")
+	H.check(not (ox == 0 and oy == 0), "pickWanderOffset non-zero (iter " .. i .. ")")
+end
+
+-- equipmentFor
+local knightSet = BotCore.equipmentFor(4)
+H.eq(#knightSet, 6, "knight equipment count (4 common + 2 weapon/shield)")
+local paladinSet = BotCore.equipmentFor(3)
+H.eq(#paladinSet, 6, "paladin equipment count")
+local sorcSet = BotCore.equipmentFor(1)
+H.eq(#sorcSet, 5, "sorcerer equipment count")
+local fallbackSet = BotCore.equipmentFor(99)
+H.eq(#fallbackSet, 6, "unknown vocation falls back to knight set")
+for _, entry in ipairs(knightSet) do
+	H.check(type(entry.slot) == "string", "equipment slots are symbolic names")
+	H.check(type(entry.itemId) == "number", "equipment ids are numbers")
+end
+
+-- phrases and delays
+local phrase = BotCore.pickPhrase(H.makeRng({ 1 }))
+H.eq(phrase, "hi", "pickPhrase deterministic with rng")
+H.check(BotCore.nextSayDelay(H.makeRng({ 100 })) == 100, "nextSayDelay respects rng")
+H.check(BotCore.firstSayDelay(H.makeRng({ 50 })) == 50, "firstSayDelay respects rng")
+
+-- mergeDefaults
+local merged = BotCore.mergeDefaults({ tickInterval = 250, heal = { enabled = false } }, BotCore.defaults)
+H.eq(merged.tickInterval, 250, "mergeDefaults keeps overrides")
+H.eq(merged.heal.enabled, false, "mergeDefaults keeps nested overrides")
+H.eq(merged.heal.health.thresholdPercent, 65, "mergeDefaults fills nested defaults")
+H.eq(merged.wanderRadius, 5, "mergeDefaults fills top-level defaults")
+
+H.finish("test_bot_core")

--- a/tests/lua/test_lib_load.lua
+++ b/tests/lua/test_lib_load.lua
@@ -1,0 +1,43 @@
+-- Self-sufficiency proof: every bot_*.lua lib must load under a bare Lua 5.5
+-- interpreter with zero engine globals stubbed. This guarantees no file-scope
+-- engine reads and no load-order dependency between the libs.
+-- Run from the repo root: lua tests/lua/test_lib_load.lua
+local H = dofile("tests/lua/harness.lua")
+
+local libs = {
+	{ path = "data/scripts/lib/bot_core.lua", global = "BotCore" },
+	{ path = "data/scripts/lib/bot_brain.lua", global = "BotBrain" },
+	{ path = "data/scripts/lib/bot_system.lua", global = "BotSystem" }
+}
+
+for _, lib in ipairs(libs) do
+	local chunk, loadError = loadfile(lib.path)
+	H.check(chunk ~= nil, lib.path .. " parses: " .. tostring(loadError))
+	if chunk then
+		local ok, runError = pcall(chunk)
+		H.check(ok, lib.path .. " loads without engine globals: " .. tostring(runError))
+		H.check(_G[lib.global] ~= nil, lib.path .. " defines " .. lib.global)
+	end
+end
+
+-- BotBrain lifecycle guards must not touch engine APIs when the system is
+-- unavailable: stop() with no pending event and activate(nil) must be safe.
+H.check(BotBrain.stop ~= nil, "BotBrain.stop exists")
+BotBrain.stop()
+H.eq(BotBrain.running, false, "BotBrain.stop clears running")
+H.eq(BotBrain.activate(nil), false, "BotBrain.activate(nil) is rejected")
+
+-- BotSystem must degrade gracefully without the engine: Game is undefined
+-- here, so availability must be false and guarded calls must return an error
+-- string instead of raising.
+Game = Game or {}
+H.eq(BotSystem.isAvailable(), false, "BotSystem unavailable without bindings")
+H.eq(BotSystem.isEnabled(), false, "BotSystem disabled without bindings")
+local ok, message = BotSystem.spawn("Test")
+H.eq(ok, false, "BotSystem.spawn fails gracefully without bindings")
+H.check(type(message) == "string" and message:find("BotManager"), "spawn failure names the missing binding")
+ok, message = BotSystem.register("Test")
+H.eq(ok, false, "BotSystem.register fails gracefully without bindings")
+H.eq(BotSystem.spawnAuto(), 0, "BotSystem.spawnAuto returns 0 without bindings")
+
+H.finish("test_lib_load")

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="..\src\baseevents.cpp" />
     <ClCompile Include="..\src\bestiary_charm.cpp" />
     <ClCompile Include="..\src\bed.cpp" />
+    <ClCompile Include="..\src\botmanager.cpp" />
     <ClCompile Include="..\src\character_bazaar.cpp" />
     <ClCompile Include="..\src\chat.cpp" />
     <ClCompile Include="..\src\combat.cpp" />
@@ -329,6 +330,8 @@
     <ClInclude Include="..\src\baseevents.h" />
     <ClInclude Include="..\src\bestiary_charm.h" />
     <ClInclude Include="..\src\bed.h" />
+    <ClInclude Include="..\src\botmanager.h" />
+    <ClInclude Include="..\src\botregistry.h" />
     <ClInclude Include="..\src\character_bazaar.h" />
     <ClInclude Include="..\src\chat.h" />
     <ClInclude Include="..\src\combat.h" />


### PR DESCRIPTION
## Resumo

Esta PR aplica correções, endurecimento, testes e benchmarks em cima da #159 (managed bot players with cast). A revisão completa validou a arquitetura da #159 contra o engine (o modelo `shared_ptr` do fork suporta o design — `Game` guarda `weak_ptr` e o `BotManager` é o dono forte correto; `removeCreature` segura uma referência local durante toda a remoção, então não há UAF/double-free), mas encontrou **um bug crítico de runtime** e uma série de itens menores, todos corrigidos aqui.

## Bug crítico: bots se auto-deslogam ~40–60s após o spawn (F2)

`Player::onThink` chama `sendPing()` incondicionalmente ([player.cpp:2837]). Para um bot sem socket, nada nunca chama `receivePing()`, então `noPongTime` cresce até o `noPongKickTime` da vocação (40–50s no `vocations.xml`) e o `sendPing` remove o player ([player.cpp:1885]). A #159 protegeu o ghost-kick e o idle-kick em `onThink`, mas não este caminho.

**Sutileza que escondeu o bug:** o pong de um espectador de cast atualiza o `lastPong` do player castado ([protocolgame.cpp:1286] → `playerReceivePing`), então **bot assistido sobrevive e bot sozinho morre** — testes feitos com cast aberto nunca viam o problema. Havia ainda um segundo sintoma: o mesmo mecanismo derruba o `attackedCreature` a cada 7s para bots sem espectador, quebrando o combate do BotBrain.

**Fix:** refresh sintético de `lastPong` no topo de `sendPing()` quando `isBot()` — o fan-out de ping para espectadores continua intacto.

**Evidência medida** (5 bots, sem espectadores, célula de 120s, mesma metodologia nas duas variantes):

| Tempo após o spawn | #159 (base) | Esta PR |
|---|---|---|
| +10s | 5/5 vivos | 5/5 vivos |
| +60s | 5/5 vivos | 5/5 vivos |
| **+65s** | **0/5 — todos deslogados** | 5/5 vivos |
| +115s | 0/5 | **5/5 vivos** |
| `despawnAllBots` no shutdown | despawnou **0** (já estavam mortos) | despawnou **5** |

A janela de morte (~60s) bate com o mínimo imposto por `pzLocked/inProtectionZone` no `sendPing` — os bots spawnam no templo (PZ).

## Demais correções

| # | Problema | Fix |
|---|---|---|
| F1 | `botmanager.cpp/h` fora do `vc18/theforgottenserver.vcxproj` → check de paridade do ctest **falha na #159** (reproduzível: `cmake -DPROJECT_SOURCE_DIR=. -P tools/check-source-list-parity.cmake`) | Fontes sincronizadas; de brinde, `fonticakclient.h` (quebra de paridade pré-existente na main) também entrou no `src/CMakeLists.txt` |
| F3 | Contabilidade dupla no despawn: `forget()` (via `onRemoveCreature`) + erase/touch de novo em `despawnByGuid` → 2 UPDATEs de `last_despawn` por despawn | `forget()` é o único sink, idempotente (erase-then-touch só quando apagou algo) |
| F4 | `BotBrain.stop()` nunca chamado no shutdown → tick continuava agendando `addEvent` | Shutdown chama `BotBrain.stop()` **antes** de `despawnAllBots`; o brain agora rastreia o `eventId` e cancela via `stopEvent` |
| F6 | Todos os UPDATEs de telemetria (`last_spawn`/`last_despawn`) síncronos na thread do dispatcher | `touchRuntimeAsync` via `g_databaseTasks` (worker FIFO único; `shutdown()` faz flush — timestamps não se perdem) |
| F7 | `isMarkedBot` retornava `false` tanto para "não registrado" quanto para erro de DB | `optional<MarkedState>` com `SELECT COUNT(*)` (uma linha sempre → `nullptr` = erro de DB, inequívoco) |
| F8 | Inserção em `activeBots` antes do `placeCreature` → rollback manual no caminho de falha | Inserção só após placement com sucesso; caminho de falha sem rollback (o `shared_ptr` local é o único dono) |
| F9 | `addToSlot` passava `count` como `subType` no `player:addItem` | `subType = 1` |
| F10 | `botSystemEnabled` default **true** — servidores atualizando ganhavam o sistema silenciosamente | Default **false** no ConfigManager e no `config.lua.dist` (opt-in explícito) |
| F11 | `talkaction:accountType(6)` cru | `ACCOUNT_TYPE_GOD` |
| F12 | Cura mágica do brain sem configuração | `BotBrain.config.heal` (enabled + thresholds), preenchido de `BotCore.defaults` |
| F13 | `Game.setBotBroadcast` sem gate de config | Checagem `botSystemEnabled` também no C++ (defesa em profundidade); `Game.spawnBot` já tinha `requireMarked=true` por default |
| F14 | Lógica pura presa em anon-namespace/singleton — sem seam de teste | Novo `src/botregistry.h` (`tfs::bot::Registry<PlayerT>` + `parseGuid`); `BotManager` delega, API pública inalterada |
| F16 | Fallbacks SQL em `bot_system.lua` duplicavam o caminho de registro do C++ (risco de drift) | Fallbacks removidos; C++ é a única implementação de register/spawn/despawn; SQL fica onde é canônico (listagem/flags). Despawn continua permitido com o sistema desabilitado (limpeza sempre possível) |

Também novo: `data/scripts/lib/bot_core.lua` — **toda a lógica de decisão do bot (parsing, vocação, seleção de alvo, cura, wander, equipamento) em módulo puro, sem nenhum símbolo do engine**, carregável em Lua 5.5 puro. `bot_brain.lua` virou um adapter fino; tick com `pcall` por bot (um bot quebrado não trava a frota) e sweep de estado órfão.

## Testes

- `ctest` (preset `asan-linux-tests`): **13/13 verdes sob ASan**, incluindo os novos `test_botregistry` (seam do registry, invariante de erase idempotente do F3) e `test_botmanager` (gates de config/thread, parsing de guid, garantias de zero-write via `Database::QueryCaptureScope`). Na #159 sem esta PR, o check de paridade **falha** (F1).
- `bash tests/lua/run.sh`: **205 checks verdes** em Lua 5.5 puro — `test_bot_core.lua` (lógica pura) e `test_lib_load.lua` (prova de autossuficiência: cada lib `bot_*.lua` carrega em ambiente nu, sem globals do engine e sem dependência de ordem de load).

## Benchmarks

Micro (Google Benchmark, novo `src/benchs/bench_botmanager.cpp`, 10 repetições, cv < 8%):

| Benchmark | Mediana |
|---|---|
| `parseGuid` | 19 ns |
| `Player(nullptr)` construir+destruir (custo fixo por spawn) | ~692 ns |
| Registry insert+erase (N=8→4096) | ~59–61 ns (flat) |
| Registry sweep, todos vivos (N=8 / 64) | 6,2 ns / 95 ns (linear, como esperado) |

Integração (servidor headless, DB clonado — nunca o de produção —, 5 bots, CPU-ms via `os.clock` porque `OTSYS_TIME` é cacheado por ciclo do dispatcher):

| Métrica (5 bots, célula de 120s) | #159 (base) | Esta PR |
|---|---|---|
| Spawn por bot (CPU-ms, p50 / máx) | 0,98 / 1,61 | 1,01 / 1,27 |
| Registro dos 5 bots (CPU-ms total) | 1,17 | 1,09 |
| Tick do BotBrain com 5 bots (CPU-ms, média) | 0,27 (122 ticks)¹ | 0,34 (240 ticks) |
| UPDATEs SQL de runtime na janela | 5 spawn + 5 despawn | 5 spawn + 5 despawn (agora **assíncronos**, fora da thread do dispatcher) |

¹ Na base só há 122 ticks com bots porque eles morrem aos ~60s (F2). O tick da PR custa +0,07 CPU-ms (pcall por bot + config merge) — 0,014% de uma janela de 500ms.

Resíduo em `players_online` após shutdown: **0** (F15 verificado — `onCreatureAppear`/`onRemoveCreature` já cobrem bots nos dois lados).

## Como reproduzir

```bash
# testes C++ + paridade
cmake --preset asan-linux-tests -DLUA_VERSION_STRING=5.5.0 && cmake --build --preset asan-linux-tests
ctest --preset asan-linux-tests --output-on-failure

# testes Lua puros
bash tests/lua/run.sh

# micro benchmarks
cmake -B build-bench -DBUILD_BENCHMARKING=ON -DCMAKE_BUILD_TYPE=Release ...
./build-bench/src/benchs/bench_botmanager --benchmark_repetitions=10
```

**Nota de upgrade:** o sistema agora vem **desabilitado** por default — adicionar `botSystemEnabled = true` no `config.lua` para usar. Bots auto-spawnados sempre abrem cast; `/bot cast nome, off` desliga depois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the managed bot system and adds test coverage.

- Bot system default changed to opt-in.
- Socketless bots now refresh pong state during ping checks.
- Bot lifecycle tracking moved into a reusable registry.
- Runtime spawn/despawn telemetry now uses database tasks.
- Bot Lua logic split into pure `BotCore` helpers and an engine adapter.
- Bot commands, startup, shutdown, tests, and benchmarks were updated.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The bot lifecycle paths keep dispatcher-thread ordering.
- Lua load-order and disabled-config paths are guarded.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/botmanager.cpp | Refactors bot ownership into the registry, adds async runtime telemetry, and tightens registry error handling. |
| src/botregistry.h | Adds a small active-bot registry with removed-player filtering and snapshot helpers. |
| src/player.cpp | Refreshes bot pong state in `sendPing()` so socketless bots are not kicked by no-pong logic. |
| data/scripts/lib/bot_brain.lua | Turns the bot brain into an engine adapter with per-bot error isolation and stoppable tick scheduling. |
| data/scripts/lib/bot_core.lua | Adds pure Lua helpers for bot config defaults, parsing, healing, targeting, wandering, and equipment selection. |
| data/scripts/lib/bot_system.lua | Centralizes register/spawn/despawn through C++ bindings and adds availability/config guards. |
| data/scripts/talkactions/god/bot.lua | Moves command parsing to `BotCore` and uses the named god account constant. |
| data/scripts/globalevents/bot_manager.lua | Adds startup availability checks and stops the brain before shutdown despawn. |
| src/tests/test_botmanager.cpp | Adds BotManager tests for config gates, GUID parsing, registry state, and captured database writes. |
| src/tests/test_botregistry.cpp | Adds registry tests for insert, find, erase, sweep, snapshots, and GUID parsing. |
| tests/lua/test_bot_core.lua | Adds pure Lua coverage for the new bot core helper functions. |
| src/benchs/bench_botmanager.cpp | Adds benchmarks for GUID parsing, player construction, registry operations, and snapshots. |

<sub>Reviews (1): Last reviewed commit: ["test(bot): engine-free Lua suite, unit t..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/0621d4b4b13a7a09f71fcee5fcc1fe2659e0a77b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43399523)</sub>

<!-- /greptile_comment -->