### PR TITLE
fix(monster): Make monsters target summons of GM/ADM players

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -840,12 +840,11 @@ bool Monster::isOpponent(const Creature* creature) const
 		       (!targetPlayer || (targetPlayer != masterPlayer && !masterPlayer->isPartner(targetPlayer)));
 	}
 
+	// A player-owned summon is always a valid opponent, even when its master
+	// has PlayerFlag_IgnoredByMonsters (e.g. GM/ADM) — only the flagged player
+	// himself is ignored (checked above), matching upstream TFS behavior.
 	auto creatureMaster = creature->getMaster();
 	const Player* creatureMasterPlayer = creatureMaster ? creatureMaster->getPlayer() : nullptr;
-	if (creatureMasterPlayer && creatureMasterPlayer->hasFlag(PlayerFlag_IgnoredByMonsters)) {
-		return false;
-	}
-
 	if (player || creatureMasterPlayer) {
 		return true;
 	}


### PR DESCRIPTION
## Problem

Monsters stay idle (standing still) when a GM/ADM enters their view together with a summon (e.g. `/summon demon`). They only start moving again when some other stimulus (like another monster pushing them) wakes them — and even then they never attack the summon.

Expected: monsters may ignore the GM/ADM himself, but a summon is a regular creature and must be detected, chased and attacked normally.

## Root cause

Introduced in c512beab (#104): `Monster::isOpponent` propagates `PlayerFlag_IgnoredByMonsters` from the summon's **master** to the summon itself:

```cpp
if (creatureMasterPlayer && creatureMasterPlayer->hasFlag(PlayerFlag_IgnoredByMonsters)) {
    return false;
}
```

Failure chain: summon enters view → `Monster::onCreatureMove` → `onCreatureEnter` → `onCreatureFound` → `isOpponent(summon)` returns `false` → `addTarget` never runs → `targetList` stays empty → `updateIdleStatus()` keeps the monster idle → it never walks or attacks.

Upstream TFS treats any player-owned creature as a valid opponent regardless of the master's flags — only the flagged player himself is ignored.

## Fix

Remove the master-flag early return. The direct check on the player himself (kept intact) still makes monsters ignore GMs/ADMs; their summons become valid opponents again.

Note: this bug was initially attributed to #162, but the spectator merge change there is set-equivalent to main and delivers the same events — the regression predates it and exists on `main` as well.

## Testing

- Static analysis of the full targeting flow (`onCreatureMove` → `onCreatureEnter` → `onCreatureFound` → `addTarget` → `updateIdleStatus`); `isOpponent` is the single gate rejecting the summon, and `isTarget`/`canSeeCreature` have no master-flag checks.
- Not compiled locally (build deps unavailable on this machine). Please build and verify in-game: leave the monsters' view and re-enter with a summon while on a GM/ADM character — monsters should immediately move and attack the summon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monster targeting behavior for player-owned summons.
  * Summons can now be treated as valid opponents even when their owner is configured to be ignored by monsters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates monster targeting for summons owned by ignored players. The main changes are:

- Removes the inherited `PlayerFlag_IgnoredByMonsters` rejection for player-owned creatures.
- Keeps the direct ignored-player check for GM/ADM characters.
- Documents that summons should remain valid monster opponents.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/monster.cpp | Updates `Monster::isOpponent` so ignored player flags no longer propagate from a player master to their summon. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Creature enters monster view] --> B[Monster checks isOpponent]
    B --> C{Creature is ignored player?}
    C -->|yes| D[Ignore player]
    C -->|no| E{Creature has player master?}
    E -->|yes| F[Treat summon as opponent]
    E -->|no| G[Continue normal monster checks]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Creature enters monster view] --> B[Monster checks isOpponent]
    B --> C{Creature is ignored player?}
    C -->|yes| D[Ignore player]
    C -->|no| E{Creature has player master?}
    E -->|yes| F[Treat summon as opponent]
    E -->|no| G[Continue normal monster checks]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(monster): Make monsters target summo..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/3f00e805a9f91167f85307617cbaac2abf39f891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43515973)</sub>

<!-- /greptile_comment -->