### PR TITLE
perf: remove spectator cache and optimize pathfinding

### DIFF
--- a/scripts/profiling/capture_callgrind.sh
+++ b/scripts/profiling/capture_callgrind.sh
@@ -35,7 +35,7 @@ command -v callgrind_control >/dev/null 2>&1 || die "callgrind_control not found
 
 output="callgrind-${scenario}.out.%p"
 valgrind --tool=callgrind \
-  --collect-atstart=no \
+  --instr-atstart=no \
   --callgrind-out-file="${output}" \
   ./tfs-valgrind &
 server_pid=$!
@@ -50,13 +50,13 @@ trap cleanup EXIT INT TERM
 
 printf 'Wait for server online, then press Enter.\n'
 read -r
-callgrind_control -p "${server_pid}" -i on
-callgrind_control -p "${server_pid}" -z
+callgrind_control -i on "${server_pid}"
+callgrind_control -z "${server_pid}"
 
 printf 'Prepare scenario "%s", then press Enter to start %ss capture.\n' "${scenario}" "${duration}"
 read -r
 sleep "${duration}"
-callgrind_control -p "${server_pid}" -d
-callgrind_control -p "${server_pid}" -i off
+callgrind_control --dump "${server_pid}"
+callgrind_control -i off "${server_pid}"
 
 printf 'Captured %s for PID %s.\n' "${scenario}" "${server_pid}"

--- a/src/benchs/bench_path_tile_lookup.cpp
+++ b/src/benchs/bench_path_tile_lookup.cpp
@@ -1,0 +1,84 @@
+#include "../otpch.h"
+
+#include "../map.h"
+#include "../tile.h"
+
+#include <benchmark/benchmark.h>
+
+namespace {
+
+struct PathLookupFixture
+{
+	PathLookupFixture()
+	{
+		for (uint16_t y = 256; y < 320; ++y) {
+			for (uint16_t x = 256; x < 320; ++x) {
+				map.setTile(x, y, 7, std::make_unique<StaticTile>(x, y, 7));
+			}
+		}
+
+		positions.reserve(64 * 64);
+		for (uint16_t y = 256; y < 320; ++y) {
+			if ((y & 1u) == 0) {
+				for (uint16_t x = 256; x < 320; ++x) {
+					positions.emplace_back(x, y, 7);
+				}
+			} else {
+				for (uint16_t x = 320; x-- > 256;) {
+					positions.emplace_back(x, y, 7);
+				}
+			}
+		}
+	}
+
+	Map map;
+	std::vector<Position> positions;
+};
+
+PathLookupFixture& fixture()
+{
+	static PathLookupFixture value;
+	return value;
+}
+
+} // namespace
+
+static void bench_pathTileLookup_fullTreeTraversal(benchmark::State& state)
+{
+	auto& [map, positions] = fixture();
+	for ([[maybe_unused]] auto _ : state) {
+		for (const Position& position : positions) {
+			benchmark::DoNotOptimize(map.getTile(position));
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * positions.size());
+}
+BENCHMARK(bench_pathTileLookup_fullTreeTraversal);
+
+static void bench_pathTileLookup_singleLeafCache(benchmark::State& state)
+{
+	auto& [map, positions] = fixture();
+	for ([[maybe_unused]] auto _ : state) {
+		QTreeLeafNode* leaf = nullptr;
+		Floor* floor = nullptr;
+		uint16_t leafBaseX = 0;
+		uint16_t leafBaseY = 0;
+
+		for (const Position& position : positions) {
+			const uint16_t baseX = position.x & ~FLOOR_MASK;
+			const uint16_t baseY = position.y & ~FLOOR_MASK;
+			if (!leaf || baseX != leafBaseX || baseY != leafBaseY) {
+				leaf = map.getQTNode(position.x, position.y);
+				floor = leaf ? leaf->getFloor(position.z) : nullptr;
+				leafBaseX = baseX;
+				leafBaseY = baseY;
+			}
+
+			benchmark::DoNotOptimize(floor ? floor->getTile(position.x, position.y, position.z) : nullptr);
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * positions.size());
+}
+BENCHMARK(bench_pathTileLookup_singleLeafCache);
+
+BENCHMARK_MAIN();

--- a/src/benchs/bench_spectators.cpp
+++ b/src/benchs/bench_spectators.cpp
@@ -3,6 +3,9 @@
 #include "../spectators.h"
 
 #include "../creature.h"
+#include "../game.h"
+#include "../instance_utils.h"
+#include "../player.h"
 
 #include <absl/container/flat_hash_set.h>
 #include <benchmark/benchmark.h>
@@ -27,6 +30,18 @@ private:
 };
 
 using Vec = std::vector<std::shared_ptr<Creature>>;
+
+SpectatorVec makePlayerSpectators(int64_t playerCount)
+{
+	SpectatorVec spectators;
+	for (int64_t i = 0; i < playerCount; ++i) {
+		auto player = std::make_shared<Player>(nullptr);
+		player->setInstanceID((i & 1) == 0 ? 1 : 2);
+		spectators.emplace_back(std::move(player));
+	}
+	spectators.partitionByType();
+	return spectators;
+}
 
 // Builds a destination of `size` creatures and a source of `size` creatures
 // where `overlapPct`% are shared with the destination.
@@ -130,5 +145,42 @@ static void bench_addSpectators_linearFind(benchmark::State& state)
 	}
 }
 BENCHMARK(bench_addSpectators_linearFind)->ArgsProduct({{35, 150}, {0, 50, 90}});
+
+static void bench_combatImpactEffect_filterCopy(benchmark::State& state)
+{
+	const SpectatorVec spectators = makePlayerSpectators(state.range(1));
+	const Position position{100, 100, 7};
+	const int64_t tileCount = state.range(0);
+
+	for ([[maybe_unused]] auto _ : state) {
+		for (int64_t tile = 0; tile < tileCount; ++tile) {
+			SpectatorVec filtered;
+			for (const auto& spectator : spectators.players()) {
+				Player* player = static_cast<Player*>(spectator.get());
+				if (player->compareInstance(1)) {
+					filtered.emplace_back(spectator);
+				}
+			}
+			Game::addMagicEffect(filtered, position, CONST_ME_POFF);
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * tileCount);
+}
+BENCHMARK(bench_combatImpactEffect_filterCopy)->ArgsProduct({{1, 9, 25, 81, 225}, {0, 1, 20, 100}});
+
+static void bench_combatImpactEffect_direct(benchmark::State& state)
+{
+	const SpectatorVec spectators = makePlayerSpectators(state.range(1));
+	const Position position{100, 100, 7};
+	const int64_t tileCount = state.range(0);
+
+	for ([[maybe_unused]] auto _ : state) {
+		for (int64_t tile = 0; tile < tileCount; ++tile) {
+			InstanceUtils::sendMagicEffectToInstance(spectators, position, CONST_ME_POFF, 1);
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * tileCount);
+}
+BENCHMARK(bench_combatImpactEffect_direct)->ArgsProduct({{1, 9, 25, 81, 225}, {0, 1, 20, 100}});
 
 BENCHMARK_MAIN();

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -904,6 +904,14 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 			InstanceUtils::sendMagicEffectToInstance(
 			    spectators, tile->getPosition(), params.impactEffect, caster->getInstanceID());
 		} else {
+			if (metrics) {
+				for (const auto& spectator : spectators.players()) {
+					const Player* player = static_cast<const Player*>(spectator.get());
+					if (player->compareInstance(0)) {
+						++metrics->effectRecipients;
+					}
+				}
+			}
 			g_game.addMagicEffect(tile->getPosition(), params.impactEffect, 0);
 		}
 	}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1689,7 +1689,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::MANA, WeaponProficiencyGain_t::KILL);
 			}
 
-			if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
+			if (damageCopy.blockType == BLOCK_NONE || damageCopy.blockType == BLOCK_ARMOR) {
 				for (const auto& condition : params.conditionList) {
 					if (caster == creature.get() || !creature->isImmune(condition->getType())) {
 						auto conditionCopy = condition->clone();

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -893,17 +893,16 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 			++metrics->impactEffects;
 		}
 		if (caster) {
-			SpectatorVec filtered;
-			for (const auto& s : spectators.players()) {
-				Player *p = static_cast<Player*>(s.get());
-				if (p->compareInstance(caster->getInstanceID())) {
-					filtered.emplace_back(s);
-					if (metrics) {
+			if (metrics) {
+				for (const auto& spectator : spectators.players()) {
+					const Player* player = static_cast<const Player*>(spectator.get());
+					if (player->compareInstance(caster->getInstanceID())) {
 						++metrics->effectRecipients;
 					}
 				}
 			}
-			Game::addMagicEffect(filtered, tile->getPosition(), params.impactEffect);
+			InstanceUtils::sendMagicEffectToInstance(
+			    spectators, tile->getPosition(), params.impactEffect, caster->getInstanceID());
 		} else {
 			g_game.addMagicEffect(tile->getPosition(), params.impactEffect, 0);
 		}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -18,6 +18,8 @@
 #include "spells.h"
 #include "weapons.h"
 
+#include <optional>
+
 extern Game g_game;
 
 namespace {
@@ -97,11 +99,16 @@ static int32_t getEffectiveMagicLevel(const Player* player, CombatType_t combatT
 	return std::max<int32_t>(0, magicLevel);
 }
 
-std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, const Direction dir)
+std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, const Direction dir,
+                           AreaCombatMetricsSample* metrics)
 {
 	auto casterPos = getNextPosition(dir, targetPos);
 
 	std::vector<Tile*> vec;
+	if (metrics) {
+		metrics->areaRows = area.getRows();
+		metrics->areaColumns = area.getCols();
+	}
 
 	auto& center = area.getCenter();
 
@@ -109,30 +116,48 @@ std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, co
 	for (uint32_t row = 0; row < area.getRows(); ++row, ++tmpPos.y) {
 		for (uint32_t col = 0; col < area.getCols(); ++col, ++tmpPos.x) {
 			if (area(row, col)) {
+				if (metrics) {
+					++metrics->activeCells;
+					++metrics->sightChecks;
+				}
 				if (g_game.isSightClear(casterPos, tmpPos, true)) {
 					Tile* tile = g_game.map.getTile(tmpPos);
 					if (!tile) {
 						auto newTile = std::make_unique<StaticTile>(tmpPos.x, tmpPos.y, tmpPos.z);
 						tile = newTile.get();
 						g_game.map.setTile(tmpPos, std::move(newTile));
+						if (metrics) {
+							++metrics->tilesCreated;
+						}
 					}
 					vec.push_back(tile);
+				} else if (metrics) {
+					++metrics->sightRejected;
 				}
 			}
 		}
 		tmpPos.x -= static_cast<uint16_t>(area.getCols());
 	}
+	if (metrics) {
+		metrics->tilesReturned = vec.size();
+	}
 	return vec;
 }
 
-std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targetPos, const AreaCombat* area)
+std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targetPos, const AreaCombat* area,
+                                 AreaCombatMetricsSample* metrics = nullptr)
 {
 	if (targetPos.z >= MAP_MAX_LAYERS) {
 		return {};
 	}
 
 	if (area) {
-		return getList(area->getArea(centerPos, targetPos), targetPos, getDirectionTo(targetPos, centerPos));
+		return getList(area->getArea(centerPos, targetPos), targetPos, getDirectionTo(targetPos, centerPos), metrics);
+	}
+	if (metrics) {
+		metrics->areaRows = 1;
+		metrics->areaColumns = 1;
+		metrics->activeCells = 1;
 	}
 
 	Tile* tile = g_game.map.getTile(targetPos);
@@ -140,6 +165,12 @@ std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targ
 		auto newTile = std::make_unique<StaticTile>(targetPos.x, targetPos.y, targetPos.z);
 		tile = newTile.get();
 		g_game.map.setTile(targetPos, std::move(newTile));
+		if (metrics) {
+			++metrics->tilesCreated;
+		}
+	}
+	if (metrics) {
+		metrics->tilesReturned = 1;
 	}
 	return {tile};
 }
@@ -758,7 +789,8 @@ bool Combat::loadCallBack(CallBackParam key, LuaScriptInterface* scriptInterface
 	return false;
 }
 
-void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params)
+void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params,
+                               AreaCombatMetricsSample* metrics)
 {
 	if (params.itemId != 0) {
 		uint16_t itemId = params.itemId;
@@ -832,6 +864,9 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 
 				auto field = std::dynamic_pointer_cast<MagicField>(itemPtr);
 				if (field) {
+					if (metrics) {
+						++metrics->fieldsCreated;
+					}
 					if (CreatureVector* creatures = tile->getCreatures()) {
 						const CreatureVector creatureRefs = *creatures;
 						for (const auto& creature : creatureRefs) {
@@ -847,16 +882,25 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 	}
 
 	if (params.tileCallback) {
+		if (metrics) {
+			++metrics->tileCallbacks;
+		}
 		params.tileCallback->onTileCombat(caster, tile);
 	}
 
 	if (params.impactEffect != CONST_ME_NONE) {
+		if (metrics) {
+			++metrics->impactEffects;
+		}
 		if (caster) {
 			SpectatorVec filtered;
 			for (const auto& s : spectators.players()) {
 				Player *p = static_cast<Player*>(s.get());
 				if (p->compareInstance(caster->getInstanceID())) {
 					filtered.emplace_back(s);
+					if (metrics) {
+						++metrics->effectRecipients;
+					}
 				}
 			}
 			Game::addMagicEffect(filtered, tile->getPosition(), params.impactEffect);
@@ -1394,8 +1438,40 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
                           const CombatParams& params)
 {
 	PerformanceScope performanceScope(PerformanceMetric::CombatDoAreaCombat);
+	const bool metricsEnabled = g_performanceMetrics.isEnabled();
+	std::optional<AreaCombatMetricsSample> areaMetrics;
+	if (metricsEnabled) {
+		areaMetrics.emplace();
+		areaMetrics->positionX = position.x;
+		areaMetrics->positionY = position.y;
+		areaMetrics->positionZ = position.z;
+		areaMetrics->itemId = params.itemId;
+		areaMetrics->impactEffect = params.impactEffect;
+		areaMetrics->scripted = params.profileScripted || !damage.instantSpellName.empty();
+		areaMetrics->hasConditions = !params.conditionList.empty();
+		areaMetrics->hasTileCallback = params.tileCallback != nullptr;
+		areaMetrics->hasTargetCallback = params.targetCallback != nullptr;
+	}
+	AreaCombatMetricsSample* metrics = areaMetrics ? &*areaMetrics : nullptr;
+
+	using MetricsClock = std::chrono::steady_clock;
+	const auto areaStarted = metricsEnabled ? MetricsClock::now() : MetricsClock::time_point{};
+	auto phaseStarted = areaStarted;
+	const auto finishPhase = [&](PerformanceMetric metric, uint64_t AreaCombatMetricsSample::*destination) {
+		if (!metrics) {
+			return;
+		}
+		const auto now = MetricsClock::now();
+		const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - phaseStarted).count();
+		metrics->*destination = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
+		g_performanceMetrics.record(metric, metrics->*destination);
+		phaseStarted = now;
+	};
+
 	auto tiles =
-	    caster ? getCombatArea(caster->getPosition(), position, area) : getCombatArea(position, position, area);
+	    caster ? getCombatArea(caster->getPosition(), position, area, metrics)
+	           : getCombatArea(position, position, area, metrics);
+	finishPhase(PerformanceMetric::CombatAreaBuildTiles, &AreaCombatMetricsSample::buildTilesNanoseconds);
 
 	Player* casterPlayer = caster ? caster->getPlayer() : nullptr;
 	const bool wpEnabled = casterPlayer && ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED);
@@ -1444,6 +1520,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 			damage.critical = true;
 		}
 	}
+	finishPhase(PerformanceMetric::CombatAreaPrepareDamage, &AreaCombatMetricsSample::prepareDamageNanoseconds);
 
 	int32_t maxX = 0;
 	int32_t maxY = 0;
@@ -1461,6 +1538,10 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, true, true, rangeX, rangeX, rangeY, rangeY);
+	if (metrics) {
+		metrics->spectators = spectators.size();
+	}
+	finishPhase(PerformanceMetric::CombatAreaCollectSpectators, &AreaCombatMetricsSample::collectSpectatorsNanoseconds);
 
 	postCombatEffects(caster, position, params);
 
@@ -1469,10 +1550,13 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 	for (Tile* tile : tiles) {
 		if (canDoCombat(caster, tile, params.aggressive) != RETURNVALUE_NOERROR) {
+			if (metrics) {
+				++metrics->combatRejected;
+			}
 			continue;
 		}
 
-		combatTileEffects(spectators, caster, tile, params);
+		combatTileEffects(spectators, caster, tile, params, metrics);
 
 		if (CreatureVector* creatures = tile->getCreatures()) {
 			const Creature* topCreature = tile->getTopCreature();
@@ -1490,6 +1574,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 				if (!params.aggressive ||
 				    (caster != creature.get() && Combat::canDoCombat(caster, creature.get()) == RETURNVALUE_NOERROR)) {
 					toDamageCreatures.push_back(creature);
+					if (metrics) {
+						++metrics->targets;
+					}
 
 					if (params.targetCasterOrTopMost) {
 						break;
@@ -1498,6 +1585,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 			}
 		}
 	}
+	finishPhase(PerformanceMetric::CombatAreaProcessTiles, &AreaCombatMetricsSample::processTilesNanoseconds);
 
 	CombatDamage leechCombat;
 	leechCombat.origin = ORIGIN_NONE;
@@ -1563,8 +1651,13 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 		bool success = false;
 		if (damageCopy.primary.type != COMBAT_MANADRAIN) {
-			if (g_game.combatBlockHit(damageCopy, caster, creature.get(), params.blockedByShield, params.blockedByArmor,
-			                          params.itemId != 0, params.ignoreResistances)) {
+			const bool fullyBlocked = g_game.combatBlockHit(
+			    damageCopy, caster, creature.get(), params.blockedByShield, params.blockedByArmor,
+			    params.itemId != 0, params.ignoreResistances);
+			if (metrics && damageCopy.blockType != BLOCK_NONE) {
+				++metrics->blockedTargets;
+			}
+			if (fullyBlocked) {
 				continue;
 			}
 			if (params.resetDamageMultiplier >= 0.0f) {
@@ -1584,6 +1677,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		}
 
 		if (success) {
+			if (metrics) {
+				++metrics->appliedTargets;
+			}
 			if (casterPlayer && wpEnabled && damageCopy.primary.type != COMBAT_HEALING && damageCopy.primary.type != COMBAT_MANADRAIN) {
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::LIFE, WeaponProficiencyGain_t::HIT);
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::MANA, WeaponProficiencyGain_t::HIT);
@@ -1598,6 +1694,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 				for (const auto& condition : params.conditionList) {
 					if (caster == creature.get() || !creature->isImmune(condition->getType())) {
 						auto conditionCopy = condition->clone();
+						if (metrics) {
+							++metrics->conditionClones;
+						}
 						if (caster) {
 							conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
 							conditionCopy->setPositionParam(CONDITION_PARAM_CASTER_POSITION, caster->getPosition());
@@ -1670,8 +1769,22 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		}
 
 		if (params.targetCallback) {
+			if (metrics) {
+				++metrics->targetCallbacks;
+			}
 			params.targetCallback->onTargetCombat(caster, creature.get());
 		}
+	}
+	finishPhase(PerformanceMetric::CombatAreaApplyTargets, &AreaCombatMetricsSample::applyTargetsNanoseconds);
+
+	if (metrics) {
+		const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(MetricsClock::now() - areaStarted).count();
+		metrics->totalNanoseconds = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
+		const Monster* casterMonster = caster ? caster->getMonster() : nullptr;
+		const std::string_view monsterName = casterMonster ? std::string_view(casterMonster->getName()) : std::string_view{};
+		const std::string_view spellName = !damage.instantSpellName.empty() ? std::string_view(damage.instantSpellName)
+		                                                               : std::string_view(params.profileName);
+		g_performanceMetrics.recordAreaCombat(*metrics, monsterName, spellName);
 	}
 }
 

--- a/src/combat.h
+++ b/src/combat.h
@@ -10,11 +10,13 @@
 #include "thing.h"
 
 #include <memory>
+#include <string>
 
 class Condition;
 class Creature;
 class MatrixArea;
 class Item;
+struct AreaCombatMetricsSample;
 
 struct Position;
 
@@ -74,6 +76,7 @@ struct CombatParams
 	CombatParams& operator=(CombatParams&&) noexcept = default;
 
 	std::forward_list<std::unique_ptr<const Condition>> conditionList;
+	std::string profileName;
 
 	std::unique_ptr<ValueCallback> valueCallback;
 	std::unique_ptr<TileCallback> tileCallback;
@@ -96,6 +99,7 @@ struct CombatParams
 	bool aggressive = true;
 	bool useCharges = false;
 	bool ignoreResistances = false;
+	bool profileScripted = false;
 
 	uint8_t chainEffect = CONST_ME_NONE;
 
@@ -167,6 +171,11 @@ public:
 	void postCombatEffects(Creature* caster, const Position& pos) const { postCombatEffects(caster, pos, params); }
 
 	void setOrigin(CombatOrigin origin) { params.origin = origin; }
+	void setProfileContext(std::string_view name, bool scripted)
+	{
+		params.profileName = name;
+		params.profileScripted = scripted;
+	}
 
 	void setupChain(const class Weapon* weapon);
 	bool doCombatChain(Creature* caster, Creature* target, bool aggressive, std::string instantSpellName = {}) const;
@@ -181,7 +190,7 @@ private:
 	                               const CombatParams& params, bool aggressive);
 
 	static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile,
-	                              const CombatParams& params);
+	                              const CombatParams& params, AreaCombatMetricsSample* metrics = nullptr);
 	CombatDamage getCombatDamage(Creature* creature, Creature* target, std::string_view instantSpellName) const;
 
 	// configurable

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1429,6 +1429,7 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(uint32_t interval)
 {
+	PerformanceScope performanceScope(PerformanceMetric::CreatureExecuteConditions);
 	std::vector<Condition*> tempConditions;
 	tempConditions.reserve(conditions.size());
 	for (const auto& c : conditions) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -477,7 +477,10 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 			requestFollowPathUpdate();
 		}
 
-		if (newPos.z != oldPos.z || !canSee(fc->getPosition())) {
+		auto masterCreature = master.lock();
+		const bool followsLiveMaster = masterCreature && masterCreature == fc && !masterCreature->isRemoved() &&
+		                               !masterCreature->isDead();
+		if (!followsLiveMaster && (newPos.z != oldPos.z || !canSee(fc->getPosition()))) {
 			onCreatureDisappear(fc.get(), false);
 		}
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -60,6 +60,51 @@ Creature::~Creature()
 	eventsList.clear();
 }
 
+void Creature::setInstanceID(uint32_t id)
+{
+	const uint32_t oldInstanceId = getInstanceID();
+	if (oldInstanceId == id) {
+		return;
+	}
+
+	Tile* tile = getTile();
+	if (!tile || isRemoved()) {
+		Thing::setInstanceID(id);
+		return;
+	}
+
+	auto self = weak_from_this().lock();
+	if (!self) {
+		Thing::setInstanceID(id);
+		return;
+	}
+
+	SpectatorVec oldSpectators;
+	g_game.map.getSpectators(oldSpectators, getPosition(), true);
+	for (const auto& spectator : oldSpectators.monsters()) {
+		if (spectator.get() != this && spectator->compareInstance(oldInstanceId)) {
+			spectator->onRemoveCreature(this, false);
+		}
+	}
+
+	if (isRemoved()) {
+		return;
+	}
+
+	Thing::setInstanceID(id);
+	if (Monster* monster = getMonster()) {
+		monster->onCreatureMove(this, tile, getPosition(), tile, getPosition(), true);
+	}
+
+	SpectatorVec newSpectators;
+	g_game.map.getSpectators(newSpectators, getPosition(), true);
+	for (const auto& spectator : newSpectators.monsters()) {
+		if (spectator.get() != this && spectator->compareInstance(id)) {
+			spectator->onCreatureAppear(this, false);
+		}
+	}
+}
+
 bool Creature::canSee(const Position& myPos, const Position& pos, int32_t viewRangeX, int32_t viewRangeY)
 {
 	if (myPos.z <= 7) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -83,6 +83,7 @@ void Creature::setInstanceID(uint32_t id)
 
 	SpectatorVec oldSpectators;
 	g_game.map.getSpectators(oldSpectators, getPosition(), true);
+	Thing::setInstanceID(id);
 	for (const auto& spectator : oldSpectators.monsters()) {
 		if (spectator.get() != this && spectator->compareInstance(oldInstanceId)) {
 			if (Monster* monster = spectator->getMonster()) {
@@ -95,7 +96,6 @@ void Creature::setInstanceID(uint32_t id)
 		return;
 	}
 
-	Thing::setInstanceID(id);
 	if (Monster* monster = getMonster()) {
 		monster->onCreatureInstanceChange(this, true);
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -83,7 +83,9 @@ void Creature::setInstanceID(uint32_t id)
 	g_game.map.getSpectators(oldSpectators, getPosition(), true);
 	for (const auto& spectator : oldSpectators.monsters()) {
 		if (spectator.get() != this && spectator->compareInstance(oldInstanceId)) {
-			spectator->onRemoveCreature(this, false);
+			if (Monster* monster = spectator->getMonster()) {
+				monster->onCreatureInstanceChange(this, false);
+			}
 		}
 	}
 
@@ -93,14 +95,16 @@ void Creature::setInstanceID(uint32_t id)
 
 	Thing::setInstanceID(id);
 	if (Monster* monster = getMonster()) {
-		monster->onCreatureMove(this, tile, getPosition(), tile, getPosition(), true);
+		monster->onCreatureInstanceChange(this, true);
 	}
 
 	SpectatorVec newSpectators;
 	g_game.map.getSpectators(newSpectators, getPosition(), true);
 	for (const auto& spectator : newSpectators.monsters()) {
 		if (spectator.get() != this && spectator->compareInstance(id)) {
-			spectator->onCreatureAppear(this, false);
+			if (Monster* monster = spectator->getMonster()) {
+				monster->onCreatureInstanceChange(this, true);
+			}
 		}
 	}
 }
@@ -1292,11 +1296,10 @@ bool Creature::setMaster(Creature* newMaster)
 		newMasterSummons.emplace_back(self);
 	}
 
+	master = std::move(masterRef);
 	if (getInstanceID() != newMaster->getInstanceID()) {
 		setInstanceID(newMaster->getInstanceID());
 	}
-
-	master = std::move(masterRef);
 	return true;
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -128,6 +128,7 @@ public:
 
 	virtual CreatureType_t getType() const = 0;
 	void setInstanceID(uint32_t id);
+	bool isCreatureCheckEnabled() const { return creatureCheck; }
 
 	// Raw type checks: no shared_from_this(), no dynamic_cast.
 	// Use for type-only checks; use getPlayer()/getMonster()/getNpc() when the pointer is needed.

--- a/src/creature.h
+++ b/src/creature.h
@@ -127,6 +127,7 @@ public:
 	virtual std::string getDescription(int32_t lookDistance) const = 0;
 
 	virtual CreatureType_t getType() const = 0;
+	void setInstanceID(uint32_t id);
 
 	// Raw type checks: no shared_from_this(), no dynamic_cast.
 	// Use for type-only checks; use getPlayer()/getMonster()/getNpc() when the pointer is needed.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5928,7 +5928,11 @@ void Game::addCreatureCheck(Creature* creature)
 		return;
 	}
 
+	const bool wasEnabled = creature->creatureCheck;
 	creature->creatureCheck = true;
+	if (!wasEnabled && creature->getMonster()) {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::CreatureCheckAdds);
+	}
 
 	if (creature->inCheckCreaturesVector) {
 		// already in a vector
@@ -5958,6 +5962,9 @@ void Game::removeCreatureCheck(Creature* creature)
 	}
 
 	if (creature->inCheckCreaturesVector) {
+		if (creature->creatureCheck && creature->getMonster()) {
+			g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::CreatureCheckRemoves);
+		}
 		creature->creatureCheck = false;
 	}
 }

--- a/src/luanpc.cpp
+++ b/src/luanpc.cpp
@@ -74,11 +74,11 @@ int luaNpcGetSpectators(lua_State* L)
 		return 1;
 	}
 
-	const auto& spectators = npc->getSpectators();
+	const auto spectators = npc->getSpectators();
 	lua_createtable(L, spectators.size(), 0);
 
 	int index = 0;
-	for (const auto& spectatorPlayer : npc->getSpectators()) {
+	for (const auto& spectatorPlayer : spectators) {
 		pushUserdata<const Player>(L, spectatorPlayer.get());
 		setCreatureMetatable(L, -1, spectatorPlayer.get());
 		lua_rawseti(L, -2, ++index);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -480,47 +480,6 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 	minRangeY = (minRangeY == 0 ? -maxViewportY : -minRangeY);
 	maxRangeY = (maxRangeY == 0 ? maxViewportY : maxRangeY);
 
-	bool cacheResult = (minRangeX == -maxViewportX && maxRangeX == maxViewportX &&
-	                    minRangeY == -maxViewportY && maxRangeY == maxViewportY);
-
-	SpectatorVec* cacheOpt = nullptr;
-	bool* hasCacheOpt = nullptr;
-
-	if (cacheResult) {
-		auto iter = spectatorsCache.find(centerPos);
-		if (iter != spectatorsCache.end()) {
-			auto& entry = iter->second;
-			SpectatorsCache::FloorData* cacheFloorData;
-			if (onlyPlayers) {
-				cacheFloorData = &entry.players;
-			} else if (onlyMonsters) {
-				cacheFloorData = &entry.monsters;
-			} else if (onlyNpcs) {
-				cacheFloorData = &entry.npcs;
-			} else {
-				cacheFloorData = &entry.creatures;
-			}
-
-			if (multifloor) {
-				cacheOpt = &cacheFloorData->multiFloor;
-				hasCacheOpt = &cacheFloorData->hasMultiFloor;
-			} else {
-				cacheOpt = &cacheFloorData->floor;
-				hasCacheOpt = &cacheFloorData->hasFloor;
-			}
-
-			if (*hasCacheOpt) {
-				if (!spectators.empty()) {
-					spectators.addSpectators(*cacheOpt);
-					spectators.partitionByType();
-				} else {
-					spectators = *cacheOpt;
-				}
-				return;
-			}
-		}
-	}
-
 	int32_t minRangeZ;
 	int32_t maxRangeZ;
 
@@ -543,37 +502,7 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 	                      onlyPlayers, onlyMonsters, onlyNpcs);
 
 	spectators.partitionByType();
-
-	if (cacheResult) {
-		auto [iter, inserted] = spectatorsCache.try_emplace(centerPos);
-		auto& entry = iter->second;
-		entry.minRangeX = minRangeX;
-		entry.maxRangeX = maxRangeX;
-		entry.minRangeY = minRangeY;
-		entry.maxRangeY = maxRangeY;
-
-		SpectatorsCache::FloorData* cacheFloorData;
-		if (onlyPlayers) {
-			cacheFloorData = &entry.players;
-		} else if (onlyMonsters) {
-			cacheFloorData = &entry.monsters;
-		} else if (onlyNpcs) {
-			cacheFloorData = &entry.npcs;
-		} else {
-			cacheFloorData = &entry.creatures;
-		}
-
-		if (multifloor) {
-			cacheFloorData->hasMultiFloor = true;
-			cacheFloorData->multiFloor = spectators;
-		} else {
-			cacheFloorData->hasFloor = true;
-			cacheFloorData->floor = spectators;
-		}
-	}
 }
-
-void Map::clearSpectatorCache() { spectatorsCache.clear(); }
 
 bool Map::canThrowObjectTo(const Position& fromPos, const Position& toPos, bool checkLineOfSight /*= true*/,
                            bool sameFloor /*= false*/, int32_t rangex /*= Map::maxClientViewportX*/,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -730,6 +730,47 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 	Position end_position;
 	auto position = creature.getPosition();
 	auto nodes = AStarNodes(position.x, position.y);
+	const QTreeLeafNode* pathLeaf = nullptr;
+	Floor* pathFloor = nullptr;
+	uint16_t pathLeafBaseX = 0;
+	uint16_t pathLeafBaseY = 0;
+	uint8_t pathFloorZ = MAP_MAX_LAYERS;
+	const auto getPathTile = [&](const Position& tilePosition) -> Tile* {
+		if (tilePosition.z >= MAP_MAX_LAYERS) {
+			return nullptr;
+		}
+
+		const uint16_t leafBaseX = tilePosition.x & ~FLOOR_MASK;
+		const uint16_t leafBaseY = tilePosition.y & ~FLOOR_MASK;
+		if (!pathLeaf || leafBaseX != pathLeafBaseX || leafBaseY != pathLeafBaseY) {
+			pathLeaf = QTreeNode::getLeafStatic<const QTreeLeafNode*, const QTreeNode*>(&root, tilePosition.x,
+			                                                                         tilePosition.y);
+			pathLeafBaseX = leafBaseX;
+			pathLeafBaseY = leafBaseY;
+			pathFloorZ = MAP_MAX_LAYERS;
+		}
+
+		if (pathFloorZ != tilePosition.z) {
+			pathFloor = pathLeaf ? const_cast<Floor*>(pathLeaf->getFloor(tilePosition.z)) : nullptr;
+			pathFloorZ = tilePosition.z;
+		}
+
+		return pathFloor ? pathFloor->getTile(tilePosition.x, tilePosition.y, tilePosition.z) : nullptr;
+	};
+	const auto canWalkToForPath = [&](const Position& tilePosition) -> Tile* {
+		Tile* tile = getPathTile(tilePosition);
+		if (creature.getTile() != tile) {
+			if (!tile) {
+				return nullptr;
+			}
+
+			const uint32_t flags = FLAG_PATHFINDING | FLAG_IGNOREFIELDDAMAGE;
+			if (tile->queryAdd(0, creature, 1, flags) != RETURNVALUE_NOERROR) {
+				return nullptr;
+			}
+		}
+		return tile;
+	};
 	const auto &target_position = pathCondition.targetPos;
 	const auto manhattan_heuristic = [&](const int_fast32_t nx, const int_fast32_t ny) -> int_fast32_t
 	{
@@ -822,8 +863,7 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 			const uint16_t neighborNodeIdx = nodes.GetNodeByPosition(position.x, position.y);
 			const bool hasNeighborNode = neighborNodeIdx != ASTAR_NODE_NONE;
 			++searchMetrics.tilesRead;
-			const Tile *tile = hasNeighborNode ? getTile(position.x, position.y, position.z)
-				: canWalkTo(creature, position);
+			const Tile* tile = hasNeighborNode ? getPathTile(position) : canWalkToForPath(position);
 
 			if (!tile) {
 				continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -735,7 +735,7 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 	uint16_t pathLeafBaseX = 0;
 	uint16_t pathLeafBaseY = 0;
 	uint8_t pathFloorZ = MAP_MAX_LAYERS;
-	const auto getPathTile = [&](const Position& tilePosition) -> Tile* {
+	const auto getPathTile = [&](const Position& tilePosition) -> const Tile* {
 		if (tilePosition.z >= MAP_MAX_LAYERS) {
 			return nullptr;
 		}
@@ -751,14 +751,14 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 		}
 
 		if (pathFloorZ != tilePosition.z) {
-			pathFloor = pathLeaf ? const_cast<Floor*>(pathLeaf->getFloor(tilePosition.z)) : nullptr;
+			pathFloor = pathLeaf ? pathLeaf->getFloor(tilePosition.z) : nullptr;
 			pathFloorZ = tilePosition.z;
 		}
 
 		return pathFloor ? pathFloor->getTile(tilePosition.x, tilePosition.y, tilePosition.z) : nullptr;
 	};
-	const auto canWalkToForPath = [&](const Position& tilePosition) -> Tile* {
-		Tile* tile = getPathTile(tilePosition);
+	const auto canWalkToForPath = [&](const Position& tilePosition) -> const Tile* {
+		const Tile* tile = getPathTile(tilePosition);
 		if (creature.getTile() != tile) {
 			if (!tile) {
 				return nullptr;

--- a/src/map.h
+++ b/src/map.h
@@ -14,25 +14,6 @@
 
 class Creature;
 
-struct SpectatorsCache {
-	struct FloorData {
-		bool hasFloor{false};
-		bool hasMultiFloor{false};
-		SpectatorVec floor;
-		SpectatorVec multiFloor;
-	};
-
-	int32_t minRangeX{0};
-	int32_t maxRangeX{0};
-	int32_t minRangeY{0};
-	int32_t maxRangeY{0};
-
-	FloorData creatures;
-	FloorData monsters;
-	FloorData npcs;
-	FloorData players;
-};
-
 struct PositionHasher {
 	std::size_t operator()(const Position& pos) const {
 		std::size_t h = 0;
@@ -89,8 +70,6 @@ private:
 	uint16_t current_node;
 	int_fast32_t closed_nodes;
 };
-
-using SpectatorCache = absl::flat_hash_map<Position, SpectatorsCache, PositionHasher>;
 
 inline constexpr int32_t FLOOR_BITS = 3;
 inline constexpr int32_t FLOOR_SIZE = (1 << FLOOR_BITS);
@@ -272,8 +251,6 @@ public:
 	                   bool onlyPlayers = false, int32_t minRangeX = 0, int32_t maxRangeX = 0, int32_t minRangeY = 0,
 	                   int32_t maxRangeY = 0, bool onlyMonsters = false, bool onlyNpcs = false);
 
-	void clearSpectatorCache();
-
 	/**
 	 * Checks if you can throw an object to that position
 	 * \param fromPos from Source point
@@ -330,8 +307,6 @@ public:
 	uint32_t getHeight() const { return height; }
 
 private:
-	SpectatorCache spectatorsCache;
-
 	QTreeNode root;
 
 	// Single-entry cache of the last leaf touched by setTile/setBasicTile.

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -598,14 +598,14 @@ void Monster::updateTargetList()
 	});
 
 	SpectatorVec spectators;
-	// OPTIMIZATION: Use multifloor=true (like upstream) to reduce spectator count
-	g_game.map.getSpectators(spectators, position, true);
+	g_game.map.getSpectators(spectators, position);
 	spectators.erase(this);
 	for (const auto& spectator : spectators) {
-		onCreatureFound(spectator.get());
+		onCreatureFound(spectator.get(), false, false);
 	}
 
 	clearFactionTargetIfNotAllowed();
+	updateIdleStatus();
 }
 
 void Monster::clearTargetList()
@@ -618,7 +618,7 @@ void Monster::clearFriendList()
 	friendList.clear();
 }
 
-void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/)
+void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/, bool refreshIdle /* = true*/)
 {
 	if (!creature) {
 		return;
@@ -640,7 +640,9 @@ void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/)
 		addTarget(creature, pushFront);
 	}
 
-	updateIdleStatus();
+	if (refreshIdle) {
+		updateIdleStatus();
+	}
 }
 
 void Monster::onCreatureEnter(Creature* creature)

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -393,8 +393,8 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 
 		if (needsFullTargetRefresh) {
 			updateTargetList();
-		} else if (pruneInvalidTargetState()) {
-			updateIdleStatus();
+		} else {
+			updateTargetListAfterMovement(oldPos, newPos);
 		}
 	} else {
 		bool canSeeNewPos = canSee(newPos);
@@ -697,6 +697,55 @@ void Monster::updateTargetList()
 	updateIdleStatus();
 	if (isIdle) {
 		clearFriendList();
+	}
+}
+
+void Monster::updateTargetListAfterMovement(const Position& oldPosition, const Position& newPosition)
+{
+	bool changed = pruneInvalidTargetState();
+	const size_t targetCount = targetList.size();
+	const size_t friendCount = friendList.size();
+	SpectatorVec spectators;
+
+	constexpr int32_t viewRangeX = Map::maxClientViewportX + 1;
+	constexpr int32_t viewRangeY = Map::maxClientViewportY + 1;
+	const auto shiftedPosition = [&newPosition](int32_t offsetX, int32_t offsetY) {
+		const int32_t x = std::clamp<int32_t>(static_cast<int32_t>(newPosition.x) + offsetX, 0,
+		                                      std::numeric_limits<uint16_t>::max());
+		const int32_t y = std::clamp<int32_t>(static_cast<int32_t>(newPosition.y) + offsetY, 0,
+		                                      std::numeric_limits<uint16_t>::max());
+		return Position{static_cast<uint16_t>(x), static_cast<uint16_t>(y), newPosition.z};
+	};
+	const auto addEdgeSpectators = [&spectators](const Position& center, int32_t rangeX, int32_t rangeY) {
+		SpectatorVec edgeSpectators;
+		g_game.map.getSpectators(edgeSpectators, center, false, false, rangeX, rangeX, rangeY, rangeY);
+		spectators.addSpectators(edgeSpectators);
+	};
+
+	if (newPosition.x > oldPosition.x) {
+		addEdgeSpectators(shiftedPosition(viewRangeX, 0), 1, viewRangeY);
+	} else if (newPosition.x < oldPosition.x) {
+		addEdgeSpectators(shiftedPosition(-viewRangeX, 0), 1, viewRangeY);
+	}
+
+	if (newPosition.y > oldPosition.y) {
+		addEdgeSpectators(shiftedPosition(0, viewRangeY), viewRangeX, 1);
+	} else if (newPosition.y < oldPosition.y) {
+		addEdgeSpectators(shiftedPosition(0, -viewRangeY), viewRangeX, 1);
+	}
+
+	spectators.erase(this);
+	for (const auto& spectator : spectators) {
+		onCreatureFound(spectator.get(), false, false);
+	}
+
+	changed = changed || targetList.size() != targetCount || friendList.size() != friendCount;
+	changed = clearFactionTargetIfNotAllowed() || changed;
+	if (changed) {
+		updateIdleStatus();
+		if (isIdle) {
+			clearFriendList();
+		}
 	}
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -445,6 +445,21 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 	}
 }
 
+void Monster::onCreatureInstanceChange(Creature* creature, bool visible)
+{
+	if (!creature) {
+		return;
+	}
+
+	if (creature == this) {
+		updateTargetList();
+	} else if (visible) {
+		onCreatureEnter(creature);
+	} else {
+		onCreatureLeave(creature);
+	}
+}
+
 void Monster::onCreatureSay(Creature* creature, SpeakClasses type, std::string_view text)
 {
 	Creature::onCreatureSay(creature, type, text);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -614,6 +614,11 @@ bool Monster::isValidKnownTarget(const std::shared_ptr<Creature>& creature) cons
 
 bool Monster::pruneInvalidTargetState()
 {
+	const bool metricsEnabled = g_performanceMetrics.isEnabled();
+	if (metricsEnabled) {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::PruneCalls);
+	}
+
 	const size_t oldFriendCount = friendList.size();
 	std::erase_if(friendList,
 	              [this](const auto& weakRef) { return !isValidKnownFriend(weakRef.lock()); });
@@ -621,6 +626,12 @@ bool Monster::pruneInvalidTargetState()
 	std::erase_if(targetList,
 	              [this](const auto& weakRef) { return !isValidKnownTarget(weakRef.lock()); });
 	bool changed = friendList.size() != oldFriendCount || targetList.size() != oldTargetCount;
+	if (metricsEnabled) {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::FriendsPruned,
+		                                       oldFriendCount - friendList.size());
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::TargetsPruned,
+		                                       oldTargetCount - targetList.size());
+	}
 
 	const auto isKnownTarget = [this](const Creature* creature) {
 		return std::any_of(targetList.begin(), targetList.end(), [creature](const auto& weakRef) {
@@ -632,6 +643,9 @@ bool Monster::pruneInvalidTargetState()
 		if (!isKnownTarget(attacked.get()) || !isValidKnownTarget(attacked)) {
 			setAttackedCreature(nullptr);
 			changed = true;
+			if (metricsEnabled) {
+				g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::AttackedCleared);
+			}
 		}
 	} else {
 		attackedCreature.reset();
@@ -643,6 +657,9 @@ bool Monster::pruneInvalidTargetState()
 		if (!followsLiveMaster && (!isKnownTarget(follow.get()) || !isValidKnownTarget(follow))) {
 			setFollowCreature(nullptr);
 			changed = true;
+			if (metricsEnabled) {
+				g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::FollowCleared);
+			}
 		}
 	} else {
 		followCreature.reset();
@@ -1401,14 +1418,21 @@ void Monster::setIdle(bool idle)
 	}
 
 	if (isIdle == idle) {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::SameStateCalls);
 		return;
 	}
 
 	isIdle = idle;
 
 	if (!isIdle) {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::TransitionToActive);
 		g_game.addCreatureCheck(this);
 	} else {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::TransitionToIdle);
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::OnIdleStatusCalls);
+		if (!damageMap.empty()) {
+			g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::DamageMapClears);
+		}
 		onIdleStatus();
 		clearTargetList();
 		clearFriendList();
@@ -1435,7 +1459,42 @@ bool Monster::shouldBeIdle() const
 
 void Monster::updateIdleStatus()
 {
-	setIdle(shouldBeIdle());
+	const bool idle = shouldBeIdle();
+	if (g_performanceMetrics.isEnabled()) {
+		g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::RefreshCalls);
+		g_performanceMetrics.recordMonsterIdle(idle ? MonsterIdleMetric::DecisionTrue
+		                                                : MonsterIdleMetric::DecisionFalse);
+
+		if (!idle) {
+			if (isSummon()) {
+				g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::BlockedBySummon);
+				g_performanceMetrics.recordMonsterActiveReason(MonsterActiveReason::Summon);
+			} else if (!targetList.empty()) {
+				const bool factionTarget = std::ranges::any_of(targetList, [this](const auto& weakRef) {
+					auto target = weakRef.lock();
+					return target && isFactionCombatTarget(target.get());
+				});
+				g_performanceMetrics.recordMonsterIdle(factionTarget ? MonsterIdleMetric::BlockedByFaction
+				                                                        : MonsterIdleMetric::BlockedByTarget);
+				g_performanceMetrics.recordMonsterActiveReason(factionTarget ? MonsterActiveReason::FactionTarget
+				                                                               : MonsterActiveReason::TargetList);
+			} else {
+				g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::BlockedByCondition);
+				g_performanceMetrics.recordMonsterActiveReason(MonsterActiveReason::AggressiveCondition);
+			}
+		} else if (!isIdle) {
+			if (!attackedCreature.expired()) {
+				g_performanceMetrics.recordMonsterActiveReason(MonsterActiveReason::AttackedCreature);
+			} else if (!followCreature.expired()) {
+				g_performanceMetrics.recordMonsterActiveReason(MonsterActiveReason::FollowCreature);
+			} else {
+				g_performanceMetrics.recordMonsterIdle(MonsterIdleMetric::ActiveWithoutReason);
+				g_performanceMetrics.recordMonsterActiveReason(MonsterActiveReason::Unknown);
+			}
+		}
+	}
+
+	setIdle(idle);
 }
 
 void Monster::onAddCondition(ConditionType_t)

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -307,7 +307,6 @@ void Monster::onCreatureAppear(Creature* creature, bool isLogin)
 		}
 
 		updateTargetList();
-		updateIdleStatus();
 	} else {
 		onCreatureEnter(creature);
 	}
@@ -383,19 +382,20 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 	}
 
 	if (creature == this) {
+		const bool needsFullTargetRefresh = isSummon() || teleport || oldPos.z != newPos.z || followCreature.expired();
 		if (isSummon()) {
 			auto master = getMaster();
 			if (master) {
 				const bool sameInstance = getInstanceID() == master->getInstanceID();
 				isMasterInRange = sameInstance && canSee(master->getPosition());
 			}
-			updateTargetList();
-		} else {
-			if (followCreature.expired()) {
-				updateTargetList();
-			}
 		}
-		updateIdleStatus();
+
+		if (needsFullTargetRefresh) {
+			updateTargetList();
+		} else if (pruneInvalidTargetState()) {
+			updateIdleStatus();
+		}
 	} else {
 		bool canSeeNewPos = canSee(newPos);
 		bool canSeeOldPos = canSee(oldPos);
@@ -418,10 +418,6 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 		auto master = getMaster();
 		if (canSeeNewPos && master && master.get() == creature && getInstanceID() == master->getInstanceID()) {
 			isMasterInRange = true; // Follow master again.
-		}
-
-		if (isIdle) {
-			updateIdleStatus();
 		}
 
 		if (!isSummon()) {
@@ -480,13 +476,15 @@ void Monster::onCreatureSay(Creature* creature, SpeakClasses type, std::string_v
 	}
 }
 
-void Monster::addFriend(Creature* creature)
+bool Monster::addFriend(Creature* creature)
 {
 	assert(creature != this);
 	auto weakRef = g_game.getCreatureWeakRef(creature);
-	if (!weakRef.expired()) {
-		friendList.insert(std::move(weakRef));
+	if (weakRef.expired()) {
+		return false;
 	}
+
+	return friendList.insert(std::move(weakRef)).second;
 }
 
 bool Monster::setType(const std::shared_ptr<MonsterType>& newType, bool restoreHealth)
@@ -543,27 +541,33 @@ bool Monster::setType(const std::shared_ptr<MonsterType>& newType, bool restoreH
 	return true;
 }
 
-void Monster::removeFriend(Creature* creature)
+bool Monster::removeFriend(Creature* creature)
 {
+	const size_t oldSize = friendList.size();
 	std::erase_if(friendList, [creature](const auto& weakRef) {
 		auto friendCreature = weakRef.lock();
 		return !friendCreature || friendCreature.get() == creature;
 	});
+	return friendList.size() != oldSize;
 }
 
-void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
+bool Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
 {
 	assert(creature != this);
 	if (!creature || !canSeeCreature(creature)) {
-		return;
+		return false;
 	}
 
 	auto weakRef = g_game.getCreatureWeakRef(creature);
-	if (weakRef.expired()) return;
+	if (weakRef.expired()) {
+		return false;
+	}
 
 	// Check if already present
 	for (const auto& w : targetList) {
-		if (w.lock().get() == creature) return;
+		if (w.lock().get() == creature) {
+			return false;
+		}
 	}
 
 	if (pushFront) {
@@ -571,14 +575,17 @@ void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
 	} else {
 		targetList.push_back(std::move(weakRef));
 	}
+	return true;
 }
 
-void Monster::removeTarget(Creature* creature)
+bool Monster::removeTarget(Creature* creature)
 {
+	const size_t oldSize = targetList.size();
 	std::erase_if(targetList, [creature](const auto& weakRef) {
 		auto target = weakRef.lock();
 		return !target || target.get() == creature;
 	});
+	return targetList.size() != oldSize;
 }
 
 bool Monster::isValidKnownFriend(const std::shared_ptr<Creature>& creature) const
@@ -605,12 +612,15 @@ bool Monster::isValidKnownTarget(const std::shared_ptr<Creature>& creature) cons
 	return isOpponent(creature.get());
 }
 
-void Monster::pruneInvalidTargetState()
+bool Monster::pruneInvalidTargetState()
 {
+	const size_t oldFriendCount = friendList.size();
 	std::erase_if(friendList,
 	              [this](const auto& weakRef) { return !isValidKnownFriend(weakRef.lock()); });
+	const size_t oldTargetCount = targetList.size();
 	std::erase_if(targetList,
 	              [this](const auto& weakRef) { return !isValidKnownTarget(weakRef.lock()); });
+	bool changed = friendList.size() != oldFriendCount || targetList.size() != oldTargetCount;
 
 	const auto isKnownTarget = [this](const Creature* creature) {
 		return std::any_of(targetList.begin(), targetList.end(), [creature](const auto& weakRef) {
@@ -621,6 +631,7 @@ void Monster::pruneInvalidTargetState()
 	if (auto attacked = attackedCreature.lock()) {
 		if (!isKnownTarget(attacked.get()) || !isValidKnownTarget(attacked)) {
 			setAttackedCreature(nullptr);
+			changed = true;
 		}
 	} else {
 		attackedCreature.reset();
@@ -631,18 +642,17 @@ void Monster::pruneInvalidTargetState()
 		const bool followsLiveMaster = isSummon() && master && follow == master && !master->isRemoved() && !master->isDead();
 		if (!followsLiveMaster && (!isKnownTarget(follow.get()) || !isValidKnownTarget(follow))) {
 			setFollowCreature(nullptr);
+			changed = true;
 		}
 	} else {
 		followCreature.reset();
 	}
+	return changed;
 }
 
 void Monster::updateTargetList()
 {
-	std::erase_if(friendList,
-	              [this](const auto& weakRef) { return !isValidKnownFriend(weakRef.lock()); });
-	std::erase_if(targetList,
-	              [this](const auto& weakRef) { return !isValidKnownTarget(weakRef.lock()); });
+	pruneInvalidTargetState();
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position);
@@ -653,6 +663,9 @@ void Monster::updateTargetList()
 
 	clearFactionTargetIfNotAllowed();
 	updateIdleStatus();
+	if (isIdle) {
+		clearFriendList();
+	}
 }
 
 void Monster::clearTargetList()
@@ -679,16 +692,20 @@ void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/, b
 		return;
 	}
 
+	bool changed = false;
 	if (isFriend(creature)) {
-		addFriend(creature);
+		changed = addFriend(creature);
 	}
 
 	if (isOpponent(creature)) {
-		addTarget(creature, pushFront);
+		changed = addTarget(creature, pushFront) || changed;
 	}
 
-	if (refreshIdle) {
+	if (refreshIdle && changed) {
 		updateIdleStatus();
+		if (isIdle) {
+			clearFriendList();
+		}
 	}
 }
 
@@ -702,12 +719,13 @@ void Monster::onCreatureEnter(Creature* creature)
 		isMasterInRange = true;
 	}
 
-	onCreatureFound(creature, true);
-
 	if (creature->isPlayer()) {
+		onCreatureFound(creature, true, false);
 		// A player entered, we might need to notice other monsters now
 		lastPlayerNearbyCheck = 0;
 		updateTargetList();
+	} else {
+		onCreatureFound(creature, true);
 	}
 }
 
@@ -807,9 +825,6 @@ bool Monster::clearFactionTargetIfNotAllowed()
 	});
 	changed = changed || targetList.size() != oldSize;
 
-	if (changed) {
-		updateIdleStatus();
-	}
 	return changed;
 }
 
@@ -924,25 +939,18 @@ void Monster::onCreatureLeave(Creature* creature)
 	const bool wasKnownTarget = std::any_of(targetList.begin(), targetList.end(), [creature](const auto& weakRef) {
 		return weakRef.lock().get() == creature;
 	});
-	removeFriend(creature);
-	removeTarget(creature);
+	bool changed = removeFriend(creature);
+	changed = removeTarget(creature) || changed;
 
 	if (auto attacked = attackedCreature.lock(); attacked.get() == creature) {
 		setAttackedCreature(nullptr);
+		changed = true;
 	}
 
 	if (!leavingMaster) {
 		if (auto follow = followCreature.lock(); follow.get() == creature) {
 			setFollowCreature(nullptr);
-		}
-	}
-
-	updateIdleStatus();
-
-	if (wasKnownTarget && !isSummon() && targetList.empty()) {
-		const int64_t walkToSpawnRadius = getInteger(ConfigManager::DEFAULT_WALKTOSPAWNRADIUS);
-		if (walkToSpawnRadius > 0 && !position.isInRange(masterPos, walkToSpawnRadius, walkToSpawnRadius)) {
-			walkToSpawn();
+			changed = true;
 		}
 	}
 
@@ -950,6 +958,19 @@ void Monster::onCreatureLeave(Creature* creature)
 		// A player left, we might need to stop fighting other monsters
 		lastPlayerNearbyCheck = 0;
 		updateTargetList();
+	} else {
+		changed = pruneInvalidTargetState() || changed;
+		changed = clearFactionTargetIfNotAllowed() || changed;
+		if (changed) {
+			updateIdleStatus();
+		}
+	}
+
+	if (wasKnownTarget && !isSummon() && targetList.empty()) {
+		const int64_t walkToSpawnRadius = getInteger(ConfigManager::DEFAULT_WALKTOSPAWNRADIUS);
+		if (walkToSpawnRadius > 0 && !position.isInRange(masterPos, walkToSpawnRadius, walkToSpawnRadius)) {
+			walkToSpawn();
+		}
 	}
 }
 
@@ -1346,8 +1367,9 @@ bool Monster::selectTarget(Creature* creature)
 	}
 
 	if (isFactionCombatTarget(creature) && !isFactionCombatAllowed()) {
-		removeTarget(creature);
-		updateIdleStatus();
+		if (removeTarget(creature)) {
+			updateIdleStatus();
+		}
 		return false;
 	}
 
@@ -1378,6 +1400,10 @@ void Monster::setIdle(bool idle)
 		return;
 	}
 
+	if (isIdle == idle) {
+		return;
+	}
+
 	isIdle = idle;
 
 	if (!isIdle) {
@@ -1390,17 +1416,26 @@ void Monster::setIdle(bool idle)
 	}
 }
 
-void Monster::updateIdleStatus()
+void Monster::onPlacedCreature()
 {
-	pruneInvalidTargetState();
+	if (isIdle) {
+		Game::removeCreatureCheck(this);
+	}
+}
 
-	bool idle = false;
-	if (!isSummon() && targetList.empty()) {
-		idle = std::find_if(conditions.begin(), conditions.end(),
-		                    [](const auto& condition) { return condition->isAggressive(); }) == conditions.end();
+bool Monster::shouldBeIdle() const
+{
+	if (isSummon() || !targetList.empty()) {
+		return false;
 	}
 
-	setIdle(idle);
+	return std::ranges::none_of(conditions,
+	                            [](const auto& condition) { return condition->isAggressive(); });
+}
+
+void Monster::updateIdleStatus()
+{
+	setIdle(shouldBeIdle());
 }
 
 void Monster::onAddCondition(ConditionType_t)
@@ -1453,8 +1488,10 @@ void Monster::onThink(uint32_t interval)
 			setIdle(true);
 		}
 	} else {
-		clearFactionTargetIfNotAllowed();
-		updateIdleStatus();
+		const bool factionChanged = clearFactionTargetIfNotAllowed();
+		if (factionChanged || (!isIdle && shouldBeIdle())) {
+			updateIdleStatus();
+		}
 
 		if (!isIdle) {
 			addEventWalk();
@@ -1583,7 +1620,9 @@ void Monster::doAttacking(uint32_t interval)
 	}
 
 	if (isFactionCombatTarget(ac.get()) && !isFactionCombatAllowed()) {
-		clearFactionTargetIfNotAllowed();
+		if (clearFactionTargetIfNotAllowed()) {
+			updateIdleStatus();
+		}
 		return;
 	}
 
@@ -1714,8 +1753,8 @@ void Monster::onThinkTarget(uint32_t interval)
 		if (auto target = getAttackedCreatureShared();
 		    target && target->getPlayer() && target->getPlayer()->getProtectionTime() > 0) {
 			setAttackedCreature(nullptr);
-			updateTargetList();
 			followCreature.reset();
+			updateTargetList();
 		}
 
 		if (mType->info.changeTargetSpeed != 0) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -545,11 +545,10 @@ bool Monster::setType(const std::shared_ptr<MonsterType>& newType, bool restoreH
 
 void Monster::removeFriend(Creature* creature)
 {
-	auto weakRef = g_game.getCreatureWeakRef(creature);
-	auto it = friendList.find(weakRef);
-	if (it != friendList.end()) {
-		friendList.erase(it);
-	}
+	std::erase_if(friendList, [creature](const auto& weakRef) {
+		auto friendCreature = weakRef.lock();
+		return !friendCreature || friendCreature.get() == creature;
+	});
 }
 
 void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
@@ -576,26 +575,74 @@ void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
 
 void Monster::removeTarget(Creature* creature)
 {
-	auto it = std::find_if(targetList.begin(), targetList.end(), [creature](const auto& weakRef) {
-		return weakRef.lock().get() == creature;
+	std::erase_if(targetList, [creature](const auto& weakRef) {
+		auto target = weakRef.lock();
+		return !target || target.get() == creature;
 	});
-	if (it != targetList.end()) {
-		targetList.erase(it);
+}
+
+bool Monster::isValidKnownFriend(const std::shared_ptr<Creature>& creature) const
+{
+	return creature && !creature->isRemoved() && !creature->isDead() && creature->getTile() &&
+	       canSee(creature->getPosition()) && canSeeCreature(creature.get()) && isFriend(creature.get());
+}
+
+bool Monster::isValidKnownTarget(const std::shared_ptr<Creature>& creature) const
+{
+	if (!creature || creature->isRemoved() || creature->isDead() || !creature->isAttackable() ||
+	    !creature->getTile() || !canSee(creature->getPosition()) || !canSeeCreature(creature.get()) ||
+	    (!isFamiliar() && creature->getZone() == ZONE_PROTECTION)) {
+		return false;
+	}
+
+	// Avoid the player-nearby spectator query used by faction combat. That
+	// policy is already enforced centrally by clearFactionTargetIfNotAllowed().
+	if (creature->getMonster() && !creature->isSummon()) {
+		return ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM) &&
+		       isFactionCombatTarget(creature.get());
+	}
+
+	return isOpponent(creature.get());
+}
+
+void Monster::pruneInvalidTargetState()
+{
+	std::erase_if(friendList,
+	              [this](const auto& weakRef) { return !isValidKnownFriend(weakRef.lock()); });
+	std::erase_if(targetList,
+	              [this](const auto& weakRef) { return !isValidKnownTarget(weakRef.lock()); });
+
+	const auto isKnownTarget = [this](const Creature* creature) {
+		return std::any_of(targetList.begin(), targetList.end(), [creature](const auto& weakRef) {
+			return weakRef.lock().get() == creature;
+		});
+	};
+
+	if (auto attacked = attackedCreature.lock()) {
+		if (!isKnownTarget(attacked.get()) || !isValidKnownTarget(attacked)) {
+			setAttackedCreature(nullptr);
+		}
+	} else {
+		attackedCreature.reset();
+	}
+
+	if (auto follow = followCreature.lock()) {
+		auto master = getMaster();
+		const bool followsLiveMaster = isSummon() && master && follow == master && !master->isRemoved() && !master->isDead();
+		if (!followsLiveMaster && (!isKnownTarget(follow.get()) || !isValidKnownTarget(follow))) {
+			setFollowCreature(nullptr);
+		}
+	} else {
+		followCreature.reset();
 	}
 }
 
 void Monster::updateTargetList()
 {
-	std::erase_if(friendList, [this](const auto& weakRef) {
-		auto creature = weakRef.lock();
-		return !creature || creature->isDead() || !canSee(creature->getPosition());
-	});
-
-	std::erase_if(targetList, [this](const auto& weakRef) {
-		auto creature = weakRef.lock();
-		return !creature || creature->isDead() || !canSee(creature->getPosition()) || !canSeeCreature(creature.get()) ||
-		       (!isFamiliar() && creature->getZone() == ZONE_PROTECTION) || !isOpponent(creature.get());
-	});
+	std::erase_if(friendList,
+	              [this](const auto& weakRef) { return !isValidKnownFriend(weakRef.lock()); });
+	std::erase_if(targetList,
+	              [this](const auto& weakRef) { return !isValidKnownTarget(weakRef.lock()); });
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position);
@@ -863,28 +910,39 @@ bool Monster::isFamiliar() const
 void Monster::onCreatureLeave(Creature* creature)
 {
 	// LOG_INFO(fmt::format("onCreatureLeave - {}", creature->getName()));
+	if (!creature) {
+		return;
+	}
 
 	auto master = getMaster();
-	if (master && master.get() == creature) {
+	const bool leavingMaster = master && master.get() == creature;
+	if (leavingMaster) {
 		// Take random steps and only use defense abilities (e.g. heal) until its master comes back
 		isMasterInRange = false;
 	}
 
-	// update friendList
-	if (isFriend(creature)) {
-		removeFriend(creature);
+	const bool wasKnownTarget = std::any_of(targetList.begin(), targetList.end(), [creature](const auto& weakRef) {
+		return weakRef.lock().get() == creature;
+	});
+	removeFriend(creature);
+	removeTarget(creature);
+
+	if (auto attacked = attackedCreature.lock(); attacked.get() == creature) {
+		setAttackedCreature(nullptr);
 	}
 
-	// update targetList
-	if (isOpponent(creature)) {
-		removeTarget(creature);
-		updateIdleStatus();
+	if (!leavingMaster) {
+		if (auto follow = followCreature.lock(); follow.get() == creature) {
+			setFollowCreature(nullptr);
+		}
+	}
 
-		if (!isSummon() && targetList.empty()) {
-			const int64_t walkToSpawnRadius = getInteger(ConfigManager::DEFAULT_WALKTOSPAWNRADIUS);
-			if (walkToSpawnRadius > 0 && !position.isInRange(masterPos, walkToSpawnRadius, walkToSpawnRadius)) {
-				walkToSpawn();
-			}
+	updateIdleStatus();
+
+	if (wasKnownTarget && !isSummon() && targetList.empty()) {
+		const int64_t walkToSpawnRadius = getInteger(ConfigManager::DEFAULT_WALKTOSPAWNRADIUS);
+		if (walkToSpawnRadius > 0 && !position.isInRange(masterPos, walkToSpawnRadius, walkToSpawnRadius)) {
+			walkToSpawn();
 		}
 	}
 
@@ -1334,6 +1392,8 @@ void Monster::setIdle(bool idle)
 
 void Monster::updateIdleStatus()
 {
+	pruneInvalidTargetState();
+
 	bool idle = false;
 	if (!isSummon() && targetList.empty()) {
 		idle = std::find_if(conditions.begin(), conditions.end(),

--- a/src/monster.h
+++ b/src/monster.h
@@ -228,6 +228,7 @@ private:
 	mutable bool cachedPlayerNearby = false;
 
 	void updateTargetList();
+	void updateTargetListAfterMovement(const Position& oldPosition, const Position& newPosition);
 	bool isValidKnownFriend(const std::shared_ptr<Creature>& creature) const;
 	bool isValidKnownTarget(const std::shared_ptr<Creature>& creature) const;
 	bool pruneInvalidTargetState();

--- a/src/monster.h
+++ b/src/monster.h
@@ -216,7 +216,7 @@ private:
 	void onCreatureEnter(Creature* creature);
 	void onCreatureLeave(Creature* creature);
 	bool selectBlockerTarget();
-	void onCreatureFound(Creature* creature, bool pushFront = false);
+	void onCreatureFound(Creature* creature, bool pushFront = false, bool refreshIdle = true);
 	bool isFactionCombatTarget(const Creature* creature) const;
 	bool isFactionCombatAllowed() const;
 	bool clearFactionTargetIfNotAllowed();

--- a/src/monster.h
+++ b/src/monster.h
@@ -110,6 +110,7 @@ public:
 	void onRemoveCreature(Creature* creature, bool isLogout) override;
 	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
 	                    const Position& oldPos, bool teleport) override;
+	void onCreatureInstanceChange(Creature* creature, bool visible);
 	void onCreatureSay(Creature* creature, SpeakClasses type, std::string_view text) override;
 	void onPlacedCreature() override;
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -226,6 +226,9 @@ private:
 	mutable bool cachedPlayerNearby = false;
 
 	void updateTargetList();
+	bool isValidKnownFriend(const std::shared_ptr<Creature>& creature) const;
+	bool isValidKnownTarget(const std::shared_ptr<Creature>& creature) const;
+	void pruneInvalidTargetState();
 	void clearTargetList();
 	void clearFriendList();
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -111,6 +111,7 @@ public:
 	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
 	                    const Position& oldPos, bool teleport) override;
 	void onCreatureSay(Creature* creature, SpeakClasses type, std::string_view text) override;
+	void onPlacedCreature() override;
 
 	void drainHealth(const std::shared_ptr<Creature>& attacker, int32_t damage) override;
 	void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
@@ -171,11 +172,11 @@ public:
 	bool isFamiliar() const;
 	bool hasPlayerNearby(int32_t range = 20) const;
 
-	void addFriend(Creature* creature);
+	bool addFriend(Creature* creature);
 	bool setType(const std::shared_ptr<MonsterType>& newType, bool restoreHealth = false);
-	void removeFriend(Creature* creature);
-	void addTarget(Creature* creature, bool pushFront = false);
-	void removeTarget(Creature* creature);
+	bool removeFriend(Creature* creature);
+	bool addTarget(Creature* creature, bool pushFront = false);
+	bool removeTarget(Creature* creature);
 
 	void callPlayerAttackEvent(Player* player);
 
@@ -228,7 +229,7 @@ private:
 	void updateTargetList();
 	bool isValidKnownFriend(const std::shared_ptr<Creature>& creature) const;
 	bool isValidKnownTarget(const std::shared_ptr<Creature>& creature) const;
-	void pruneInvalidTargetState();
+	bool pruneInvalidTargetState();
 	void clearTargetList();
 	void clearFriendList();
 
@@ -236,6 +237,7 @@ private:
 	std::shared_ptr<Item> getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) override;
 
 	void updateIdleStatus();
+	bool shouldBeIdle() const;
 
 	void onAddCondition(ConditionType_t type) override;
 	void onEndCondition(ConditionType_t type) override;

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -145,6 +145,7 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			return false;
 		}
 
+		combatSpell->getCombat()->setProfileContext(spell->scriptName, true);
 		combatSpell->getCombat()->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue, 0);
 		sb.ownedSpell = std::move(combatSpell);
 	} else {
@@ -347,6 +348,7 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			combat->setParam(COMBAT_PARAM_EFFECT, spell->effect);
 		}
 
+		combat->setProfileContext(spell->name, false);
 		combat->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue, 0);
 		sb.ownedSpell = std::make_unique<CombatSpell>(combat, spell->needTarget, spell->needDirection);
 	}

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -475,7 +475,6 @@ void Npc::reset(bool reload)
 
 	parameters.clear();
 	shopPlayerSet.clear();
-	spectators.clear();
 
 	if (reload) {
 		load();
@@ -490,11 +489,7 @@ void Npc::reload()
 
 	SpectatorVec players;
 	g_game.map.getSpectators(players, getPosition(), true, true);
-	for (const auto& player : players.players()) {
-		spectators.insert(std::static_pointer_cast<Player>(player));
-	}
-
-	const bool hasSpectators = !spectators.empty();
+	const bool hasSpectators = !players.empty();
 	setIdle(!hasSpectators);
 
 	if (hasSpectators && walkTicks > 0) {
@@ -786,13 +781,7 @@ void Npc::onPlayerCloseChannel(Player* player)
 
 void Npc::onThink(uint32_t interval)
 {
-	SpectatorVec players;
-	g_game.map.getSpectators(players, getPosition(), true, true, Npcs::ViewportX, Npcs::ViewportX,
-	                         Npcs::ViewportY, Npcs::ViewportY);
-	for (const auto& player : players.players()) {
-		spectators.insert(std::static_pointer_cast<Player>(player));
-	}
-
+	const auto spectators = getSpectators();
 	setIdle(spectators.empty());
 
 	if (isIdle) {
@@ -828,7 +817,23 @@ void Npc::onThink(uint32_t interval)
 		addEventWalk();
 	}
 
-	spectators.clear();
+}
+
+std::vector<std::shared_ptr<Player>> Npc::getSpectators() const
+{
+	SpectatorVec players;
+	g_game.map.getSpectators(players, getPosition(), true, true, Npcs::ViewportX, Npcs::ViewportX,
+	                         Npcs::ViewportY, Npcs::ViewportY);
+
+	std::vector<std::shared_ptr<Player>> result;
+	result.reserve(players.players().size());
+	for (const auto& player : players.players()) {
+		result.emplace_back(std::static_pointer_cast<Player>(player));
+	}
+
+	std::ranges::sort(result);
+	result.erase(std::unique(result.begin(), result.end()), result.end());
+	return result;
 }
 
 void Npc::doSay(std::string_view text) { g_game.internalCreatureSay(this, TALKTYPE_SAY, text, false); }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -831,8 +831,6 @@ std::vector<std::shared_ptr<Player>> Npc::getSpectators() const
 		result.emplace_back(std::static_pointer_cast<Player>(player));
 	}
 
-	std::ranges::sort(result);
-	result.erase(std::unique(result.begin(), result.end()), result.end());
 	return result;
 }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -224,7 +224,7 @@ public:
 	bool setFollowCreature(Creature* creature) override;
 	void clearFocusIfNeeded(Player* player);
 
-	const auto& getSpectators() { return spectators; }
+	std::vector<std::shared_ptr<Player>> getSpectators() const;
 
 	uint8_t getSpeechBubble() const { return speechBubble; }
 	void setSpeechBubble(const uint8_t bubble) { 
@@ -269,7 +269,6 @@ private:
 	void reset(bool reload = false);
 
 	std::set<std::shared_ptr<Player>> shopPlayerSet;
-	std::set<std::shared_ptr<Player>> spectators;
 
 	std::string name;
 	std::string filename;

--- a/src/performance_metrics.cpp
+++ b/src/performance_metrics.cpp
@@ -13,6 +13,7 @@ PerformanceMetrics g_performanceMetrics;
 
 namespace {
 constexpr auto REPORT_INTERVAL = std::chrono::seconds(5);
+constexpr auto AREA_COMBAT_SLOW_SAMPLE_THRESHOLD = std::chrono::milliseconds(1);
 
 constexpr std::array<std::string_view, static_cast<size_t>(PerformanceMetric::Count)> METRIC_NAMES = {
 	"TaskReactor::runOnce", "TaskReactor::drainInbox", "TaskReactor::drainReadyTasks",
@@ -22,7 +23,9 @@ constexpr std::array<std::string_view, static_cast<size_t>(PerformanceMetric::Co
 	"Game::internalMoveCreature", "Map::getPathMatching", "Map::moveCreature", "Map::getSpectators",
 	"Monster::onThink",
 	"Monster::onWalk", "Monster::doAttacking", "CombatSpell::castSpell",
-	"Combat::doCombat", "Combat::doAreaCombat",
+	"Combat::doCombat", "Combat::doAreaCombat", "Combat::area.buildTiles",
+	"Combat::area.prepareDamage", "Combat::area.collectSpectators", "Combat::area.processTiles+collectTargets",
+	"Combat::area.applyTargets", "Creature::executeConditions",
 };
 
 size_t histogramIndex(uint64_t nanoseconds) noexcept
@@ -147,6 +150,53 @@ void PerformanceMetrics::recordPathRequest(bool success, uint64_t nodesVisited, 
 	path.pathLength.fetch_add(pathLength, std::memory_order_relaxed);
 }
 
+void PerformanceMetrics::recordAreaCombat(const AreaCombatMetricsSample& sample, std::string_view monsterName,
+                                          std::string_view spellName) noexcept
+{
+	if (!isEnabled()) {
+		return;
+	}
+
+	areaCombat.casts.fetch_add(1, std::memory_order_relaxed);
+	areaCombat.areaRows.fetch_add(sample.areaRows, std::memory_order_relaxed);
+	areaCombat.areaColumns.fetch_add(sample.areaColumns, std::memory_order_relaxed);
+	areaCombat.activeCells.fetch_add(sample.activeCells, std::memory_order_relaxed);
+	areaCombat.sightChecks.fetch_add(sample.sightChecks, std::memory_order_relaxed);
+	areaCombat.sightRejected.fetch_add(sample.sightRejected, std::memory_order_relaxed);
+	areaCombat.tilesReturned.fetch_add(sample.tilesReturned, std::memory_order_relaxed);
+	areaCombat.tilesCreated.fetch_add(sample.tilesCreated, std::memory_order_relaxed);
+	areaCombat.combatRejected.fetch_add(sample.combatRejected, std::memory_order_relaxed);
+	areaCombat.spectators.fetch_add(sample.spectators, std::memory_order_relaxed);
+	areaCombat.targets.fetch_add(sample.targets, std::memory_order_relaxed);
+	areaCombat.blockedTargets.fetch_add(sample.blockedTargets, std::memory_order_relaxed);
+	areaCombat.appliedTargets.fetch_add(sample.appliedTargets, std::memory_order_relaxed);
+	areaCombat.conditionClones.fetch_add(sample.conditionClones, std::memory_order_relaxed);
+	areaCombat.tileCallbacks.fetch_add(sample.tileCallbacks, std::memory_order_relaxed);
+	areaCombat.targetCallbacks.fetch_add(sample.targetCallbacks, std::memory_order_relaxed);
+	areaCombat.impactEffects.fetch_add(sample.impactEffects, std::memory_order_relaxed);
+	areaCombat.fieldsCreated.fetch_add(sample.fieldsCreated, std::memory_order_relaxed);
+	areaCombat.effectRecipients.fetch_add(sample.effectRecipients, std::memory_order_relaxed);
+
+	if (sample.totalNanoseconds < static_cast<uint64_t>(
+	        std::chrono::duration_cast<std::chrono::nanoseconds>(AREA_COMBAT_SLOW_SAMPLE_THRESHOLD).count()) ||
+	    sample.totalNanoseconds <= slowestAreaCombat.maximumNanoseconds.load(std::memory_order_relaxed)) {
+		return;
+	}
+
+	try {
+		std::scoped_lock lock(slowestAreaCombat.mutex);
+		if (sample.totalNanoseconds <= slowestAreaCombat.maximumNanoseconds.load(std::memory_order_relaxed)) {
+			return;
+		}
+		slowestAreaCombat.sample = sample;
+		slowestAreaCombat.monsterName.assign(monsterName);
+		slowestAreaCombat.spellName.assign(spellName);
+		slowestAreaCombat.maximumNanoseconds.store(sample.totalNanoseconds, std::memory_order_relaxed);
+	} catch (...) {
+		// Profiling must never interfere with combat execution.
+	}
+}
+
 void PerformanceMetrics::maybeReport()
 {
 	if (!isEnabled()) {
@@ -162,7 +212,7 @@ void PerformanceMetrics::maybeReport()
 	}
 
 	std::string report;
-	report.reserve(4096);
+	report.reserve(8192);
 	for (size_t metricIndex = 0; metricIndex < metrics.size(); ++metricIndex) {
 		auto& data = metrics[metricIndex];
 		const uint64_t calls = data.calls.exchange(0, std::memory_order_relaxed);
@@ -192,6 +242,69 @@ void PerformanceMetrics::maybeReport()
 		reactor.deferred.exchange(0, std::memory_order_relaxed),
 		reactor.expired.exchange(0, std::memory_order_relaxed),
 		reactor.dropped.exchange(0, std::memory_order_relaxed));
+
+	const uint64_t areaCombatCasts = areaCombat.casts.exchange(0, std::memory_order_relaxed);
+	if (areaCombatCasts > 0) {
+		report += fmt::format(
+			"[Perf] area_combat casts={} rows={} cols={} active_cells={} sight_checks={} sight_rejected={} "
+			"tiles={} tiles_created={} combat_rejected={} spectators={} collect_targets={} blocked={} applied={} "
+			"condition_clones={} tile_callbacks={} target_callbacks={} effects={} fields={} recipients={}\n",
+			areaCombatCasts,
+			areaCombat.areaRows.exchange(0, std::memory_order_relaxed),
+			areaCombat.areaColumns.exchange(0, std::memory_order_relaxed),
+			areaCombat.activeCells.exchange(0, std::memory_order_relaxed),
+			areaCombat.sightChecks.exchange(0, std::memory_order_relaxed),
+			areaCombat.sightRejected.exchange(0, std::memory_order_relaxed),
+			areaCombat.tilesReturned.exchange(0, std::memory_order_relaxed),
+			areaCombat.tilesCreated.exchange(0, std::memory_order_relaxed),
+			areaCombat.combatRejected.exchange(0, std::memory_order_relaxed),
+			areaCombat.spectators.exchange(0, std::memory_order_relaxed),
+			areaCombat.targets.exchange(0, std::memory_order_relaxed),
+			areaCombat.blockedTargets.exchange(0, std::memory_order_relaxed),
+			areaCombat.appliedTargets.exchange(0, std::memory_order_relaxed),
+			areaCombat.conditionClones.exchange(0, std::memory_order_relaxed),
+			areaCombat.tileCallbacks.exchange(0, std::memory_order_relaxed),
+			areaCombat.targetCallbacks.exchange(0, std::memory_order_relaxed),
+			areaCombat.impactEffects.exchange(0, std::memory_order_relaxed),
+			areaCombat.fieldsCreated.exchange(0, std::memory_order_relaxed),
+			areaCombat.effectRecipients.exchange(0, std::memory_order_relaxed));
+	}
+
+	AreaCombatMetricsSample slowestAreaSample;
+	std::string slowestAreaMonster;
+	std::string slowestAreaSpell;
+	uint64_t slowestAreaNanoseconds = 0;
+	{
+		std::scoped_lock lock(slowestAreaCombat.mutex);
+		slowestAreaNanoseconds = slowestAreaCombat.maximumNanoseconds.exchange(0, std::memory_order_relaxed);
+		if (slowestAreaNanoseconds > 0) {
+			slowestAreaSample = slowestAreaCombat.sample;
+			slowestAreaMonster = std::move(slowestAreaCombat.monsterName);
+			slowestAreaSpell = std::move(slowestAreaCombat.spellName);
+			slowestAreaCombat.sample = {};
+		}
+	}
+	if (slowestAreaNanoseconds > 0) {
+		report += fmt::format(
+			"[Perf] area_combat slowest_us={:.3f} monster={} spell={} mode={} pos=({},{},{}) "
+			"geometry={}x{} active={} tiles={} created={} targets={} item={} effect={} "
+			"conditions={} tile_callback={} target_callback={} "
+			"phases_us={{build:{:.3f},prepare:{:.3f},spectators:{:.3f},process_tiles_collect_targets:{:.3f},apply_targets:{:.3f}}}\n",
+			slowestAreaNanoseconds / 1'000.0,
+			slowestAreaMonster.empty() ? "none" : slowestAreaMonster,
+			slowestAreaSpell.empty() ? "unknown" : slowestAreaSpell,
+			slowestAreaSample.scripted ? "scripted" : "native",
+			slowestAreaSample.positionX, slowestAreaSample.positionY, slowestAreaSample.positionZ,
+			slowestAreaSample.areaRows, slowestAreaSample.areaColumns, slowestAreaSample.activeCells,
+			slowestAreaSample.tilesReturned, slowestAreaSample.tilesCreated, slowestAreaSample.targets,
+			slowestAreaSample.itemId, slowestAreaSample.impactEffect,
+			slowestAreaSample.hasConditions, slowestAreaSample.hasTileCallback, slowestAreaSample.hasTargetCallback,
+			slowestAreaSample.buildTilesNanoseconds / 1'000.0,
+			slowestAreaSample.prepareDamageNanoseconds / 1'000.0,
+			slowestAreaSample.collectSpectatorsNanoseconds / 1'000.0,
+			slowestAreaSample.processTilesNanoseconds / 1'000.0,
+			slowestAreaSample.applyTargetsNanoseconds / 1'000.0);
+	}
 
 	uint64_t slowestNanoseconds = 0;
 	std::string slowestDescription;

--- a/src/performance_metrics.cpp
+++ b/src/performance_metrics.cpp
@@ -28,6 +28,19 @@ constexpr std::array<std::string_view, static_cast<size_t>(PerformanceMetric::Co
 	"Combat::area.applyTargets", "Creature::executeConditions",
 };
 
+constexpr std::array<std::string_view, static_cast<size_t>(MonsterIdleMetric::Count)> MONSTER_IDLE_METRIC_NAMES = {
+	"refresh_calls", "decision_true", "decision_false", "transition_to_idle", "transition_to_active",
+	"same_state_calls", "prune_calls", "targets_pruned", "friends_pruned", "attacked_cleared",
+	"follow_cleared", "blocked_by_target", "blocked_by_condition", "blocked_by_summon", "blocked_by_faction",
+	"active_without_reason", "on_idle_status_calls", "damage_map_clears", "creature_check_adds",
+	"creature_check_removes",
+};
+
+constexpr std::array<std::string_view, static_cast<size_t>(MonsterActiveReason::Count)> MONSTER_ACTIVE_REASON_NAMES = {
+	"target_list", "attacked_creature", "follow_creature", "aggressive_condition", "summon",
+	"faction_target", "unknown",
+};
+
 size_t histogramIndex(uint64_t nanoseconds) noexcept
 {
 	return std::min<size_t>(std::bit_width(nanoseconds), 63);
@@ -197,6 +210,30 @@ void PerformanceMetrics::recordAreaCombat(const AreaCombatMetricsSample& sample,
 	}
 }
 
+void PerformanceMetrics::recordMonsterIdle(MonsterIdleMetric metric, uint64_t count) noexcept
+{
+	if (isEnabled()) {
+		monsterIdle[static_cast<size_t>(metric)].fetch_add(count, std::memory_order_relaxed);
+	}
+}
+
+void PerformanceMetrics::recordMonsterActiveReason(MonsterActiveReason reason, uint64_t count) noexcept
+{
+	if (isEnabled()) {
+		monsterActiveReasons[static_cast<size_t>(reason)].fetch_add(count, std::memory_order_relaxed);
+	}
+}
+
+uint64_t PerformanceMetrics::getMonsterIdleMetric(MonsterIdleMetric metric) const noexcept
+{
+	return monsterIdle[static_cast<size_t>(metric)].load(std::memory_order_relaxed);
+}
+
+uint64_t PerformanceMetrics::getMonsterActiveReason(MonsterActiveReason reason) const noexcept
+{
+	return monsterActiveReasons[static_cast<size_t>(reason)].load(std::memory_order_relaxed);
+}
+
 void PerformanceMetrics::maybeReport()
 {
 	if (!isEnabled()) {
@@ -268,6 +305,34 @@ void PerformanceMetrics::maybeReport()
 			areaCombat.impactEffects.exchange(0, std::memory_order_relaxed),
 			areaCombat.fieldsCreated.exchange(0, std::memory_order_relaxed),
 			areaCombat.effectRecipients.exchange(0, std::memory_order_relaxed));
+	}
+
+	bool hasMonsterIdleMetrics = false;
+	std::array<uint64_t, static_cast<size_t>(MonsterIdleMetric::Count)> monsterIdleValues{};
+	for (size_t i = 0; i < monsterIdleValues.size(); ++i) {
+		monsterIdleValues[i] = monsterIdle[i].exchange(0, std::memory_order_relaxed);
+		hasMonsterIdleMetrics = hasMonsterIdleMetrics || monsterIdleValues[i] != 0;
+	}
+	if (hasMonsterIdleMetrics) {
+		report += "[Perf] monster_idle";
+		for (size_t i = 0; i < monsterIdleValues.size(); ++i) {
+			report += fmt::format(" {}={}", MONSTER_IDLE_METRIC_NAMES[i], monsterIdleValues[i]);
+		}
+		report += '\n';
+	}
+
+	bool hasMonsterActiveReasons = false;
+	std::array<uint64_t, static_cast<size_t>(MonsterActiveReason::Count)> monsterActiveReasonValues{};
+	for (size_t i = 0; i < monsterActiveReasonValues.size(); ++i) {
+		monsterActiveReasonValues[i] = monsterActiveReasons[i].exchange(0, std::memory_order_relaxed);
+		hasMonsterActiveReasons = hasMonsterActiveReasons || monsterActiveReasonValues[i] != 0;
+	}
+	if (hasMonsterActiveReasons) {
+		report += "[Perf] monster_active_reason";
+		for (size_t i = 0; i < monsterActiveReasonValues.size(); ++i) {
+			report += fmt::format(" {}={}", MONSTER_ACTIVE_REASON_NAMES[i], monsterActiveReasonValues[i]);
+		}
+		report += '\n';
 	}
 
 	AreaCombatMetricsSample slowestAreaSample;

--- a/src/performance_metrics.cpp
+++ b/src/performance_metrics.cpp
@@ -229,11 +229,6 @@ uint64_t PerformanceMetrics::getMonsterIdleMetric(MonsterIdleMetric metric) cons
 	return monsterIdle[static_cast<size_t>(metric)].load(std::memory_order_relaxed);
 }
 
-uint64_t PerformanceMetrics::getMonsterActiveReason(MonsterActiveReason reason) const noexcept
-{
-	return monsterActiveReasons[static_cast<size_t>(reason)].load(std::memory_order_relaxed);
-}
-
 void PerformanceMetrics::maybeReport()
 {
 	if (!isEnabled()) {

--- a/src/performance_metrics.h
+++ b/src/performance_metrics.h
@@ -46,6 +46,43 @@ enum class PerformanceMetric : uint8_t
 	Count,
 };
 
+enum class MonsterIdleMetric : uint8_t
+{
+	RefreshCalls,
+	DecisionTrue,
+	DecisionFalse,
+	TransitionToIdle,
+	TransitionToActive,
+	SameStateCalls,
+	PruneCalls,
+	TargetsPruned,
+	FriendsPruned,
+	AttackedCleared,
+	FollowCleared,
+	BlockedByTarget,
+	BlockedByCondition,
+	BlockedBySummon,
+	BlockedByFaction,
+	ActiveWithoutReason,
+	OnIdleStatusCalls,
+	DamageMapClears,
+	CreatureCheckAdds,
+	CreatureCheckRemoves,
+	Count,
+};
+
+enum class MonsterActiveReason : uint8_t
+{
+	TargetList,
+	AttackedCreature,
+	FollowCreature,
+	AggressiveCondition,
+	Summon,
+	FactionTarget,
+	Unknown,
+	Count,
+};
+
 struct AreaCombatMetricsSample
 {
 	uint64_t buildTilesNanoseconds = 0;
@@ -101,6 +138,10 @@ public:
 	void recordPathRequest(bool success, uint64_t nodesVisited, uint64_t tilesRead, uint64_t pathLength) noexcept;
 	void recordAreaCombat(const AreaCombatMetricsSample& sample, std::string_view monsterName,
 	                      std::string_view spellName) noexcept;
+	void recordMonsterIdle(MonsterIdleMetric metric, uint64_t count = 1) noexcept;
+	void recordMonsterActiveReason(MonsterActiveReason reason, uint64_t count = 1) noexcept;
+	[[nodiscard]] uint64_t getMonsterIdleMetric(MonsterIdleMetric metric) const noexcept;
+	[[nodiscard]] uint64_t getMonsterActiveReason(MonsterActiveReason reason) const noexcept;
 	void maybeReport();
 
 private:
@@ -177,6 +218,8 @@ private:
 	ReactorData reactor;
 	PathData path;
 	AreaCombatData areaCombat;
+	std::array<std::atomic<uint64_t>, static_cast<size_t>(MonsterIdleMetric::Count)> monsterIdle{};
+	std::array<std::atomic<uint64_t>, static_cast<size_t>(MonsterActiveReason::Count)> monsterActiveReasons{};
 	SlowestReactorCallback slowestReactorCallback;
 	SlowestAreaCombat slowestAreaCombat;
 	std::atomic_bool enabled{false};

--- a/src/performance_metrics.h
+++ b/src/performance_metrics.h
@@ -141,7 +141,6 @@ public:
 	void recordMonsterIdle(MonsterIdleMetric metric, uint64_t count = 1) noexcept;
 	void recordMonsterActiveReason(MonsterActiveReason reason, uint64_t count = 1) noexcept;
 	[[nodiscard]] uint64_t getMonsterIdleMetric(MonsterIdleMetric metric) const noexcept;
-	[[nodiscard]] uint64_t getMonsterActiveReason(MonsterActiveReason reason) const noexcept;
 	void maybeReport();
 
 private:

--- a/src/performance_metrics.h
+++ b/src/performance_metrics.h
@@ -37,7 +37,52 @@ enum class PerformanceMetric : uint8_t
 	CombatSpellCastSpell,
 	CombatDoCombat,
 	CombatDoAreaCombat,
+	CombatAreaBuildTiles,
+	CombatAreaPrepareDamage,
+	CombatAreaCollectSpectators,
+	CombatAreaProcessTiles,
+	CombatAreaApplyTargets,
+	CreatureExecuteConditions,
 	Count,
+};
+
+struct AreaCombatMetricsSample
+{
+	uint64_t buildTilesNanoseconds = 0;
+	uint64_t prepareDamageNanoseconds = 0;
+	uint64_t collectSpectatorsNanoseconds = 0;
+	uint64_t processTilesNanoseconds = 0;
+	uint64_t applyTargetsNanoseconds = 0;
+	uint64_t totalNanoseconds = 0;
+
+	uint64_t areaRows = 0;
+	uint64_t areaColumns = 0;
+	uint64_t activeCells = 0;
+	uint64_t sightChecks = 0;
+	uint64_t sightRejected = 0;
+	uint64_t tilesReturned = 0;
+	uint64_t tilesCreated = 0;
+	uint64_t combatRejected = 0;
+	uint64_t spectators = 0;
+	uint64_t targets = 0;
+	uint64_t blockedTargets = 0;
+	uint64_t appliedTargets = 0;
+	uint64_t conditionClones = 0;
+	uint64_t tileCallbacks = 0;
+	uint64_t targetCallbacks = 0;
+	uint64_t impactEffects = 0;
+	uint64_t fieldsCreated = 0;
+	uint64_t effectRecipients = 0;
+
+	uint16_t positionX = 0;
+	uint16_t positionY = 0;
+	uint16_t itemId = 0;
+	uint16_t impactEffect = 0;
+	uint8_t positionZ = 0;
+	bool scripted = false;
+	bool hasConditions = false;
+	bool hasTileCallback = false;
+	bool hasTargetCallback = false;
 };
 
 class PerformanceMetrics
@@ -54,6 +99,8 @@ public:
 	void recordReactorCallbackSource(uint64_t nanoseconds, std::string_view description,
 	                                 std::string_view origin) noexcept;
 	void recordPathRequest(bool success, uint64_t nodesVisited, uint64_t tilesRead, uint64_t pathLength) noexcept;
+	void recordAreaCombat(const AreaCombatMetricsSample& sample, std::string_view monsterName,
+	                      std::string_view spellName) noexcept;
 	void maybeReport();
 
 private:
@@ -86,6 +133,29 @@ private:
 		std::atomic<uint64_t> pathLength{0};
 	};
 
+	struct AreaCombatData
+	{
+		std::atomic<uint64_t> casts{0};
+		std::atomic<uint64_t> areaRows{0};
+		std::atomic<uint64_t> areaColumns{0};
+		std::atomic<uint64_t> activeCells{0};
+		std::atomic<uint64_t> sightChecks{0};
+		std::atomic<uint64_t> sightRejected{0};
+		std::atomic<uint64_t> tilesReturned{0};
+		std::atomic<uint64_t> tilesCreated{0};
+		std::atomic<uint64_t> combatRejected{0};
+		std::atomic<uint64_t> spectators{0};
+		std::atomic<uint64_t> targets{0};
+		std::atomic<uint64_t> blockedTargets{0};
+		std::atomic<uint64_t> appliedTargets{0};
+		std::atomic<uint64_t> conditionClones{0};
+		std::atomic<uint64_t> tileCallbacks{0};
+		std::atomic<uint64_t> targetCallbacks{0};
+		std::atomic<uint64_t> impactEffects{0};
+		std::atomic<uint64_t> fieldsCreated{0};
+		std::atomic<uint64_t> effectRecipients{0};
+	};
+
 	struct SlowestReactorCallback
 	{
 		std::mutex mutex;
@@ -94,10 +164,21 @@ private:
 		std::string origin;
 	};
 
+	struct SlowestAreaCombat
+	{
+		std::mutex mutex;
+		std::atomic<uint64_t> maximumNanoseconds{0};
+		AreaCombatMetricsSample sample;
+		std::string monsterName;
+		std::string spellName;
+	};
+
 	std::array<MetricData, static_cast<size_t>(PerformanceMetric::Count)> metrics;
 	ReactorData reactor;
 	PathData path;
+	AreaCombatData areaCombat;
 	SlowestReactorCallback slowestReactorCallback;
+	SlowestAreaCombat slowestAreaCombat;
 	std::atomic_bool enabled{false};
 	std::atomic<int64_t> nextReportNanoseconds{0};
 };

--- a/src/tests/test_combat.cpp
+++ b/src/tests/test_combat.cpp
@@ -1,0 +1,107 @@
+#include "../otpch.h"
+
+#include "../combat.h"
+#include "../events.h"
+#include "../game.h"
+#include "../matrixarea.h"
+#include "../scriptmanager.h"
+#include "../tile.h"
+
+#include "test_support.h"
+
+namespace {
+
+class EventsGuard
+{
+public:
+	EventsGuard() : previous(g_events) { g_events = &events; }
+	~EventsGuard() { g_events = previous; }
+
+private:
+	Events* previous;
+	Events events;
+};
+
+class TestTarget final : public Creature
+{
+public:
+	explicit TestTarget(BlockType_t blockType) : blockType(blockType) {}
+
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+	BlockType_t blockHit(const std::shared_ptr<Creature>&, CombatType_t, int32_t& damage, bool, bool, bool, bool,
+	                     CombatOrigin) override
+	{
+		if (blockType != BLOCK_NONE) {
+			damage = 0;
+		}
+		return blockType;
+	}
+
+private:
+	std::string name = "area combat test target";
+	BlockType_t blockType;
+};
+
+void addCreature(const Position& position, const std::shared_ptr<TestTarget>& creature)
+{
+	if (!g_game.map.getTile(position)) {
+		g_game.map.setTile(position.x, position.y, position.z,
+		                   std::make_unique<StaticTile>(position.x, position.y, position.z));
+	}
+
+	Tile* tile = g_game.map.getTile(position);
+	tile->internalAddThing(creature.get());
+	g_game.map.getQTNode(position.x, position.y)->addCreature(creature.get());
+}
+
+void removeCreature(const std::shared_ptr<TestTarget>& creature)
+{
+	Tile* tile = creature->getTile();
+	const Position position = tile->getPosition();
+	g_game.map.getQTNode(position.x, position.y)->removeCreature(creature.get());
+	tile->removeThing(creature.get(), 0);
+	creature->setParent(nullptr);
+}
+
+} // namespace
+
+TEST_CASE(area_conditions_use_each_targets_block_state)
+{
+	EventsGuard eventsGuard;
+	const Position blockedPosition{300, 300, 7};
+	const Position unblockedPosition{301, 300, 7};
+	auto blockedTarget = std::make_shared<TestTarget>(BLOCK_DEFENSE);
+	auto unblockedTarget = std::make_shared<TestTarget>(BLOCK_NONE);
+	addCreature(blockedPosition, blockedTarget);
+	addCreature(unblockedPosition, unblockedTarget);
+
+	AreaCombat area;
+	area.setupArea({3, 1}, 1);
+
+	CombatDamage damage;
+	damage.primary.type = COMBAT_PHYSICALDAMAGE;
+	damage.primary.value = -100;
+	damage.origin = ORIGIN_SPELL;
+
+	CombatParams params;
+	params.aggressive = false;
+	params.conditionList.push_front(
+	    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INFIGHT, 10'000));
+
+	Combat::doAreaCombat(nullptr, unblockedPosition, &area, damage, params);
+
+	CHECK(!blockedTarget->hasCondition(CONDITION_INFIGHT));
+	CHECK(unblockedTarget->hasCondition(CONDITION_INFIGHT));
+
+	removeCreature(blockedTarget);
+	removeCreature(unblockedTarget);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_map_spectators.cpp
+++ b/src/tests/test_map_spectators.cpp
@@ -1,0 +1,168 @@
+#include "../otpch.h"
+
+#include "../creature.h"
+#include "../map.h"
+#include "../tile.h"
+#include "test_support.h"
+
+namespace {
+
+class TestCreature : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+private:
+	std::string name = "map spectator test creature";
+};
+
+class TestPlayer final : public TestCreature
+{
+public:
+	CreatureType_t getType() const override { return CREATURETYPE_PLAYER; }
+	Player* getPlayer() override { return reinterpret_cast<Player*>(this); }
+	const Player* getPlayer() const override { return reinterpret_cast<const Player*>(this); }
+};
+
+class TestMonster final : public TestCreature
+{
+public:
+	Monster* getMonster() override { return reinterpret_cast<Monster*>(this); }
+	const Monster* getMonster() const override { return reinterpret_cast<const Monster*>(this); }
+};
+
+class TestNpc final : public TestCreature
+{
+public:
+	CreatureType_t getType() const override { return CREATURETYPE_NPC; }
+	Npc* getNpc() override { return reinterpret_cast<Npc*>(this); }
+	const Npc* getNpc() const override { return reinterpret_cast<const Npc*>(this); }
+};
+
+void addCreature(Map& map, const Position& position, const std::shared_ptr<TestCreature>& creature)
+{
+	if (!map.getTile(position)) {
+		map.setTile(position.x, position.y, position.z,
+		            std::make_unique<StaticTile>(position.x, position.y, position.z));
+	}
+
+	Tile* tile = map.getTile(position);
+	tile->internalAddThing(creature.get());
+	map.getQTNode(position.x, position.y)->addCreature(creature.get());
+}
+
+void removeCreature(Map& map, const std::shared_ptr<TestCreature>& creature)
+{
+	Tile* tile = creature->getTile();
+	const Position position = tile->getPosition();
+	map.getQTNode(position.x, position.y)->removeCreature(creature.get());
+	tile->removeThing(creature.get(), 0);
+	creature->setParent(nullptr);
+}
+
+bool contains(const SpectatorVec& spectators, const Creature* expected)
+{
+	return std::ranges::any_of(spectators, [expected](const auto& spectator) { return spectator.get() == expected; });
+}
+
+} // namespace
+
+TEST_CASE(spectator_queries_are_live_after_add_and_remove)
+{
+	Map map;
+	const Position center{100, 100, 7};
+
+	SpectatorVec beforeAdd;
+	map.getSpectators(beforeAdd, center);
+	CHECK(beforeAdd.empty());
+
+	auto creature = std::make_shared<TestMonster>();
+	addCreature(map, center, creature);
+
+	SpectatorVec afterAdd;
+	map.getSpectators(afterAdd, center);
+	CHECK(contains(afterAdd, creature.get()));
+
+	afterAdd = {};
+	std::weak_ptr<TestMonster> weakCreature = creature;
+	removeCreature(map, creature);
+
+	SpectatorVec afterRemove;
+	map.getSpectators(afterRemove, center);
+	CHECK(!contains(afterRemove, creature.get()));
+
+	creature.reset();
+	CHECK(weakCreature.expired());
+}
+
+TEST_CASE(spectator_floor_rules_match_surface_and_underground_visibility)
+{
+	Map map;
+	auto surfaceAbove = std::make_shared<TestMonster>();
+	auto surfaceSame = std::make_shared<TestMonster>();
+	auto underground = std::make_shared<TestMonster>();
+	addCreature(map, Position{120, 120, 6}, surfaceAbove);
+	addCreature(map, Position{120, 120, 7}, surfaceSame);
+	addCreature(map, Position{120, 120, 8}, underground);
+
+	SpectatorVec sameFloor;
+	map.getSpectators(sameFloor, Position{120, 120, 7});
+	CHECK(!contains(sameFloor, surfaceAbove.get()));
+	CHECK(contains(sameFloor, surfaceSame.get()));
+	CHECK(!contains(sameFloor, underground.get()));
+
+	SpectatorVec surfaceMultiFloor;
+	map.getSpectators(surfaceMultiFloor, Position{120, 120, 7}, true);
+	CHECK(contains(surfaceMultiFloor, surfaceAbove.get()));
+	CHECK(contains(surfaceMultiFloor, surfaceSame.get()));
+	CHECK(!contains(surfaceMultiFloor, underground.get()));
+
+	SpectatorVec undergroundMultiFloor;
+	map.getSpectators(undergroundMultiFloor, Position{120, 120, 8}, true);
+	CHECK(contains(undergroundMultiFloor, surfaceAbove.get()));
+	CHECK(contains(undergroundMultiFloor, surfaceSame.get()));
+	CHECK(contains(undergroundMultiFloor, underground.get()));
+
+	removeCreature(map, surfaceAbove);
+	removeCreature(map, surfaceSame);
+	removeCreature(map, underground);
+}
+
+TEST_CASE(spectator_type_filters_return_only_requested_categories)
+{
+	Map map;
+	const Position center{140, 140, 7};
+	auto player = std::make_shared<TestPlayer>();
+	auto monster = std::make_shared<TestMonster>();
+	auto npc = std::make_shared<TestNpc>();
+	addCreature(map, center, player);
+	addCreature(map, center, monster);
+	addCreature(map, center, npc);
+
+	SpectatorVec players;
+	map.getSpectators(players, center, false, true);
+	CHECK(players.size() == 1);
+	CHECK(contains(players, player.get()));
+
+	SpectatorVec monsters;
+	map.getSpectators(monsters, center, false, false, 0, 0, 0, 0, true);
+	CHECK(monsters.size() == 1);
+	CHECK(contains(monsters, monster.get()));
+
+	SpectatorVec npcs;
+	map.getSpectators(npcs, center, false, false, 0, 0, 0, 0, false, true);
+	CHECK(npcs.size() == 1);
+	CHECK(contains(npcs, npc.get()));
+
+	removeCreature(map, player);
+	removeCreature(map, monster);
+	removeCreature(map, npc);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_monster_idle_events.cpp
+++ b/src/tests/test_monster_idle_events.cpp
@@ -1,6 +1,7 @@
 #include "../otpch.h"
 
 #include "../configmanager.h"
+#include "../events.h"
 #include "../game.h"
 #include "../monster.h"
 #include "../movement.h"
@@ -56,9 +57,11 @@ class WorldFixture
 {
 public:
 	WorldFixture()
-	    : oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM)),
+	    : oldEvents(g_events),
+	      oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM)),
 	      oldRequirePlayer(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY))
 	{
+		g_events = &events;
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, true);
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, false);
 		if (!g_moveEvents) {
@@ -75,6 +78,7 @@ public:
 		}
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, oldFactionSystem);
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, oldRequirePlayer);
+		g_events = oldEvents;
 	}
 
 	void place(const std::shared_ptr<Creature>& creature, const Position& position)
@@ -85,6 +89,8 @@ public:
 	}
 
 private:
+	Events* oldEvents;
+	Events events;
 	bool oldFactionSystem;
 	bool oldRequirePlayer;
 	std::vector<std::weak_ptr<Creature>> creatures;
@@ -242,6 +248,105 @@ TEST_CASE(monster_cleans_target_after_real_teleport_out_of_view)
 	CHECK(!monster->getAttackedCreatureShared());
 	CHECK(!monster->getFollowCreatureShared());
 	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_cleans_target_after_real_teleport_to_another_floor)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{800, 500, 7});
+	world.place(target, Position{801, 500, 7});
+	selectTarget(monster, target);
+	const Position destination{801, 500, 8};
+	ensureTile(destination);
+
+	CHECK(g_game.internalTeleport(target.get(), destination) == RETURNVALUE_NOERROR);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+	CHECK(!monster->isCreatureCheckEnabled());
+}
+
+TEST_CASE(monster_cleans_target_after_real_teleport_into_protection_zone)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{810, 500, 7});
+	world.place(target, Position{811, 500, 7});
+	selectTarget(monster, target);
+	const Position destination{812, 500, 7};
+	ensureTile(destination);
+	g_game.map.getTile(destination)->setFlag(TILESTATE_PROTECTIONZONE);
+
+	CHECK(g_game.internalTeleport(target.get(), destination) == RETURNVALUE_NOERROR);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+	CHECK(!monster->isCreatureCheckEnabled());
+}
+
+TEST_CASE(monster_cleans_target_after_logout_removal)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{820, 500, 7});
+	world.place(target, Position{821, 500, 7});
+	selectTarget(monster, target);
+
+	CHECK(g_game.removeCreature(target.get(), true));
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+	CHECK(!monster->isCreatureCheckEnabled());
+}
+
+TEST_CASE(aggressive_condition_ends_with_one_idle_transition)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{830, 500, 7});
+	world.place(target, Position{831, 500, 7});
+	selectTarget(monster, target);
+	CHECK(monster->addCondition(
+	    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INFIGHT, 10'000, 0, false, 0, true)));
+	monster->onRemoveCreature(target.get(), false);
+	CHECK(!monster->getIdleStatus());
+	MetricsFixture metrics;
+	const uint64_t transitionsToIdle = metrics.get(MonsterIdleMetric::TransitionToIdle);
+	const uint64_t onIdleStatusCalls = metrics.get(MonsterIdleMetric::OnIdleStatusCalls);
+
+	monster->removeCondition(CONDITION_INFIGHT, true);
+
+	CHECK(monster->getIdleStatus());
+	CHECK(metrics.get(MonsterIdleMetric::TransitionToIdle) == transitionsToIdle + 1);
+	CHECK(metrics.get(MonsterIdleMetric::OnIdleStatusCalls) == onIdleStatusCalls + 1);
+}
+
+TEST_CASE(active_monster_without_reason_converges_to_idle_on_think)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	world.place(monster, Position{840, 500, 7});
+	MetricsFixture metrics;
+	const uint64_t activeWithoutReason = metrics.get(MonsterIdleMetric::ActiveWithoutReason);
+	monster->setIdle(false);
+	CHECK(monster->isCreatureCheckEnabled());
+
+	monster->onThink(EVENT_CREATURE_THINK_INTERVAL);
+
+	CHECK(monster->getIdleStatus());
+	CHECK(!monster->isCreatureCheckEnabled());
+	CHECK(metrics.get(MonsterIdleMetric::ActiveWithoutReason) == activeWithoutReason + 1);
 }
 
 TEST_CASE(monster_clears_faction_target_when_policy_is_disabled)

--- a/src/tests/test_monster_idle_events.cpp
+++ b/src/tests/test_monster_idle_events.cpp
@@ -1,0 +1,93 @@
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../game.h"
+#include "../monster.h"
+#include "../movement.h"
+#include "../scriptmanager.h"
+#include "../tile.h"
+
+#include "test_support.h"
+
+namespace {
+
+std::shared_ptr<Monster> makeMonster(bool enemy = false)
+{
+	auto type = std::make_shared<MonsterType>();
+	type->name = enemy ? "Idle Event Enemy" : "Idle Event Monster";
+	type->nameDescription = enemy ? "an idle event enemy" : "an idle event monster";
+	type->info.isHostile = true;
+	type->info.faction = enemy ? FACTION_LIONUSURPERS : FACTION_LION;
+	type->info.enemyFactions.insert(enemy ? FACTION_LION : FACTION_LIONUSURPERS);
+	return std::make_shared<Monster>(type);
+}
+
+void ensureTile(const Position& position)
+{
+	if (!g_game.map.getTile(position)) {
+		g_game.map.setTile(position.x, position.y, position.z,
+		                   std::make_unique<StaticTile>(position.x, position.y, position.z));
+	}
+}
+
+class WorldFixture
+{
+public:
+	WorldFixture() : oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM))
+	{
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, true);
+		if (!g_moveEvents) {
+			g_moveEvents = std::make_unique<MoveEvents>();
+		}
+	}
+
+	~WorldFixture()
+	{
+		for (auto it = creatures.rbegin(); it != creatures.rend(); ++it) {
+			if (auto creature = it->lock(); creature && !creature->isRemoved()) {
+				g_game.removeCreature(creature.get(), false);
+			}
+		}
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, oldFactionSystem);
+	}
+
+	void place(const std::shared_ptr<Creature>& creature, const Position& position)
+	{
+		creatures.push_back(creature);
+		ensureTile(position);
+		CHECK(g_game.internalPlaceCreature(creature.get(), position, false, true));
+	}
+
+private:
+	bool oldFactionSystem;
+	std::vector<std::weak_ptr<Creature>> creatures;
+};
+
+void selectTarget(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Monster>& target)
+{
+	monster->addTarget(target.get());
+	CHECK(monster->setAttackedCreature(target.get()));
+	CHECK(monster->setFollowCreature(target.get()));
+	monster->setIdle(false);
+}
+
+} // namespace
+
+TEST_CASE(monster_cleans_target_when_instance_changes_at_same_position)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{700, 500, 7});
+	world.place(target, Position{701, 500, 7});
+	selectTarget(monster, target);
+
+	target->setInstanceID(7);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_monster_idle_events.cpp
+++ b/src/tests/test_monster_idle_events.cpp
@@ -129,6 +129,22 @@ TEST_CASE(monster_cleans_target_when_instance_changes_at_same_position)
 	CHECK(monster->getIdleStatus());
 }
 
+TEST_CASE(summon_keeps_master_while_adopting_master_instance)
+{
+	WorldFixture world;
+	auto summon = makeMonster();
+	auto master = std::make_shared<TestCreature>();
+	world.place(summon, Position{705, 500, 7});
+	world.place(master, Position{706, 500, 7});
+	master->setInstanceID(11);
+
+	CHECK(summon->setMaster(master.get()));
+
+	CHECK(summon->getMaster() == master);
+	CHECK(summon->getInstanceID() == master->getInstanceID());
+	CHECK(!summon->getIdleStatus());
+}
+
 TEST_CASE(idle_monster_is_removed_from_creature_checks_after_placement)
 {
 	WorldFixture world;

--- a/src/tests/test_monster_idle_events.cpp
+++ b/src/tests/test_monster_idle_events.cpp
@@ -4,12 +4,34 @@
 #include "../game.h"
 #include "../monster.h"
 #include "../movement.h"
+#include "../performance_metrics.h"
 #include "../scriptmanager.h"
 #include "../tile.h"
 
 #include "test_support.h"
 
 namespace {
+
+class TestCreature final : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void removeList() override {}
+	void addList() override {}
+	void setID() override
+	{
+		if (id == 0) {
+			id = nextId++;
+		}
+	}
+
+private:
+	inline static uint32_t nextId = 0x51000000;
+	std::string name = "idle event test creature";
+};
 
 std::shared_ptr<Monster> makeMonster(bool enemy = false)
 {
@@ -33,9 +55,12 @@ void ensureTile(const Position& position)
 class WorldFixture
 {
 public:
-	WorldFixture() : oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM))
+	WorldFixture()
+	    : oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM)),
+	      oldRequirePlayer(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY))
 	{
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, true);
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, false);
 		if (!g_moveEvents) {
 			g_moveEvents = std::make_unique<MoveEvents>();
 		}
@@ -49,6 +74,7 @@ public:
 			}
 		}
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, oldFactionSystem);
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, oldRequirePlayer);
 	}
 
 	void place(const std::shared_ptr<Creature>& creature, const Position& position)
@@ -60,7 +86,20 @@ public:
 
 private:
 	bool oldFactionSystem;
+	bool oldRequirePlayer;
 	std::vector<std::weak_ptr<Creature>> creatures;
+};
+
+class MetricsFixture
+{
+public:
+	MetricsFixture() : wasEnabled(g_performanceMetrics.isEnabled()) { g_performanceMetrics.setEnabled(true); }
+	~MetricsFixture() { g_performanceMetrics.setEnabled(wasEnabled); }
+
+	uint64_t get(MonsterIdleMetric metric) const { return g_performanceMetrics.getMonsterIdleMetric(metric); }
+
+private:
+	bool wasEnabled;
 };
 
 void selectTarget(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Monster>& target)
@@ -83,6 +122,123 @@ TEST_CASE(monster_cleans_target_when_instance_changes_at_same_position)
 	selectTarget(monster, target);
 
 	target->setInstanceID(7);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(idle_monster_is_removed_from_creature_checks_after_placement)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	world.place(monster, Position{710, 500, 7});
+
+	CHECK(monster->getIdleStatus());
+	CHECK(!monster->isCreatureCheckEnabled());
+}
+
+TEST_CASE(monster_idle_transition_is_idempotent_and_clears_damage_once)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto firstAttacker = std::make_shared<TestCreature>();
+	auto secondAttacker = std::make_shared<TestCreature>();
+	world.place(monster, Position{720, 500, 7});
+	world.place(firstAttacker, Position{721, 500, 7});
+	world.place(secondAttacker, Position{722, 500, 7});
+	MetricsFixture metrics;
+
+	const uint64_t transitionsToActive = metrics.get(MonsterIdleMetric::TransitionToActive);
+	const uint64_t transitionsToIdle = metrics.get(MonsterIdleMetric::TransitionToIdle);
+	const uint64_t sameStateCalls = metrics.get(MonsterIdleMetric::SameStateCalls);
+	const uint64_t onIdleStatusCalls = metrics.get(MonsterIdleMetric::OnIdleStatusCalls);
+	const uint64_t damageMapClears = metrics.get(MonsterIdleMetric::DamageMapClears);
+
+	monster->setIdle(false);
+	monster->setIdle(false);
+	CHECK(monster->isCreatureCheckEnabled());
+	firstAttacker->onAttackedCreatureDrainHealth(monster, 10);
+	secondAttacker->onAttackedCreatureDrainHealth(monster, 20);
+	CHECK(monster->getDamageMap().size() == 2);
+
+	monster->setIdle(true);
+	CHECK(!monster->isCreatureCheckEnabled());
+	CHECK(monster->getDamageMap().empty());
+	monster->setIdle(true);
+
+	CHECK(metrics.get(MonsterIdleMetric::TransitionToActive) == transitionsToActive + 1);
+	CHECK(metrics.get(MonsterIdleMetric::TransitionToIdle) == transitionsToIdle + 1);
+	CHECK(metrics.get(MonsterIdleMetric::SameStateCalls) == sameStateCalls + 2);
+	CHECK(metrics.get(MonsterIdleMetric::OnIdleStatusCalls) == onIdleStatusCalls + 1);
+	CHECK(metrics.get(MonsterIdleMetric::DamageMapClears) == damageMapClears + 1);
+}
+
+TEST_CASE(monster_target_and_friend_mutations_report_real_changes)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto creature = std::make_shared<TestCreature>();
+	world.place(monster, Position{730, 500, 7});
+	world.place(creature, Position{731, 500, 7});
+
+	CHECK(monster->addTarget(creature.get()));
+	CHECK(!monster->addTarget(creature.get()));
+	CHECK(monster->removeTarget(creature.get()));
+	CHECK(!monster->removeTarget(creature.get()));
+	CHECK(monster->addFriend(creature.get()));
+	CHECK(!monster->addFriend(creature.get()));
+	CHECK(monster->removeFriend(creature.get()));
+	CHECK(!monster->removeFriend(creature.get()));
+}
+
+TEST_CASE(monster_does_not_refresh_idle_for_duplicate_creature_found)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{740, 500, 7});
+	world.place(target, Position{741, 500, 7});
+	monster->onCreatureAppear(target.get(), false);
+	MetricsFixture metrics;
+	const uint64_t refreshCalls = metrics.get(MonsterIdleMetric::RefreshCalls);
+
+	monster->onCreatureAppear(target.get(), false);
+
+	CHECK(metrics.get(MonsterIdleMetric::RefreshCalls) == refreshCalls);
+}
+
+TEST_CASE(monster_cleans_target_after_real_teleport_out_of_view)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{750, 500, 7});
+	world.place(target, Position{751, 500, 7});
+	selectTarget(monster, target);
+	const Position destination{780, 500, 7};
+	ensureTile(destination);
+
+	CHECK(g_game.internalTeleport(target.get(), destination) == RETURNVALUE_NOERROR);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_clears_faction_target_when_policy_is_disabled)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{790, 500, 7});
+	world.place(target, Position{791, 500, 7});
+	selectTarget(monster, target);
+
+	ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, false);
+	monster->onThink(EVENT_CREATURE_THINK_INTERVAL);
 
 	CHECK(monster->getTargetList().empty());
 	CHECK(!monster->getAttackedCreatureShared());

--- a/src/tests/test_monster_target_state.cpp
+++ b/src/tests/test_monster_target_state.cpp
@@ -1,13 +1,21 @@
 #include "../otpch.h"
 
+#include "../chat.h"
 #include "../configmanager.h"
+#include "../events.h"
 #include "../game.h"
+#include "../globalevent.h"
+#include "../groups.h"
+#include "../item.h"
 #include "../monster.h"
 #include "../movement.h"
+#include "../player.h"
 #include "../scriptmanager.h"
 #include "../tile.h"
 
 #include "test_support.h"
+
+#include <filesystem>
 
 namespace {
 
@@ -44,21 +52,69 @@ std::shared_ptr<Monster> makeMonster(bool target = false)
 	return std::make_shared<Monster>(type);
 }
 
+std::shared_ptr<Player> makePlayer()
+{
+	auto player = std::make_shared<Player>(nullptr);
+	player->setName("Monster Target State Player");
+	player->setGroup(std::make_shared<Group>());
+	return player;
+}
+
+void ensureItemTypes()
+{
+	static const bool loaded = [] {
+		const auto itemFile = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+		                      "data/items/items.otb";
+		return Item::items.loadFromOtb(itemFile.string());
+	}();
+	CHECK(loaded);
+}
+
 void ensureTile(const Position& position)
 {
 	if (!g_game.map.getTile(position)) {
 		g_game.map.setTile(position.x, position.y, position.z,
 		                   std::make_unique<StaticTile>(position.x, position.y, position.z));
 	}
+
+	Tile* tile = g_game.map.getTile(position);
+	if (!tile->getGround()) {
+		tile->setGround(std::make_shared<Item>(0));
+	}
+}
+
+void addStairHeight(Tile* tile)
+{
+	static const uint16_t heightItemId = [] {
+		for (size_t id = 1; id < Item::items.size(); ++id) {
+			const ItemType& itemType = Item::items[id];
+			if (itemType.id != 0 && !itemType.isGroundTile() && itemType.hasHeight &&
+			    (!itemType.blockSolid || itemType.moveable)) {
+				return static_cast<uint16_t>(id);
+			}
+		}
+		return uint16_t{0};
+	}();
+	CHECK(heightItemId != 0);
+	for (uint8_t i = 0; i < 3; ++i) {
+		auto item = std::make_shared<Item>(heightItemId);
+		tile->internalAddThing(item.get());
+	}
+	CHECK(tile->hasHeight(3));
 }
 
 class WorldFixture
 {
 public:
 	WorldFixture()
-	    : oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM)),
+	    : oldChat(g_chat), oldEvents(g_events), oldGlobalEvents(g_globalEvents),
+	      oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM)),
 	      oldRequirePlayer(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY))
 	{
+		ensureItemTypes();
+		g_chat = &chat;
+		g_events = &events;
+		g_globalEvents = &globalEvents;
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, true);
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, false);
 		if (!g_moveEvents) {
@@ -75,6 +131,9 @@ public:
 		}
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, oldFactionSystem);
 		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, oldRequirePlayer);
+		g_globalEvents = oldGlobalEvents;
+		g_events = oldEvents;
+		g_chat = oldChat;
 	}
 
 	void place(const std::shared_ptr<Creature>& creature, const Position& position)
@@ -85,6 +144,12 @@ public:
 	}
 
 private:
+	Chat* oldChat;
+	Events* oldEvents;
+	GlobalEvents* oldGlobalEvents;
+	Chat chat;
+	Events events;
+	GlobalEvents globalEvents;
 	bool oldFactionSystem;
 	bool oldRequirePlayer;
 	std::vector<std::weak_ptr<Creature>> creatures;
@@ -99,12 +164,27 @@ void selectTarget(const std::shared_ptr<Monster>& monster, const std::shared_ptr
 	monster->setIdle(false);
 }
 
-void moveCreatureForMonster(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Creature>& creature,
-                            const Position& oldPosition, const Position& newPosition)
+void moveCreatureForMonster(const std::shared_ptr<Creature>& creature, const Position& newPosition)
 {
 	ensureTile(newPosition);
-	monster->onCreatureMove(creature.get(), g_game.map.getTile(newPosition), newPosition,
-	                        g_game.map.getTile(oldPosition), oldPosition, true);
+	Tile* expectedTile = g_game.map.getTile(newPosition);
+	CHECK(g_game.internalMoveCreature(*creature, *expectedTile, FLAG_NOLIMIT) == RETURNVALUE_NOERROR);
+	CHECK(creature->getPosition() == newPosition);
+	CHECK(creature->getTile() == expectedTile);
+}
+
+void moveCreatureByDirection(const std::shared_ptr<Creature>& creature, Direction direction,
+                             const Position& expectedPosition)
+{
+	ensureTile(expectedPosition);
+	Tile* expectedTile = g_game.map.getTile(expectedPosition);
+	const ReturnValue result = g_game.internalMoveCreature(creature.get(), direction, FLAG_NOLIMIT);
+	if (result != RETURNVALUE_NOERROR) {
+		throw std::runtime_error("directional creature move failed with ReturnValue " +
+		                         std::to_string(static_cast<uint8_t>(result)));
+	}
+	CHECK(creature->getPosition() == expectedPosition);
+	CHECK(creature->getTile() == expectedTile);
 }
 
 void flushCreatureChecks()
@@ -112,6 +192,13 @@ void flushCreatureChecks()
 	for (size_t index = 0; index < EVENT_CREATURECOUNT; ++index) {
 		g_game.checkCreatures(index);
 	}
+}
+
+bool hasTarget(const std::shared_ptr<Monster>& monster, const Creature* creature)
+{
+	return std::ranges::any_of(monster->getTargetList(), [creature](const auto& weakRef) {
+		return weakRef.lock().get() == creature;
+	});
 }
 
 } // namespace
@@ -213,8 +300,7 @@ TEST_CASE(summon_preserves_master_follow_across_floor_change)
 	CHECK(summon->setMaster(master.get()));
 	CHECK(summon->setFollowCreature(master.get()));
 
-	summon->onCreatureMove(master.get(), g_game.map.getTile(newMasterPosition), newMasterPosition,
-	                       g_game.map.getTile(oldMasterPosition), oldMasterPosition, true);
+	moveCreatureForMonster(master, newMasterPosition);
 
 	CHECK(summon->getMaster() == master);
 	CHECK(summon->getFollowCreatureShared() == master);
@@ -245,7 +331,7 @@ TEST_CASE(monster_cleans_target_that_moves_out_of_view)
 	world.place(target, oldPosition);
 	selectTarget(monster, target);
 
-	moveCreatureForMonster(monster, target, oldPosition, newPosition);
+	moveCreatureForMonster(target, newPosition);
 
 	CHECK(monster->getTargetList().empty());
 	CHECK(!monster->getAttackedCreatureShared());
@@ -259,17 +345,27 @@ TEST_CASE(monster_cleans_target_that_changes_floor)
 	auto monster = makeMonster();
 	auto target = makeMonster(true);
 	const Position oldPosition{600, 500, 7};
-	const Position newPosition{600, 500, 8};
+	const Position newPosition{600, 500, 6};
 	world.place(monster, Position{599, 500, 7});
 	world.place(target, oldPosition);
 	selectTarget(monster, target);
+	CHECK(monster->canSee(oldPosition));
+	CHECK(Creature::canSee(monster->getPosition(), oldPosition, Map::maxClientViewportX + 1,
+	                       Map::maxClientViewportY + 1));
+	CHECK(Creature::canSee(monster->getPosition(), newPosition, Map::maxClientViewportX + 1,
+	                       Map::maxClientViewportY + 1));
+	CHECK(!monster->canSee(newPosition));
 
-	moveCreatureForMonster(monster, target, oldPosition, newPosition);
+	moveCreatureForMonster(target, newPosition);
 
 	CHECK(monster->getTargetList().empty());
 	CHECK(!monster->getAttackedCreatureShared());
 	CHECK(!monster->getFollowCreatureShared());
 	CHECK(monster->getIdleStatus());
+
+	moveCreatureForMonster(target, oldPosition);
+	CHECK(hasTarget(monster, target.get()));
+	CHECK(!monster->getIdleStatus());
 }
 
 TEST_CASE(monster_cleans_target_that_enters_protection_zone)
@@ -285,12 +381,18 @@ TEST_CASE(monster_cleans_target_that_enters_protection_zone)
 	ensureTile(newPosition);
 	g_game.map.getTile(newPosition)->setFlag(TILESTATE_PROTECTIONZONE);
 
-	moveCreatureForMonster(monster, target, oldPosition, newPosition);
+	moveCreatureForMonster(target, newPosition);
+	CHECK(target->getZone() == ZONE_PROTECTION);
 
 	CHECK(monster->getTargetList().empty());
 	CHECK(!monster->getAttackedCreatureShared());
 	CHECK(!monster->getFollowCreatureShared());
 	CHECK(monster->getIdleStatus());
+
+	moveCreatureForMonster(target, oldPosition);
+	CHECK(target->getZone() != ZONE_PROTECTION);
+	CHECK(hasTarget(monster, target.get()));
+	CHECK(!monster->getIdleStatus());
 }
 
 TEST_CASE(monster_prunes_expired_friend_reference)
@@ -327,7 +429,7 @@ TEST_CASE(familiar_preserves_master_follow_across_floor_change)
 	CHECK(familiar->setMaster(master.get()));
 	CHECK(familiar->setFollowCreature(master.get()));
 
-	moveCreatureForMonster(familiar, master, oldMasterPosition, newMasterPosition);
+	moveCreatureForMonster(master, newMasterPosition);
 
 	CHECK(familiar->getMaster() == master);
 	CHECK(familiar->getFollowCreatureShared() == master);
@@ -370,6 +472,108 @@ TEST_CASE(monster_can_return_to_combat_after_becoming_idle)
 	CHECK(!monster->getIdleStatus());
 	CHECK(monster->getAttackedCreatureShared() == target);
 	CHECK(monster->getFollowCreatureShared() == target);
+}
+
+TEST_CASE(monsters_clean_all_player_target_states_after_real_floor_transition)
+{
+	WorldFixture world;
+	auto monsterA = makeMonster();
+	auto monsterB = makeMonster();
+	auto monsterC = makeMonster();
+	auto player = makePlayer();
+	const Position oldPosition{900, 500, 7};
+	const Position newPosition{901, 500, 6};
+	world.place(monsterA, Position{899, 499, 7});
+	world.place(monsterB, Position{899, 500, 7});
+	world.place(monsterC, Position{899, 501, 7});
+	world.place(player, oldPosition);
+	ensureTile(newPosition);
+	addStairHeight(player->getTile());
+
+	CHECK(monsterA->canSee(oldPosition));
+	CHECK(Creature::canSee(monsterA->getPosition(), newPosition, Map::maxClientViewportX + 1,
+	                       Map::maxClientViewportY + 1));
+	CHECK(!monsterA->canSee(newPosition));
+	selectTarget(monsterA, player);
+	CHECK(monsterB->addTarget(player.get()));
+	CHECK(monsterB->setFollowCreature(player.get()));
+	monsterB->setAttackedCreature(nullptr);
+	CHECK(monsterC->addTarget(player.get()));
+	monsterC->setAttackedCreature(nullptr);
+	monsterC->setFollowCreature(nullptr);
+	CHECK(hasTarget(monsterA, player.get()));
+	CHECK(hasTarget(monsterB, player.get()));
+	CHECK(hasTarget(monsterC, player.get()));
+
+	moveCreatureByDirection(player, DIRECTION_EAST, newPosition);
+
+	for (const auto& monster : {monsterA, monsterB, monsterC}) {
+		CHECK(!hasTarget(monster, player.get()));
+		CHECK(!monster->getAttackedCreatureShared());
+		CHECK(!monster->getFollowCreatureShared());
+		CHECK(monster->getIdleStatus());
+		CHECK(!monster->isCreatureCheckEnabled());
+	}
+	// Execute the work an already queued follow task would perform. The stale
+	// task must observe the cleared follow pointer and stop before pathfinding.
+	g_game.updateCreatureWalk(monsterA->getID());
+	CHECK(monsterA->getIdleStatus());
+	CHECK(!monsterA->getFollowCreatureShared());
+
+	moveCreatureByDirection(player, DIRECTION_WEST, oldPosition);
+	for (const auto& monster : {monsterA, monsterB, monsterC}) {
+		CHECK(hasTarget(monster, player.get()));
+		CHECK(!monster->getIdleStatus());
+		CHECK(monster->isCreatureCheckEnabled());
+	}
+}
+
+TEST_CASE(monster_does_not_readd_player_during_same_position_instance_change)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto newInstanceMonster = makeMonster();
+	auto player = makePlayer();
+	const Position position{920, 500, 7};
+	world.place(monster, Position{919, 500, 7});
+	newInstanceMonster->setInstanceID(7);
+	world.place(newInstanceMonster, Position{921, 500, 7});
+	world.place(player, position);
+	selectTarget(monster, player);
+
+	player->setInstanceID(7);
+
+	CHECK(player->getPosition() == position);
+	CHECK(player->getTile() == g_game.map.getTile(position));
+	CHECK(player->getInstanceID() == 7);
+	CHECK(!hasTarget(monster, player.get()));
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+	CHECK(hasTarget(newInstanceMonster, player.get()));
+	CHECK(!newInstanceMonster->getIdleStatus());
+}
+
+TEST_CASE(moving_monster_discovers_new_stationary_target)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto followedTarget = makeMonster(true);
+	auto stationaryTarget = makeMonster(true);
+	const Position oldPosition{940, 500, 7};
+	const Position newPosition{941, 500, 7};
+	world.place(monster, oldPosition);
+	world.place(followedTarget, Position{940, 501, 7});
+	world.place(stationaryTarget, Position{950, 500, 7});
+	selectTarget(monster, followedTarget);
+	CHECK(!hasTarget(monster, stationaryTarget.get()));
+	CHECK(!monster->canSee(stationaryTarget->getPosition()));
+
+	moveCreatureForMonster(monster, newPosition);
+
+	CHECK(monster->canSee(stationaryTarget->getPosition()));
+	CHECK(hasTarget(monster, followedTarget.get()));
+	CHECK(hasTarget(monster, stationaryTarget.get()));
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_monster_target_state.cpp
+++ b/src/tests/test_monster_target_state.cpp
@@ -1,0 +1,375 @@
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../game.h"
+#include "../monster.h"
+#include "../movement.h"
+#include "../scriptmanager.h"
+#include "../tile.h"
+
+#include "test_support.h"
+
+namespace {
+
+class TestCreature final : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void removeList() override {}
+	void addList() override {}
+	void setID() override
+	{
+		if (id == 0) {
+			id = nextId++;
+		}
+	}
+	void markDead() { health = 0; }
+
+private:
+	inline static uint32_t nextId = 0x50000000;
+	std::string name = "monster target state test creature";
+};
+
+std::shared_ptr<Monster> makeMonster(bool target = false)
+{
+	auto type = std::make_shared<MonsterType>();
+	type->name = target ? "Target State Enemy" : "Target State Test Monster";
+	type->nameDescription = target ? "a target state enemy" : "a target state test monster";
+	type->info.isHostile = true;
+	type->info.faction = target ? FACTION_LIONUSURPERS : FACTION_LION;
+	type->info.enemyFactions.insert(target ? FACTION_LION : FACTION_LIONUSURPERS);
+	return std::make_shared<Monster>(type);
+}
+
+void ensureTile(const Position& position)
+{
+	if (!g_game.map.getTile(position)) {
+		g_game.map.setTile(position.x, position.y, position.z,
+		                   std::make_unique<StaticTile>(position.x, position.y, position.z));
+	}
+}
+
+class WorldFixture
+{
+public:
+	WorldFixture()
+	    : oldFactionSystem(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_SYSTEM)),
+	      oldRequirePlayer(ConfigManager::getBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY))
+	{
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, true);
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, false);
+		if (!g_moveEvents) {
+			g_moveEvents = std::make_unique<MoveEvents>();
+		}
+	}
+
+	~WorldFixture()
+	{
+		for (auto it = creatures.rbegin(); it != creatures.rend(); ++it) {
+			if (auto creature = it->lock(); creature && !creature->isRemoved()) {
+				g_game.removeCreature(creature.get(), false);
+			}
+		}
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_SYSTEM, oldFactionSystem);
+		ConfigManager::setBoolean(ConfigManager::MONSTER_FACTION_REQUIRE_PLAYER_NEARBY, oldRequirePlayer);
+	}
+
+	void place(const std::shared_ptr<Creature>& creature, const Position& position)
+	{
+		creatures.push_back(creature);
+		ensureTile(position);
+		CHECK(g_game.internalPlaceCreature(creature.get(), position, false, true));
+	}
+
+private:
+	bool oldFactionSystem;
+	bool oldRequirePlayer;
+	std::vector<std::weak_ptr<Creature>> creatures;
+};
+
+void selectTarget(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Creature>& target)
+{
+	monster->addTarget(target.get());
+	CHECK(monster->getTargetList().size() == 1);
+	CHECK(monster->setAttackedCreature(target.get()));
+	CHECK(monster->setFollowCreature(target.get()));
+	monster->setIdle(false);
+}
+
+void moveCreatureForMonster(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Creature>& creature,
+                            const Position& oldPosition, const Position& newPosition)
+{
+	ensureTile(newPosition);
+	monster->onCreatureMove(creature.get(), g_game.map.getTile(newPosition), newPosition,
+	                        g_game.map.getTile(oldPosition), oldPosition, true);
+}
+
+void flushCreatureChecks()
+{
+	for (size_t index = 0; index < EVENT_CREATURECOUNT; ++index) {
+		g_game.checkCreatures(index);
+	}
+}
+
+} // namespace
+
+TEST_CASE(monster_removes_leaving_creature_by_identity)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = std::make_shared<TestCreature>();
+	world.place(monster, Position{500, 500, 7});
+	world.place(target, Position{501, 500, 7});
+	selectTarget(monster, target);
+	target->markDead();
+
+	monster->onRemoveCreature(target.get(), false);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_keeps_other_valid_target_after_one_leaves)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto firstTarget = std::make_shared<TestCreature>();
+	auto secondTarget = makeMonster(true);
+	world.place(monster, Position{510, 500, 7});
+	world.place(firstTarget, Position{511, 500, 7});
+	world.place(secondTarget, Position{512, 500, 7});
+	selectTarget(monster, firstTarget);
+	monster->addTarget(secondTarget.get());
+	CHECK(monster->getTargetList().size() == 2);
+
+	monster->onRemoveCreature(firstTarget.get(), false);
+
+	CHECK(monster->getTargetList().size() == 1);
+	CHECK(monster->getTargetList().front().lock() == secondTarget);
+	CHECK(!monster->getIdleStatus());
+}
+
+TEST_CASE(monster_prunes_target_removed_without_leave_callback)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{520, 500, 7});
+	world.place(target, Position{521, 500, 7});
+	selectTarget(monster, target);
+
+	// A different instance prevents the normal removal callback from reaching
+	// the monster, reproducing stale state after an external transition.
+	target->setInstanceID(1);
+	CHECK(g_game.removeCreature(target.get(), false));
+	std::weak_ptr<Monster> expiredTarget = target;
+	target.reset();
+	flushCreatureChecks();
+	CHECK(expiredTarget.expired());
+	monster->onThink(EVENT_CREATURE_THINK_INTERVAL);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_stays_active_while_aggressive_condition_exists)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = std::make_shared<TestCreature>();
+	world.place(monster, Position{530, 500, 7});
+	world.place(target, Position{531, 500, 7});
+	selectTarget(monster, target);
+	CHECK(monster->addCondition(
+	    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INFIGHT, 10'000, 0, false, 0, true)));
+
+	monster->onRemoveCreature(target.get(), false);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getIdleStatus());
+
+	monster->removeCondition(CONDITION_INFIGHT, true);
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(summon_preserves_master_follow_across_floor_change)
+{
+	WorldFixture world;
+	auto summon = makeMonster();
+	auto master = std::make_shared<TestCreature>();
+	const Position summonPosition{540, 500, 7};
+	const Position oldMasterPosition{541, 500, 7};
+	const Position newMasterPosition{541, 500, 8};
+	world.place(summon, summonPosition);
+	world.place(master, oldMasterPosition);
+	ensureTile(newMasterPosition);
+	CHECK(summon->setMaster(master.get()));
+	CHECK(summon->setFollowCreature(master.get()));
+
+	summon->onCreatureMove(master.get(), g_game.map.getTile(newMasterPosition), newMasterPosition,
+	                       g_game.map.getTile(oldMasterPosition), oldMasterPosition, true);
+
+	CHECK(summon->getMaster() == master);
+	CHECK(summon->getFollowCreatureShared() == master);
+}
+
+TEST_CASE(monster_does_not_duplicate_known_target)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	world.place(monster, Position{550, 500, 7});
+	world.place(target, Position{551, 500, 7});
+
+	monster->addTarget(target.get());
+	monster->addTarget(target.get());
+
+	CHECK(monster->getTargetList().size() == 1);
+}
+
+TEST_CASE(monster_cleans_target_that_moves_out_of_view)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	const Position oldPosition{560, 500, 7};
+	const Position newPosition{590, 500, 7};
+	world.place(monster, Position{559, 500, 7});
+	world.place(target, oldPosition);
+	selectTarget(monster, target);
+
+	moveCreatureForMonster(monster, target, oldPosition, newPosition);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_cleans_target_that_changes_floor)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	const Position oldPosition{600, 500, 7};
+	const Position newPosition{600, 500, 8};
+	world.place(monster, Position{599, 500, 7});
+	world.place(target, oldPosition);
+	selectTarget(monster, target);
+
+	moveCreatureForMonster(monster, target, oldPosition, newPosition);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_cleans_target_that_enters_protection_zone)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto target = makeMonster(true);
+	const Position oldPosition{610, 500, 7};
+	const Position newPosition{612, 500, 7};
+	world.place(monster, Position{609, 500, 7});
+	world.place(target, oldPosition);
+	selectTarget(monster, target);
+	ensureTile(newPosition);
+	g_game.map.getTile(newPosition)->setFlag(TILESTATE_PROTECTIONZONE);
+
+	moveCreatureForMonster(monster, target, oldPosition, newPosition);
+
+	CHECK(monster->getTargetList().empty());
+	CHECK(!monster->getAttackedCreatureShared());
+	CHECK(!monster->getFollowCreatureShared());
+	CHECK(monster->getIdleStatus());
+}
+
+TEST_CASE(monster_prunes_expired_friend_reference)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	auto friendMonster = makeMonster();
+	world.place(monster, Position{620, 500, 7});
+	world.place(friendMonster, Position{621, 500, 7});
+	monster->addFriend(friendMonster.get());
+	CHECK(!monster->getFriendList().empty());
+
+	friendMonster->setInstanceID(1);
+	CHECK(g_game.removeCreature(friendMonster.get(), false));
+	std::weak_ptr<Monster> expiredFriend = friendMonster;
+	friendMonster.reset();
+	flushCreatureChecks();
+	CHECK(expiredFriend.expired());
+	monster->onThink(EVENT_CREATURE_THINK_INTERVAL);
+
+	CHECK(monster->getFriendList().empty());
+}
+
+TEST_CASE(familiar_preserves_master_follow_across_floor_change)
+{
+	WorldFixture world;
+	auto familiar = makeMonster();
+	auto master = std::make_shared<TestCreature>();
+	const Position oldMasterPosition{631, 500, 7};
+	const Position newMasterPosition{631, 500, 8};
+	world.place(familiar, Position{630, 500, 7});
+	world.place(master, oldMasterPosition);
+	familiar->setGuildEmblem(GUILDEMBLEM_ALLY);
+	CHECK(familiar->setMaster(master.get()));
+	CHECK(familiar->setFollowCreature(master.get()));
+
+	moveCreatureForMonster(familiar, master, oldMasterPosition, newMasterPosition);
+
+	CHECK(familiar->getMaster() == master);
+	CHECK(familiar->getFollowCreatureShared() == master);
+}
+
+TEST_CASE(removing_master_definitively_removes_summon)
+{
+	WorldFixture world;
+	auto master = std::make_shared<TestCreature>();
+	auto summon = makeMonster();
+	world.place(master, Position{640, 500, 7});
+	world.place(summon, Position{641, 500, 7});
+	CHECK(summon->setMaster(master.get()));
+	CHECK(summon->setFollowCreature(master.get()));
+
+	CHECK(g_game.removeCreature(master.get(), true));
+
+	CHECK(master->isRemoved());
+	CHECK(summon->isRemoved());
+	CHECK(!summon->getMaster());
+	CHECK(!summon->getFollowCreatureShared());
+}
+
+TEST_CASE(monster_can_return_to_combat_after_becoming_idle)
+{
+	WorldFixture world;
+	auto monster = makeMonster();
+	world.place(monster, Position{650, 500, 7});
+	monster->setIdle(false);
+	monster->setIdle(false);
+	monster->onThink(EVENT_CREATURE_THINK_INTERVAL);
+	CHECK(monster->getIdleStatus());
+
+	auto target = makeMonster(true);
+	world.place(target, Position{651, 500, 7});
+	monster->addTarget(target.get());
+	CHECK(monster->selectTarget(target.get()));
+	monster->setIdle(false);
+
+	CHECK(!monster->getIdleStatus());
+	CHECK(monster->getAttackedCreatureShared() == target);
+	CHECK(monster->getFollowCreatureShared() == target);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_pathfinding.cpp
+++ b/src/tests/test_pathfinding.cpp
@@ -1,0 +1,140 @@
+#include "../otpch.h"
+
+#include "../creature.h"
+#include "../map.h"
+#include "../tile.h"
+#include "test_support.h"
+
+namespace {
+
+class PathCreature final : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+private:
+	std::string name = "pathfinding test creature";
+};
+
+class PathTile final : public DynamicTile
+{
+public:
+	PathTile(uint16_t x, uint16_t y, uint8_t z, bool walkable) : DynamicTile(x, y, z), walkable(walkable) {}
+
+	ReturnValue queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature* = nullptr) const override
+	{
+		return walkable ? RETURNVALUE_NOERROR : RETURNVALUE_NOTPOSSIBLE;
+	}
+
+private:
+	bool walkable;
+};
+
+using BlockedPositions = std::set<std::pair<uint16_t, uint16_t>>;
+
+void addGrid(Map& map, uint16_t minX, uint16_t maxX, uint16_t minY, uint16_t maxY, const BlockedPositions& blocked = {})
+{
+	for (uint16_t y = minY; y <= maxY; ++y) {
+		for (uint16_t x = minX; x <= maxX; ++x) {
+			const bool walkable = !blocked.contains({x, y});
+			map.setTile(x, y, 7, std::make_unique<PathTile>(x, y, 7, walkable));
+		}
+	}
+}
+
+FindPathParams exactPathParams(bool allowDiagonal = true)
+{
+	FindPathParams params;
+	params.clearSight = false;
+	params.allowDiagonal = allowDiagonal;
+	params.maxSearchDist = 32;
+	params.minTargetDist = 0;
+	params.maxTargetDist = 0;
+	return params;
+}
+
+bool findPath(Map& map, const Position& start, const Position& target, const FindPathParams& params,
+              std::vector<Direction>& directions)
+{
+	auto creature = std::make_shared<PathCreature>();
+	Tile* startTile = map.getTile(start);
+	startTile->internalAddThing(creature.get());
+	const bool found = map.getPathMatching(*creature, directions, FrozenPathingConditionCall(target), params);
+	startTile->removeThing(creature.get(), 0);
+	creature->setParent(nullptr);
+	return found;
+}
+
+} // namespace
+
+TEST_CASE(pathfinding_crosses_quadtree_leaf_boundaries)
+{
+	Map map;
+	addGrid(map, 96, 112, 96, 104);
+	std::vector<Direction> directions;
+	CHECK(findPath(map, Position{97, 100, 7}, Position{111, 100, 7}, exactPathParams(false), directions));
+	CHECK(directions.size() == 14);
+}
+
+TEST_CASE(pathfinding_routes_around_a_wall_through_a_gap)
+{
+	Map map;
+	BlockedPositions wall;
+	for (uint16_t y = 96; y <= 104; ++y) {
+		if (y != 102) {
+			wall.emplace(104, y);
+		}
+	}
+	addGrid(map, 96, 112, 96, 104, wall);
+
+	std::vector<Direction> directions;
+	CHECK(findPath(map, Position{100, 100, 7}, Position{108, 100, 7}, exactPathParams(false), directions));
+	CHECK(directions.size() > 8);
+}
+
+TEST_CASE(pathfinding_fails_when_a_wall_has_no_gap)
+{
+	Map map;
+	BlockedPositions wall;
+	for (uint16_t y = 96; y <= 104; ++y) {
+		wall.emplace(104, y);
+	}
+	addGrid(map, 96, 112, 96, 104, wall);
+
+	std::vector<Direction> directions;
+	CHECK(!findPath(map, Position{100, 100, 7}, Position{108, 100, 7}, exactPathParams(false), directions));
+	CHECK(directions.empty());
+}
+
+TEST_CASE(pathfinding_respects_diagonal_setting)
+{
+	Map map;
+	addGrid(map, 200, 202, 200, 202, {{201, 200}, {200, 201}});
+
+	std::vector<Direction> diagonalDirections;
+	CHECK(findPath(map, Position{200, 200, 7}, Position{201, 201, 7}, exactPathParams(true), diagonalDirections));
+	CHECK(diagonalDirections.size() == 1);
+
+	std::vector<Direction> cardinalDirections;
+	// The existing algorithm always checks all eight neighbors for the start
+	// node; allowDiagonal only narrows later expansions. Preserve that behavior.
+	CHECK(findPath(map, Position{200, 200, 7}, Position{201, 201, 7}, exactPathParams(false), cardinalDirections));
+	CHECK(cardinalDirections.size() == 1);
+}
+
+TEST_CASE(pathfinding_same_start_and_target_returns_empty_path)
+{
+	Map map;
+	addGrid(map, 300, 300, 300, 300);
+	std::vector<Direction> directions;
+	CHECK(findPath(map, Position{300, 300, 7}, Position{300, 300, 7}, exactPathParams(), directions));
+	CHECK(directions.empty());
+}
+
+TFS_TEST_MAIN()

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -990,8 +990,6 @@ void Tile::addThing(int32_t, Thing* thing)
 			return;
 		}
 
-		g_game.map.clearSpectatorCache();
-
 		creature->setParent(this);
 		CreatureVector* creatures = makeCreatures();
 		creatures->insert(creatures->begin(), std::move(creatureRef));
@@ -1229,8 +1227,6 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 			auto it = std::find_if(creatures->begin(), creatures->end(),
 				[creature](const auto& sp) { return sp.get() == creature; });
 			if (it != creatures->end()) {
-				g_game.map.clearSpectatorCache();
-
 				creatures->erase(it);
 			}
 		}
@@ -1666,8 +1662,6 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 			logSharedCreatureLockFailure("Tile::internalAddThing", creature);
 			return;
 		}
-
-		g_game.map.clearSpectatorCache();
 
 		creature->setParent(this);
 		CreatureVector* creatures = makeCreatures();


### PR DESCRIPTION
## Summary

- remove the persistent dynamic spectator cache and its global invalidation calls
- make spectator queries read live quadtree state
- stop NPCs from retaining copied player spectator ownership
- restrict monster target refreshes to the visible floor and refresh idle state once per scan
- cache only the active structural quadtree leaf during each path search
- fix the Callgrind capture script so instrumentation and dumps work with Valgrind 3.22
- add live spectator, ownership, floor/filter, pathfinding, and lookup benchmark coverage

## Why

The spectator cache retained `shared_ptr<Creature>` results and depended on broad invalidation from tile mutations. That extended object lifetimes, created invalidation work during movement, and risked stale dynamic state.

Pathfinding repeatedly traversed the quadtree for adjacent tiles even though searches commonly remain inside the same 8x8 structural leaf. The replacement cache is local to one search and stores only structural lookup state; it does not cache walkability or dynamic decisions. `Tile::queryAdd` and all pathfinding flags remain unchanged.

## Impact and measurements

- `Map::moveCreature`: 30.489 us to 8.738 us average for the comparable 24-move startup workload (~71% reduction)
- controlled 4096-tile lookup benchmark: 90.523 us with full traversal versus 28.606 us with the local leaf cache (~3.16x faster)
- live `Map::getSpectators` queries cost 5-10 us versus ~3.4 us with persistent cached results; this is the explicit trade-off for live state and bounded ownership
- the existing two-scan movement union remains unchanged to preserve callback order, floor projection, and deduplication behavior
- no NPC walkability cache was added because no measured gain justified dynamic invalidation risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed area-combat performance metrics, reporting, and slowest-sample breakdowns.
  * Added combat “profile context” for both scripted and non-scripted spell execution.
  * Exposed NPC spectator querying via a new `getSpectators()` API.
  * Added microbenchmarks for tile lookup and combat impact dispatch.

* **Bug Fixes**
  * Improved monster friend/target pruning and idle-state refresh correctness.
  * Refined pathfinding tile access and spectator visibility handling.
  * Removed spectator caching behavior to keep spectator results consistent.

* **Tests**
  * Added/expanded unit tests for spectators, pathfinding, area combat conditions, and monster targeting/idle events.

* **Chores / Profiling**
  * Updated Callgrind capture configuration and control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->