### PR TITLE
perf(combat): diagnose area combat spikes

### DIFF
--- a/src/benchs/bench_spectators.cpp
+++ b/src/benchs/bench_spectators.cpp
@@ -3,6 +3,9 @@
 #include "../spectators.h"
 
 #include "../creature.h"
+#include "../game.h"
+#include "../instance_utils.h"
+#include "../player.h"
 
 #include <absl/container/flat_hash_set.h>
 #include <benchmark/benchmark.h>
@@ -27,6 +30,18 @@ private:
 };
 
 using Vec = std::vector<std::shared_ptr<Creature>>;
+
+SpectatorVec makePlayerSpectators(int64_t playerCount)
+{
+	SpectatorVec spectators;
+	for (int64_t i = 0; i < playerCount; ++i) {
+		auto player = std::make_shared<Player>(nullptr);
+		player->setInstanceID((i & 1) == 0 ? 1 : 2);
+		spectators.emplace_back(std::move(player));
+	}
+	spectators.partitionByType();
+	return spectators;
+}
 
 // Builds a destination of `size` creatures and a source of `size` creatures
 // where `overlapPct`% are shared with the destination.
@@ -130,5 +145,42 @@ static void bench_addSpectators_linearFind(benchmark::State& state)
 	}
 }
 BENCHMARK(bench_addSpectators_linearFind)->ArgsProduct({{35, 150}, {0, 50, 90}});
+
+static void bench_combatImpactEffect_filterCopy(benchmark::State& state)
+{
+	const SpectatorVec spectators = makePlayerSpectators(state.range(1));
+	const Position position{100, 100, 7};
+	const int64_t tileCount = state.range(0);
+
+	for ([[maybe_unused]] auto _ : state) {
+		for (int64_t tile = 0; tile < tileCount; ++tile) {
+			SpectatorVec filtered;
+			for (const auto& spectator : spectators.players()) {
+				Player* player = static_cast<Player*>(spectator.get());
+				if (player->compareInstance(1)) {
+					filtered.emplace_back(spectator);
+				}
+			}
+			Game::addMagicEffect(filtered, position, CONST_ME_POFF);
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * tileCount);
+}
+BENCHMARK(bench_combatImpactEffect_filterCopy)->ArgsProduct({{1, 9, 25, 81, 225}, {0, 1, 20, 100}});
+
+static void bench_combatImpactEffect_direct(benchmark::State& state)
+{
+	const SpectatorVec spectators = makePlayerSpectators(state.range(1));
+	const Position position{100, 100, 7};
+	const int64_t tileCount = state.range(0);
+
+	for ([[maybe_unused]] auto _ : state) {
+		for (int64_t tile = 0; tile < tileCount; ++tile) {
+			InstanceUtils::sendMagicEffectToInstance(spectators, position, CONST_ME_POFF, 1);
+		}
+	}
+	state.SetItemsProcessed(state.iterations() * tileCount);
+}
+BENCHMARK(bench_combatImpactEffect_direct)->ArgsProduct({{1, 9, 25, 81, 225}, {0, 1, 20, 100}});
 
 BENCHMARK_MAIN();

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1689,7 +1689,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::MANA, WeaponProficiencyGain_t::KILL);
 			}
 
-			if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
+			if (damageCopy.blockType == BLOCK_NONE || damageCopy.blockType == BLOCK_ARMOR) {
 				for (const auto& condition : params.conditionList) {
 					if (caster == creature.get() || !creature->isImmune(condition->getType())) {
 						auto conditionCopy = condition->clone();

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -893,17 +893,16 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 			++metrics->impactEffects;
 		}
 		if (caster) {
-			SpectatorVec filtered;
-			for (const auto& s : spectators.players()) {
-				Player *p = static_cast<Player*>(s.get());
-				if (p->compareInstance(caster->getInstanceID())) {
-					filtered.emplace_back(s);
-					if (metrics) {
+			if (metrics) {
+				for (const auto& spectator : spectators.players()) {
+					const Player* player = static_cast<const Player*>(spectator.get());
+					if (player->compareInstance(caster->getInstanceID())) {
 						++metrics->effectRecipients;
 					}
 				}
 			}
-			Game::addMagicEffect(filtered, tile->getPosition(), params.impactEffect);
+			InstanceUtils::sendMagicEffectToInstance(
+			    spectators, tile->getPosition(), params.impactEffect, caster->getInstanceID());
 		} else {
 			g_game.addMagicEffect(tile->getPosition(), params.impactEffect, 0);
 		}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -18,6 +18,8 @@
 #include "spells.h"
 #include "weapons.h"
 
+#include <optional>
+
 extern Game g_game;
 
 namespace {
@@ -97,11 +99,16 @@ static int32_t getEffectiveMagicLevel(const Player* player, CombatType_t combatT
 	return std::max<int32_t>(0, magicLevel);
 }
 
-std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, const Direction dir)
+std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, const Direction dir,
+                           AreaCombatMetricsSample* metrics)
 {
 	auto casterPos = getNextPosition(dir, targetPos);
 
 	std::vector<Tile*> vec;
+	if (metrics) {
+		metrics->areaRows = area.getRows();
+		metrics->areaColumns = area.getCols();
+	}
 
 	auto& center = area.getCenter();
 
@@ -109,30 +116,48 @@ std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, co
 	for (uint32_t row = 0; row < area.getRows(); ++row, ++tmpPos.y) {
 		for (uint32_t col = 0; col < area.getCols(); ++col, ++tmpPos.x) {
 			if (area(row, col)) {
+				if (metrics) {
+					++metrics->activeCells;
+					++metrics->sightChecks;
+				}
 				if (g_game.isSightClear(casterPos, tmpPos, true)) {
 					Tile* tile = g_game.map.getTile(tmpPos);
 					if (!tile) {
 						auto newTile = std::make_unique<StaticTile>(tmpPos.x, tmpPos.y, tmpPos.z);
 						tile = newTile.get();
 						g_game.map.setTile(tmpPos, std::move(newTile));
+						if (metrics) {
+							++metrics->tilesCreated;
+						}
 					}
 					vec.push_back(tile);
+				} else if (metrics) {
+					++metrics->sightRejected;
 				}
 			}
 		}
 		tmpPos.x -= static_cast<uint16_t>(area.getCols());
 	}
+	if (metrics) {
+		metrics->tilesReturned = vec.size();
+	}
 	return vec;
 }
 
-std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targetPos, const AreaCombat* area)
+std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targetPos, const AreaCombat* area,
+                                 AreaCombatMetricsSample* metrics = nullptr)
 {
 	if (targetPos.z >= MAP_MAX_LAYERS) {
 		return {};
 	}
 
 	if (area) {
-		return getList(area->getArea(centerPos, targetPos), targetPos, getDirectionTo(targetPos, centerPos));
+		return getList(area->getArea(centerPos, targetPos), targetPos, getDirectionTo(targetPos, centerPos), metrics);
+	}
+	if (metrics) {
+		metrics->areaRows = 1;
+		metrics->areaColumns = 1;
+		metrics->activeCells = 1;
 	}
 
 	Tile* tile = g_game.map.getTile(targetPos);
@@ -140,6 +165,12 @@ std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targ
 		auto newTile = std::make_unique<StaticTile>(targetPos.x, targetPos.y, targetPos.z);
 		tile = newTile.get();
 		g_game.map.setTile(targetPos, std::move(newTile));
+		if (metrics) {
+			++metrics->tilesCreated;
+		}
+	}
+	if (metrics) {
+		metrics->tilesReturned = 1;
 	}
 	return {tile};
 }
@@ -758,7 +789,8 @@ bool Combat::loadCallBack(CallBackParam key, LuaScriptInterface* scriptInterface
 	return false;
 }
 
-void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params)
+void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params,
+                               AreaCombatMetricsSample* metrics)
 {
 	if (params.itemId != 0) {
 		uint16_t itemId = params.itemId;
@@ -832,6 +864,9 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 
 				auto field = std::dynamic_pointer_cast<MagicField>(itemPtr);
 				if (field) {
+					if (metrics) {
+						++metrics->fieldsCreated;
+					}
 					if (CreatureVector* creatures = tile->getCreatures()) {
 						const CreatureVector creatureRefs = *creatures;
 						for (const auto& creature : creatureRefs) {
@@ -847,16 +882,25 @@ void Combat::combatTileEffects(const SpectatorVec& spectators, Creature* caster,
 	}
 
 	if (params.tileCallback) {
+		if (metrics) {
+			++metrics->tileCallbacks;
+		}
 		params.tileCallback->onTileCombat(caster, tile);
 	}
 
 	if (params.impactEffect != CONST_ME_NONE) {
+		if (metrics) {
+			++metrics->impactEffects;
+		}
 		if (caster) {
 			SpectatorVec filtered;
 			for (const auto& s : spectators.players()) {
 				Player *p = static_cast<Player*>(s.get());
 				if (p->compareInstance(caster->getInstanceID())) {
 					filtered.emplace_back(s);
+					if (metrics) {
+						++metrics->effectRecipients;
+					}
 				}
 			}
 			Game::addMagicEffect(filtered, tile->getPosition(), params.impactEffect);
@@ -1394,8 +1438,40 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
                           const CombatParams& params)
 {
 	PerformanceScope performanceScope(PerformanceMetric::CombatDoAreaCombat);
+	const bool metricsEnabled = g_performanceMetrics.isEnabled();
+	std::optional<AreaCombatMetricsSample> areaMetrics;
+	if (metricsEnabled) {
+		areaMetrics.emplace();
+		areaMetrics->positionX = position.x;
+		areaMetrics->positionY = position.y;
+		areaMetrics->positionZ = position.z;
+		areaMetrics->itemId = params.itemId;
+		areaMetrics->impactEffect = params.impactEffect;
+		areaMetrics->scripted = params.profileScripted || !damage.instantSpellName.empty();
+		areaMetrics->hasConditions = !params.conditionList.empty();
+		areaMetrics->hasTileCallback = params.tileCallback != nullptr;
+		areaMetrics->hasTargetCallback = params.targetCallback != nullptr;
+	}
+	AreaCombatMetricsSample* metrics = areaMetrics ? &*areaMetrics : nullptr;
+
+	using MetricsClock = std::chrono::steady_clock;
+	const auto areaStarted = metricsEnabled ? MetricsClock::now() : MetricsClock::time_point{};
+	auto phaseStarted = areaStarted;
+	const auto finishPhase = [&](PerformanceMetric metric, uint64_t AreaCombatMetricsSample::*destination) {
+		if (!metrics) {
+			return;
+		}
+		const auto now = MetricsClock::now();
+		const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - phaseStarted).count();
+		metrics->*destination = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
+		g_performanceMetrics.record(metric, metrics->*destination);
+		phaseStarted = now;
+	};
+
 	auto tiles =
-	    caster ? getCombatArea(caster->getPosition(), position, area) : getCombatArea(position, position, area);
+	    caster ? getCombatArea(caster->getPosition(), position, area, metrics)
+	           : getCombatArea(position, position, area, metrics);
+	finishPhase(PerformanceMetric::CombatAreaBuildTiles, &AreaCombatMetricsSample::buildTilesNanoseconds);
 
 	Player* casterPlayer = caster ? caster->getPlayer() : nullptr;
 	const bool wpEnabled = casterPlayer && ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED);
@@ -1444,6 +1520,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 			damage.critical = true;
 		}
 	}
+	finishPhase(PerformanceMetric::CombatAreaPrepareDamage, &AreaCombatMetricsSample::prepareDamageNanoseconds);
 
 	int32_t maxX = 0;
 	int32_t maxY = 0;
@@ -1461,6 +1538,10 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, true, true, rangeX, rangeX, rangeY, rangeY);
+	if (metrics) {
+		metrics->spectators = spectators.size();
+	}
+	finishPhase(PerformanceMetric::CombatAreaCollectSpectators, &AreaCombatMetricsSample::collectSpectatorsNanoseconds);
 
 	postCombatEffects(caster, position, params);
 
@@ -1469,10 +1550,13 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 	for (Tile* tile : tiles) {
 		if (canDoCombat(caster, tile, params.aggressive) != RETURNVALUE_NOERROR) {
+			if (metrics) {
+				++metrics->combatRejected;
+			}
 			continue;
 		}
 
-		combatTileEffects(spectators, caster, tile, params);
+		combatTileEffects(spectators, caster, tile, params, metrics);
 
 		if (CreatureVector* creatures = tile->getCreatures()) {
 			const Creature* topCreature = tile->getTopCreature();
@@ -1490,6 +1574,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 				if (!params.aggressive ||
 				    (caster != creature.get() && Combat::canDoCombat(caster, creature.get()) == RETURNVALUE_NOERROR)) {
 					toDamageCreatures.push_back(creature);
+					if (metrics) {
+						++metrics->targets;
+					}
 
 					if (params.targetCasterOrTopMost) {
 						break;
@@ -1498,6 +1585,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 			}
 		}
 	}
+	finishPhase(PerformanceMetric::CombatAreaProcessTiles, &AreaCombatMetricsSample::processTilesNanoseconds);
 
 	CombatDamage leechCombat;
 	leechCombat.origin = ORIGIN_NONE;
@@ -1563,8 +1651,13 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 		bool success = false;
 		if (damageCopy.primary.type != COMBAT_MANADRAIN) {
-			if (g_game.combatBlockHit(damageCopy, caster, creature.get(), params.blockedByShield, params.blockedByArmor,
-			                          params.itemId != 0, params.ignoreResistances)) {
+			const bool fullyBlocked = g_game.combatBlockHit(
+			    damageCopy, caster, creature.get(), params.blockedByShield, params.blockedByArmor,
+			    params.itemId != 0, params.ignoreResistances);
+			if (metrics && damageCopy.blockType != BLOCK_NONE) {
+				++metrics->blockedTargets;
+			}
+			if (fullyBlocked) {
 				continue;
 			}
 			if (params.resetDamageMultiplier >= 0.0f) {
@@ -1584,6 +1677,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		}
 
 		if (success) {
+			if (metrics) {
+				++metrics->appliedTargets;
+			}
 			if (casterPlayer && wpEnabled && damageCopy.primary.type != COMBAT_HEALING && damageCopy.primary.type != COMBAT_MANADRAIN) {
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::LIFE, WeaponProficiencyGain_t::HIT);
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::MANA, WeaponProficiencyGain_t::HIT);
@@ -1598,6 +1694,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 				for (const auto& condition : params.conditionList) {
 					if (caster == creature.get() || !creature->isImmune(condition->getType())) {
 						auto conditionCopy = condition->clone();
+						if (metrics) {
+							++metrics->conditionClones;
+						}
 						if (caster) {
 							conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
 							conditionCopy->setPositionParam(CONDITION_PARAM_CASTER_POSITION, caster->getPosition());
@@ -1670,8 +1769,22 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		}
 
 		if (params.targetCallback) {
+			if (metrics) {
+				++metrics->targetCallbacks;
+			}
 			params.targetCallback->onTargetCombat(caster, creature.get());
 		}
+	}
+	finishPhase(PerformanceMetric::CombatAreaApplyTargets, &AreaCombatMetricsSample::applyTargetsNanoseconds);
+
+	if (metrics) {
+		const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(MetricsClock::now() - areaStarted).count();
+		metrics->totalNanoseconds = elapsed > 0 ? static_cast<uint64_t>(elapsed) : 0;
+		const Monster* casterMonster = caster ? caster->getMonster() : nullptr;
+		const std::string_view monsterName = casterMonster ? std::string_view(casterMonster->getName()) : std::string_view{};
+		const std::string_view spellName = !damage.instantSpellName.empty() ? std::string_view(damage.instantSpellName)
+		                                                               : std::string_view(params.profileName);
+		g_performanceMetrics.recordAreaCombat(*metrics, monsterName, spellName);
 	}
 }
 

--- a/src/combat.h
+++ b/src/combat.h
@@ -10,11 +10,13 @@
 #include "thing.h"
 
 #include <memory>
+#include <string>
 
 class Condition;
 class Creature;
 class MatrixArea;
 class Item;
+struct AreaCombatMetricsSample;
 
 struct Position;
 
@@ -74,6 +76,7 @@ struct CombatParams
 	CombatParams& operator=(CombatParams&&) noexcept = default;
 
 	std::forward_list<std::unique_ptr<const Condition>> conditionList;
+	std::string profileName;
 
 	std::unique_ptr<ValueCallback> valueCallback;
 	std::unique_ptr<TileCallback> tileCallback;
@@ -96,6 +99,7 @@ struct CombatParams
 	bool aggressive = true;
 	bool useCharges = false;
 	bool ignoreResistances = false;
+	bool profileScripted = false;
 
 	uint8_t chainEffect = CONST_ME_NONE;
 
@@ -167,6 +171,11 @@ public:
 	void postCombatEffects(Creature* caster, const Position& pos) const { postCombatEffects(caster, pos, params); }
 
 	void setOrigin(CombatOrigin origin) { params.origin = origin; }
+	void setProfileContext(std::string_view name, bool scripted)
+	{
+		params.profileName = name;
+		params.profileScripted = scripted;
+	}
 
 	void setupChain(const class Weapon* weapon);
 	bool doCombatChain(Creature* caster, Creature* target, bool aggressive, std::string instantSpellName = {}) const;
@@ -181,7 +190,7 @@ private:
 	                               const CombatParams& params, bool aggressive);
 
 	static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile,
-	                              const CombatParams& params);
+	                              const CombatParams& params, AreaCombatMetricsSample* metrics = nullptr);
 	CombatDamage getCombatDamage(Creature* creature, Creature* target, std::string_view instantSpellName) const;
 
 	// configurable

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1429,6 +1429,7 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(uint32_t interval)
 {
+	PerformanceScope performanceScope(PerformanceMetric::CreatureExecuteConditions);
 	std::vector<Condition*> tempConditions;
 	tempConditions.reserve(conditions.size());
 	for (const auto& c : conditions) {

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -145,6 +145,7 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			return false;
 		}
 
+		combatSpell->getCombat()->setProfileContext(spell->scriptName, true);
 		combatSpell->getCombat()->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue, 0);
 		sb.ownedSpell = std::move(combatSpell);
 	} else {
@@ -347,6 +348,7 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			combat->setParam(COMBAT_PARAM_EFFECT, spell->effect);
 		}
 
+		combat->setProfileContext(spell->name, false);
 		combat->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue, 0);
 		sb.ownedSpell = std::make_unique<CombatSpell>(combat, spell->needTarget, spell->needDirection);
 	}

--- a/src/performance_metrics.cpp
+++ b/src/performance_metrics.cpp
@@ -13,6 +13,7 @@ PerformanceMetrics g_performanceMetrics;
 
 namespace {
 constexpr auto REPORT_INTERVAL = std::chrono::seconds(5);
+constexpr auto AREA_COMBAT_SLOW_SAMPLE_THRESHOLD = std::chrono::milliseconds(1);
 
 constexpr std::array<std::string_view, static_cast<size_t>(PerformanceMetric::Count)> METRIC_NAMES = {
 	"TaskReactor::runOnce", "TaskReactor::drainInbox", "TaskReactor::drainReadyTasks",
@@ -22,7 +23,9 @@ constexpr std::array<std::string_view, static_cast<size_t>(PerformanceMetric::Co
 	"Game::internalMoveCreature", "Map::getPathMatching", "Map::moveCreature", "Map::getSpectators",
 	"Monster::onThink",
 	"Monster::onWalk", "Monster::doAttacking", "CombatSpell::castSpell",
-	"Combat::doCombat", "Combat::doAreaCombat",
+	"Combat::doCombat", "Combat::doAreaCombat", "Combat::area.buildTiles",
+	"Combat::area.prepareDamage", "Combat::area.collectSpectators", "Combat::area.processTiles+collectTargets",
+	"Combat::area.applyTargets", "Creature::executeConditions",
 };
 
 size_t histogramIndex(uint64_t nanoseconds) noexcept
@@ -147,6 +150,53 @@ void PerformanceMetrics::recordPathRequest(bool success, uint64_t nodesVisited, 
 	path.pathLength.fetch_add(pathLength, std::memory_order_relaxed);
 }
 
+void PerformanceMetrics::recordAreaCombat(const AreaCombatMetricsSample& sample, std::string_view monsterName,
+                                          std::string_view spellName) noexcept
+{
+	if (!isEnabled()) {
+		return;
+	}
+
+	areaCombat.casts.fetch_add(1, std::memory_order_relaxed);
+	areaCombat.areaRows.fetch_add(sample.areaRows, std::memory_order_relaxed);
+	areaCombat.areaColumns.fetch_add(sample.areaColumns, std::memory_order_relaxed);
+	areaCombat.activeCells.fetch_add(sample.activeCells, std::memory_order_relaxed);
+	areaCombat.sightChecks.fetch_add(sample.sightChecks, std::memory_order_relaxed);
+	areaCombat.sightRejected.fetch_add(sample.sightRejected, std::memory_order_relaxed);
+	areaCombat.tilesReturned.fetch_add(sample.tilesReturned, std::memory_order_relaxed);
+	areaCombat.tilesCreated.fetch_add(sample.tilesCreated, std::memory_order_relaxed);
+	areaCombat.combatRejected.fetch_add(sample.combatRejected, std::memory_order_relaxed);
+	areaCombat.spectators.fetch_add(sample.spectators, std::memory_order_relaxed);
+	areaCombat.targets.fetch_add(sample.targets, std::memory_order_relaxed);
+	areaCombat.blockedTargets.fetch_add(sample.blockedTargets, std::memory_order_relaxed);
+	areaCombat.appliedTargets.fetch_add(sample.appliedTargets, std::memory_order_relaxed);
+	areaCombat.conditionClones.fetch_add(sample.conditionClones, std::memory_order_relaxed);
+	areaCombat.tileCallbacks.fetch_add(sample.tileCallbacks, std::memory_order_relaxed);
+	areaCombat.targetCallbacks.fetch_add(sample.targetCallbacks, std::memory_order_relaxed);
+	areaCombat.impactEffects.fetch_add(sample.impactEffects, std::memory_order_relaxed);
+	areaCombat.fieldsCreated.fetch_add(sample.fieldsCreated, std::memory_order_relaxed);
+	areaCombat.effectRecipients.fetch_add(sample.effectRecipients, std::memory_order_relaxed);
+
+	if (sample.totalNanoseconds < static_cast<uint64_t>(
+	        std::chrono::duration_cast<std::chrono::nanoseconds>(AREA_COMBAT_SLOW_SAMPLE_THRESHOLD).count()) ||
+	    sample.totalNanoseconds <= slowestAreaCombat.maximumNanoseconds.load(std::memory_order_relaxed)) {
+		return;
+	}
+
+	try {
+		std::scoped_lock lock(slowestAreaCombat.mutex);
+		if (sample.totalNanoseconds <= slowestAreaCombat.maximumNanoseconds.load(std::memory_order_relaxed)) {
+			return;
+		}
+		slowestAreaCombat.sample = sample;
+		slowestAreaCombat.monsterName.assign(monsterName);
+		slowestAreaCombat.spellName.assign(spellName);
+		slowestAreaCombat.maximumNanoseconds.store(sample.totalNanoseconds, std::memory_order_relaxed);
+	} catch (...) {
+		// Profiling must never interfere with combat execution.
+	}
+}
+
 void PerformanceMetrics::maybeReport()
 {
 	if (!isEnabled()) {
@@ -162,7 +212,7 @@ void PerformanceMetrics::maybeReport()
 	}
 
 	std::string report;
-	report.reserve(4096);
+	report.reserve(8192);
 	for (size_t metricIndex = 0; metricIndex < metrics.size(); ++metricIndex) {
 		auto& data = metrics[metricIndex];
 		const uint64_t calls = data.calls.exchange(0, std::memory_order_relaxed);
@@ -192,6 +242,69 @@ void PerformanceMetrics::maybeReport()
 		reactor.deferred.exchange(0, std::memory_order_relaxed),
 		reactor.expired.exchange(0, std::memory_order_relaxed),
 		reactor.dropped.exchange(0, std::memory_order_relaxed));
+
+	const uint64_t areaCombatCasts = areaCombat.casts.exchange(0, std::memory_order_relaxed);
+	if (areaCombatCasts > 0) {
+		report += fmt::format(
+			"[Perf] area_combat casts={} rows={} cols={} active_cells={} sight_checks={} sight_rejected={} "
+			"tiles={} tiles_created={} combat_rejected={} spectators={} collect_targets={} blocked={} applied={} "
+			"condition_clones={} tile_callbacks={} target_callbacks={} effects={} fields={} recipients={}\n",
+			areaCombatCasts,
+			areaCombat.areaRows.exchange(0, std::memory_order_relaxed),
+			areaCombat.areaColumns.exchange(0, std::memory_order_relaxed),
+			areaCombat.activeCells.exchange(0, std::memory_order_relaxed),
+			areaCombat.sightChecks.exchange(0, std::memory_order_relaxed),
+			areaCombat.sightRejected.exchange(0, std::memory_order_relaxed),
+			areaCombat.tilesReturned.exchange(0, std::memory_order_relaxed),
+			areaCombat.tilesCreated.exchange(0, std::memory_order_relaxed),
+			areaCombat.combatRejected.exchange(0, std::memory_order_relaxed),
+			areaCombat.spectators.exchange(0, std::memory_order_relaxed),
+			areaCombat.targets.exchange(0, std::memory_order_relaxed),
+			areaCombat.blockedTargets.exchange(0, std::memory_order_relaxed),
+			areaCombat.appliedTargets.exchange(0, std::memory_order_relaxed),
+			areaCombat.conditionClones.exchange(0, std::memory_order_relaxed),
+			areaCombat.tileCallbacks.exchange(0, std::memory_order_relaxed),
+			areaCombat.targetCallbacks.exchange(0, std::memory_order_relaxed),
+			areaCombat.impactEffects.exchange(0, std::memory_order_relaxed),
+			areaCombat.fieldsCreated.exchange(0, std::memory_order_relaxed),
+			areaCombat.effectRecipients.exchange(0, std::memory_order_relaxed));
+	}
+
+	AreaCombatMetricsSample slowestAreaSample;
+	std::string slowestAreaMonster;
+	std::string slowestAreaSpell;
+	uint64_t slowestAreaNanoseconds = 0;
+	{
+		std::scoped_lock lock(slowestAreaCombat.mutex);
+		slowestAreaNanoseconds = slowestAreaCombat.maximumNanoseconds.exchange(0, std::memory_order_relaxed);
+		if (slowestAreaNanoseconds > 0) {
+			slowestAreaSample = slowestAreaCombat.sample;
+			slowestAreaMonster = std::move(slowestAreaCombat.monsterName);
+			slowestAreaSpell = std::move(slowestAreaCombat.spellName);
+			slowestAreaCombat.sample = {};
+		}
+	}
+	if (slowestAreaNanoseconds > 0) {
+		report += fmt::format(
+			"[Perf] area_combat slowest_us={:.3f} monster={} spell={} mode={} pos=({},{},{}) "
+			"geometry={}x{} active={} tiles={} created={} targets={} item={} effect={} "
+			"conditions={} tile_callback={} target_callback={} "
+			"phases_us={{build:{:.3f},prepare:{:.3f},spectators:{:.3f},process_tiles_collect_targets:{:.3f},apply_targets:{:.3f}}}\n",
+			slowestAreaNanoseconds / 1'000.0,
+			slowestAreaMonster.empty() ? "none" : slowestAreaMonster,
+			slowestAreaSpell.empty() ? "unknown" : slowestAreaSpell,
+			slowestAreaSample.scripted ? "scripted" : "native",
+			slowestAreaSample.positionX, slowestAreaSample.positionY, slowestAreaSample.positionZ,
+			slowestAreaSample.areaRows, slowestAreaSample.areaColumns, slowestAreaSample.activeCells,
+			slowestAreaSample.tilesReturned, slowestAreaSample.tilesCreated, slowestAreaSample.targets,
+			slowestAreaSample.itemId, slowestAreaSample.impactEffect,
+			slowestAreaSample.hasConditions, slowestAreaSample.hasTileCallback, slowestAreaSample.hasTargetCallback,
+			slowestAreaSample.buildTilesNanoseconds / 1'000.0,
+			slowestAreaSample.prepareDamageNanoseconds / 1'000.0,
+			slowestAreaSample.collectSpectatorsNanoseconds / 1'000.0,
+			slowestAreaSample.processTilesNanoseconds / 1'000.0,
+			slowestAreaSample.applyTargetsNanoseconds / 1'000.0);
+	}
 
 	uint64_t slowestNanoseconds = 0;
 	std::string slowestDescription;

--- a/src/performance_metrics.h
+++ b/src/performance_metrics.h
@@ -37,7 +37,52 @@ enum class PerformanceMetric : uint8_t
 	CombatSpellCastSpell,
 	CombatDoCombat,
 	CombatDoAreaCombat,
+	CombatAreaBuildTiles,
+	CombatAreaPrepareDamage,
+	CombatAreaCollectSpectators,
+	CombatAreaProcessTiles,
+	CombatAreaApplyTargets,
+	CreatureExecuteConditions,
 	Count,
+};
+
+struct AreaCombatMetricsSample
+{
+	uint64_t buildTilesNanoseconds = 0;
+	uint64_t prepareDamageNanoseconds = 0;
+	uint64_t collectSpectatorsNanoseconds = 0;
+	uint64_t processTilesNanoseconds = 0;
+	uint64_t applyTargetsNanoseconds = 0;
+	uint64_t totalNanoseconds = 0;
+
+	uint64_t areaRows = 0;
+	uint64_t areaColumns = 0;
+	uint64_t activeCells = 0;
+	uint64_t sightChecks = 0;
+	uint64_t sightRejected = 0;
+	uint64_t tilesReturned = 0;
+	uint64_t tilesCreated = 0;
+	uint64_t combatRejected = 0;
+	uint64_t spectators = 0;
+	uint64_t targets = 0;
+	uint64_t blockedTargets = 0;
+	uint64_t appliedTargets = 0;
+	uint64_t conditionClones = 0;
+	uint64_t tileCallbacks = 0;
+	uint64_t targetCallbacks = 0;
+	uint64_t impactEffects = 0;
+	uint64_t fieldsCreated = 0;
+	uint64_t effectRecipients = 0;
+
+	uint16_t positionX = 0;
+	uint16_t positionY = 0;
+	uint16_t itemId = 0;
+	uint16_t impactEffect = 0;
+	uint8_t positionZ = 0;
+	bool scripted = false;
+	bool hasConditions = false;
+	bool hasTileCallback = false;
+	bool hasTargetCallback = false;
 };
 
 class PerformanceMetrics
@@ -54,6 +99,8 @@ public:
 	void recordReactorCallbackSource(uint64_t nanoseconds, std::string_view description,
 	                                 std::string_view origin) noexcept;
 	void recordPathRequest(bool success, uint64_t nodesVisited, uint64_t tilesRead, uint64_t pathLength) noexcept;
+	void recordAreaCombat(const AreaCombatMetricsSample& sample, std::string_view monsterName,
+	                      std::string_view spellName) noexcept;
 	void maybeReport();
 
 private:
@@ -86,6 +133,29 @@ private:
 		std::atomic<uint64_t> pathLength{0};
 	};
 
+	struct AreaCombatData
+	{
+		std::atomic<uint64_t> casts{0};
+		std::atomic<uint64_t> areaRows{0};
+		std::atomic<uint64_t> areaColumns{0};
+		std::atomic<uint64_t> activeCells{0};
+		std::atomic<uint64_t> sightChecks{0};
+		std::atomic<uint64_t> sightRejected{0};
+		std::atomic<uint64_t> tilesReturned{0};
+		std::atomic<uint64_t> tilesCreated{0};
+		std::atomic<uint64_t> combatRejected{0};
+		std::atomic<uint64_t> spectators{0};
+		std::atomic<uint64_t> targets{0};
+		std::atomic<uint64_t> blockedTargets{0};
+		std::atomic<uint64_t> appliedTargets{0};
+		std::atomic<uint64_t> conditionClones{0};
+		std::atomic<uint64_t> tileCallbacks{0};
+		std::atomic<uint64_t> targetCallbacks{0};
+		std::atomic<uint64_t> impactEffects{0};
+		std::atomic<uint64_t> fieldsCreated{0};
+		std::atomic<uint64_t> effectRecipients{0};
+	};
+
 	struct SlowestReactorCallback
 	{
 		std::mutex mutex;
@@ -94,10 +164,21 @@ private:
 		std::string origin;
 	};
 
+	struct SlowestAreaCombat
+	{
+		std::mutex mutex;
+		std::atomic<uint64_t> maximumNanoseconds{0};
+		AreaCombatMetricsSample sample;
+		std::string monsterName;
+		std::string spellName;
+	};
+
 	std::array<MetricData, static_cast<size_t>(PerformanceMetric::Count)> metrics;
 	ReactorData reactor;
 	PathData path;
+	AreaCombatData areaCombat;
 	SlowestReactorCallback slowestReactorCallback;
+	SlowestAreaCombat slowestAreaCombat;
 	std::atomic_bool enabled{false};
 	std::atomic<int64_t> nextReportNanoseconds{0};
 };

--- a/src/tests/test_combat.cpp
+++ b/src/tests/test_combat.cpp
@@ -1,0 +1,107 @@
+#include "../otpch.h"
+
+#include "../combat.h"
+#include "../events.h"
+#include "../game.h"
+#include "../matrixarea.h"
+#include "../scriptmanager.h"
+#include "../tile.h"
+
+#include "test_support.h"
+
+namespace {
+
+class EventsGuard
+{
+public:
+	EventsGuard() : previous(g_events) { g_events = &events; }
+	~EventsGuard() { g_events = previous; }
+
+private:
+	Events* previous;
+	Events events;
+};
+
+class TestTarget final : public Creature
+{
+public:
+	explicit TestTarget(BlockType_t blockType) : blockType(blockType) {}
+
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+	BlockType_t blockHit(const std::shared_ptr<Creature>&, CombatType_t, int32_t& damage, bool, bool, bool, bool,
+	                     CombatOrigin) override
+	{
+		if (blockType != BLOCK_NONE) {
+			damage = 0;
+		}
+		return blockType;
+	}
+
+private:
+	std::string name = "area combat test target";
+	BlockType_t blockType;
+};
+
+void addCreature(const Position& position, const std::shared_ptr<TestTarget>& creature)
+{
+	if (!g_game.map.getTile(position)) {
+		g_game.map.setTile(position.x, position.y, position.z,
+		                   std::make_unique<StaticTile>(position.x, position.y, position.z));
+	}
+
+	Tile* tile = g_game.map.getTile(position);
+	tile->internalAddThing(creature.get());
+	g_game.map.getQTNode(position.x, position.y)->addCreature(creature.get());
+}
+
+void removeCreature(const std::shared_ptr<TestTarget>& creature)
+{
+	Tile* tile = creature->getTile();
+	const Position position = tile->getPosition();
+	g_game.map.getQTNode(position.x, position.y)->removeCreature(creature.get());
+	tile->removeThing(creature.get(), 0);
+	creature->setParent(nullptr);
+}
+
+} // namespace
+
+TEST_CASE(area_conditions_use_each_targets_block_state)
+{
+	EventsGuard eventsGuard;
+	const Position blockedPosition{300, 300, 7};
+	const Position unblockedPosition{301, 300, 7};
+	auto blockedTarget = std::make_shared<TestTarget>(BLOCK_DEFENSE);
+	auto unblockedTarget = std::make_shared<TestTarget>(BLOCK_NONE);
+	addCreature(blockedPosition, blockedTarget);
+	addCreature(unblockedPosition, unblockedTarget);
+
+	AreaCombat area;
+	area.setupArea({3, 1}, 1);
+
+	CombatDamage damage;
+	damage.primary.type = COMBAT_PHYSICALDAMAGE;
+	damage.primary.value = -100;
+	damage.origin = ORIGIN_SPELL;
+
+	CombatParams params;
+	params.aggressive = false;
+	params.conditionList.push_front(
+	    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INFIGHT, 10'000));
+
+	Combat::doAreaCombat(nullptr, unblockedPosition, &area, damage, params);
+
+	CHECK(!blockedTarget->hasCondition(CONDITION_INFIGHT));
+	CHECK(unblockedTarget->hasCondition(CONDITION_INFIGHT));
+
+	removeCreature(blockedTarget);
+	removeCreature(unblockedTarget);
+}
+
+TFS_TEST_MAIN()


### PR DESCRIPTION
## Summary

This PR diagnoses the isolated `Combat::doAreaCombat` wall-clock spike observed on the performance branch and applies only the two changes supported by code inspection and controlled measurements.

It is intentionally based on `perf/remove-dynamic-cache-and-optimize-pathfinding` / PR #177. Merge that dependency first.

## What changed

- adds disabled-by-default phase metrics for area construction, damage preparation, spectator collection, tile/target processing, target application, and condition execution;
- records aggregate geometry/work counters and only captures monster/spell context for slow samples;
- removes the temporary `SpectatorVec` copy created for every impact-effect tile and uses the existing instance-aware direct-send helper;
- fixes area conditions to use the current target's `damageCopy.blockType`;
- adds a regression test proving blocked and unblocked targets in the same area keep independent condition state;
- adds controlled effect-delivery benchmarks for 1/9/25/81/225 tiles and 0/1/20/100 players.

No persistent cache, pathfinding change, combat deferral, RNG change, damage change, callback reordering, or lifetime/ownership reduction was introduced.

## Evidence

The captured production interval had 410 area casts: p95 0.524 ms, p99 1.048 ms, and one 43.569 ms maximum. `Map::getSpectators` peaked at 96 us. Because the spike was a single wall-clock outlier and could not be reproduced as sustained CPU work, structural tile lookup, target reserve, field handling, and callback changes were rejected pending the new phase data.

Random-interleaved benchmark means for the changed helper:

| Tiles / players | Filter-copy | Direct helper | Speedup |
|---|---:|---:|---:|
| 25 / 20 | 4,145 ns | 1,354 ns | 3.06x |
| 225 / 20 | 48,032 ns | 11,577 ns | 4.15x |
| 25 / 100 | 28,411 ns | 11,021 ns | 2.58x |
| 225 / 100 | 172,435 ns | 70,434 ns | 2.45x |

Callgrind on 225 tiles / 100 players recorded 9,853,833 total instructions for filter-copy versus 9,126,046 for direct send (common process startup included), while the measured workload time fell from 36.819 ms to 15.238 ms under Callgrind.

## Validation

- full Release server build: passed;
- CTest: 18/18 passed;
- regression negative proof: old block-state line fails the new test; corrected line passes;
- ASan with leak detection: passed;
- combined ASan + UBSan: passed;
- Valgrind Memcheck: 0 errors, 0 leaks, 1,119 allocations / 1,119 frees;
- Callgrind controlled area-combat test: completed; `Combat::doAreaCombat` recorded 17,907 instructions in the minimal two-target scenario;
- `perf stat`: unavailable because this WSL kernel has no matching `perf` package installed.

The original 43 ms live spike was not reproducible without the same online monster/spell/player scenario. The added slow-sample context and phase counters are the next evidence-gathering step; this PR does not claim the local helper optimization alone removes that outlier.
