### PR TITLE
Optimize Bestiary, Market, Stash, Prey, and Battle Pass

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -36,8 +36,7 @@ PlayerStorageKeys = {
 
     -- Battle Pass
     -- The detailed state is persisted in player KV under the "battlepass" scope.
-    -- These numeric storages are intentionally reserved for timers/version markers.
-    battlePassSeasonEpoch = 90730,
+    -- This numeric storage is reserved for the active reward timer.
     battlePassDoubleSkillUntil = 90731,
 
     -- Forge system

--- a/data/migrations/59.lua
+++ b/data/migrations/59.lua
@@ -1,3 +1,96 @@
 function onUpdateDatabase()
-	return false
+	logMigration("Updating database to version 60 (move Market persistence to C++)")
+
+	local function columnExists(tableName, columnName)
+		local query = "SELECT COUNT(*) AS `count` FROM `information_schema`.`COLUMNS`"
+			.. " WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '" .. tableName .. "'"
+			.. " AND `COLUMN_NAME` = '" .. columnName .. "'"
+		local queryResult = db.storeQuery(query)
+		local exists = queryResult and result.getNumber(queryResult, "count") > 0
+		if queryResult then
+			result.free(queryResult)
+		end
+		return exists
+	end
+
+	local function indexExists(tableName, indexName)
+		local query = "SELECT COUNT(*) AS `count` FROM `information_schema`.`STATISTICS`"
+			.. " WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '" .. tableName .. "'"
+			.. " AND `INDEX_NAME` = '" .. indexName .. "'"
+		local queryResult = db.storeQuery(query)
+		local exists = queryResult and result.getNumber(queryResult, "count") > 0
+		if queryResult then
+			result.free(queryResult)
+		end
+		return exists
+	end
+
+	local function ensureColumn(tableName, columnName, definition)
+		return columnExists(tableName, columnName)
+			or db.query("ALTER TABLE `" .. tableName .. "` ADD COLUMN `" .. columnName .. "` " .. definition)
+	end
+
+	local function ensureIndex(tableName, indexName, columns)
+		return indexExists(tableName, indexName)
+			or db.query("ALTER TABLE `" .. tableName .. "` ADD INDEX `" .. indexName .. "` (" .. columns .. ")")
+	end
+
+	if not db.query([[CREATE TABLE IF NOT EXISTS `market_offers` (
+		`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+		`player_id` INT NOT NULL,
+		`sale` TINYINT NOT NULL DEFAULT 0,
+		`itemtype` SMALLINT UNSIGNED NOT NULL,
+		`amount` SMALLINT UNSIGNED NOT NULL,
+		`created` INT UNSIGNED NOT NULL,
+		`anonymous` TINYINT NOT NULL DEFAULT 0,
+		`price` INT UNSIGNED NOT NULL DEFAULT 0,
+		`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+		`attributes` MEDIUMBLOB NULL,
+		PRIMARY KEY (`id`),
+		KEY `idx_market_offers_item_sale_price` (`itemtype`, `sale`, `price`, `created`),
+		KEY `idx_market_offers_player_created` (`player_id`, `created`),
+		KEY `idx_market_offers_created` (`created`),
+		CONSTRAINT `fk_market_offers_player` FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
+	) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8]]) then
+		return false
+	end
+
+	if not db.query([[CREATE TABLE IF NOT EXISTS `market_history` (
+		`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+		`player_id` INT NOT NULL,
+		`sale` TINYINT NOT NULL DEFAULT 0,
+		`itemtype` SMALLINT UNSIGNED NOT NULL,
+		`amount` SMALLINT UNSIGNED NOT NULL,
+		`price` INT UNSIGNED NOT NULL DEFAULT 0,
+		`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+		`expires_at` BIGINT UNSIGNED NOT NULL,
+		`inserted` BIGINT UNSIGNED NOT NULL,
+		`state` TINYINT UNSIGNED NOT NULL,
+		PRIMARY KEY (`id`),
+		KEY `idx_market_history_player_inserted` (`player_id`, `inserted`),
+		CONSTRAINT `fk_market_history_player` FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
+	) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8]]) then
+		return false
+	end
+
+	if not db.query([[CREATE TABLE IF NOT EXISTS `market_statistics` (
+		`itemtype` SMALLINT UNSIGNED NOT NULL,
+		`sale` TINYINT NOT NULL DEFAULT 0,
+		`day` INT UNSIGNED NOT NULL,
+		`transactions` INT UNSIGNED NOT NULL DEFAULT 0,
+		`total_price` BIGINT UNSIGNED NOT NULL DEFAULT 0,
+		`highest_price` INT UNSIGNED NOT NULL DEFAULT 0,
+		`lowest_price` INT UNSIGNED NOT NULL DEFAULT 0,
+		PRIMARY KEY (`itemtype`, `sale`, `day`)
+	) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8]]) then
+		return false
+	end
+
+	return ensureColumn("market_offers", "tier", "TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `price`")
+		and ensureColumn("market_offers", "attributes", "MEDIUMBLOB NULL AFTER `tier`")
+		and ensureColumn("market_history", "tier", "TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `price`")
+		and ensureIndex("market_offers", "idx_market_offers_item_sale_price", "`itemtype`, `sale`, `price`, `created`")
+		and ensureIndex("market_offers", "idx_market_offers_player_created", "`player_id`, `created`")
+		and ensureIndex("market_offers", "idx_market_offers_created", "`created`")
+		and ensureIndex("market_history", "idx_market_history_player_inserted", "`player_id`, `inserted`")
 end

--- a/data/migrations/59.lua
+++ b/data/migrations/59.lua
@@ -13,16 +13,19 @@ function onUpdateDatabase()
 		return exists
 	end
 
-	local function indexExists(tableName, indexName)
-		local query = "SELECT COUNT(*) AS `count` FROM `information_schema`.`STATISTICS`"
+	local function indexSignature(tableName, indexName)
+		local columns = {}
+		local query = "SELECT `COLUMN_NAME` FROM `information_schema`.`STATISTICS`"
 			.. " WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = '" .. tableName .. "'"
-			.. " AND `INDEX_NAME` = '" .. indexName .. "'"
+			.. " AND `INDEX_NAME` = '" .. indexName .. "' ORDER BY `SEQ_IN_INDEX`"
 		local queryResult = db.storeQuery(query)
-		local exists = queryResult and result.getNumber(queryResult, "count") > 0
 		if queryResult then
+			repeat
+				columns[#columns + 1] = result.getString(queryResult, "COLUMN_NAME")
+			until not result.next(queryResult)
 			result.free(queryResult)
 		end
-		return exists
+		return table.concat(columns, ",")
 	end
 
 	local function ensureColumn(tableName, columnName, definition)
@@ -30,9 +33,17 @@ function onUpdateDatabase()
 			or db.query("ALTER TABLE `" .. tableName .. "` ADD COLUMN `" .. columnName .. "` " .. definition)
 	end
 
-	local function ensureIndex(tableName, indexName, columns)
-		return indexExists(tableName, indexName)
-			or db.query("ALTER TABLE `" .. tableName .. "` ADD INDEX `" .. indexName .. "` (" .. columns .. ")")
+	local function ensureIndex(tableName, indexName, columns, expectedSignature)
+		local currentSignature = indexSignature(tableName, indexName)
+		if currentSignature == expectedSignature then
+			return true
+		end
+
+		local dropIndex = currentSignature ~= "" and "DROP INDEX `" .. indexName .. "`, " or ""
+		return db.query(
+			"ALTER TABLE `" .. tableName .. "` " .. dropIndex ..
+			"ADD INDEX `" .. indexName .. "` (" .. columns .. ")"
+		) and indexSignature(tableName, indexName) == expectedSignature
 	end
 
 	if not db.query([[CREATE TABLE IF NOT EXISTS `market_offers` (
@@ -89,8 +100,8 @@ function onUpdateDatabase()
 	return ensureColumn("market_offers", "tier", "TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `price`")
 		and ensureColumn("market_offers", "attributes", "MEDIUMBLOB NULL AFTER `tier`")
 		and ensureColumn("market_history", "tier", "TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `price`")
-		and ensureIndex("market_offers", "idx_market_offers_item_sale_price", "`itemtype`, `sale`, `price`, `created`")
-		and ensureIndex("market_offers", "idx_market_offers_player_created", "`player_id`, `created`")
-		and ensureIndex("market_offers", "idx_market_offers_created", "`created`")
-		and ensureIndex("market_history", "idx_market_history_player_inserted", "`player_id`, `inserted`")
+		and ensureIndex("market_offers", "idx_market_offers_item_sale_price", "`itemtype`, `sale`, `price`, `created`", "itemtype,sale,price,created")
+		and ensureIndex("market_offers", "idx_market_offers_player_created", "`player_id`, `created`", "player_id,created")
+		and ensureIndex("market_offers", "idx_market_offers_created", "`created`", "created")
+		and ensureIndex("market_history", "idx_market_history_player_inserted", "`player_id`, `inserted`", "player_id,inserted")
 end

--- a/data/migrations/60.lua
+++ b/data/migrations/60.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/data/migrations/60.lua
+++ b/data/migrations/60.lua
@@ -30,21 +30,33 @@ function onUpdateDatabase()
 		return table.concat(columns, ",")
 	end
 
-	local function hasPlayerForeignKey()
+	-- Returns "cascade" when the FK exists with ON DELETE CASCADE,
+	-- "wrong_rule" and the constraint name when it exists with a different rule,
+	-- or false when no matching FK exists.
+	local function checkPlayerForeignKey()
 		local queryResult = db.storeQuery([[
-			SELECT COUNT(*) AS `count`
-			FROM `information_schema`.`KEY_COLUMN_USAGE`
-			WHERE `CONSTRAINT_SCHEMA` = DATABASE()
-			  AND `TABLE_NAME` = 'player_supplystash'
-			  AND `COLUMN_NAME` = 'player_id'
-			  AND `REFERENCED_TABLE_NAME` = 'players'
-			  AND `REFERENCED_COLUMN_NAME` = 'id'
+			SELECT `rc`.`CONSTRAINT_NAME`, `rc`.`DELETE_RULE`
+			FROM `information_schema`.`KEY_COLUMN_USAGE` AS `kcu`
+			JOIN `information_schema`.`REFERENTIAL_CONSTRAINTS` AS `rc`
+			  ON `rc`.`CONSTRAINT_SCHEMA` = `kcu`.`CONSTRAINT_SCHEMA`
+			  AND `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
+			WHERE `kcu`.`CONSTRAINT_SCHEMA` = DATABASE()
+			  AND `kcu`.`TABLE_NAME` = 'player_supplystash'
+			  AND `kcu`.`COLUMN_NAME` = 'player_id'
+			  AND `kcu`.`REFERENCED_TABLE_NAME` = 'players'
+			  AND `kcu`.`REFERENCED_COLUMN_NAME` = 'id'
+			LIMIT 1
 		]])
-		local exists = queryResult and result.getNumber(queryResult, "count") > 0
-		if queryResult then
-			result.free(queryResult)
+		if not queryResult then
+			return false
 		end
-		return exists
+		local constraintName = result.getString(queryResult, "CONSTRAINT_NAME")
+		local deleteRule = result.getString(queryResult, "DELETE_RULE")
+		result.free(queryResult)
+		if deleteRule == "CASCADE" then
+			return "cascade"
+		end
+		return "wrong_rule", constraintName
 	end
 
 	if not db.query([[
@@ -81,7 +93,17 @@ function onUpdateDatabase()
 		end
 	end
 
-	if not hasPlayerForeignKey() then
+	local fkStatus, constraintName = checkPlayerForeignKey()
+	if fkStatus == "wrong_rule" then
+		if not db.query(
+			"ALTER TABLE `player_supplystash` DROP FOREIGN KEY `" .. constraintName .. "`"
+		) then
+			return false
+		end
+		fkStatus = false
+	end
+
+	if not fkStatus then
 		if not db.query([[
 			DELETE `stash` FROM `player_supplystash` AS `stash`
 			LEFT JOIN `players` AS `player` ON `player`.`id` = `stash`.`player_id`

--- a/data/migrations/60.lua
+++ b/data/migrations/60.lua
@@ -1,3 +1,99 @@
 function onUpdateDatabase()
-	return false
+	logMigration("Updating database to version 61 (move Supply Stash persistence to C++)")
+
+	local function columnExists(columnName)
+		local queryResult = db.storeQuery(
+			"SELECT COUNT(*) AS `count` FROM `information_schema`.`COLUMNS`" ..
+			" WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'player_supplystash'" ..
+			" AND `COLUMN_NAME` = '" .. columnName .. "'"
+		)
+		local exists = queryResult and result.getNumber(queryResult, "count") > 0
+		if queryResult then
+			result.free(queryResult)
+		end
+		return exists
+	end
+
+	local function primaryKeySignature()
+		local columns = {}
+		local queryResult = db.storeQuery(
+			"SELECT `COLUMN_NAME` FROM `information_schema`.`STATISTICS`" ..
+			" WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'player_supplystash'" ..
+			" AND `INDEX_NAME` = 'PRIMARY' ORDER BY `SEQ_IN_INDEX`"
+		)
+		if queryResult then
+			repeat
+				columns[#columns + 1] = result.getString(queryResult, "COLUMN_NAME")
+			until not result.next(queryResult)
+			result.free(queryResult)
+		end
+		return table.concat(columns, ",")
+	end
+
+	local function hasPlayerForeignKey()
+		local queryResult = db.storeQuery([[
+			SELECT COUNT(*) AS `count`
+			FROM `information_schema`.`KEY_COLUMN_USAGE`
+			WHERE `CONSTRAINT_SCHEMA` = DATABASE()
+			  AND `TABLE_NAME` = 'player_supplystash'
+			  AND `COLUMN_NAME` = 'player_id'
+			  AND `REFERENCED_TABLE_NAME` = 'players'
+			  AND `REFERENCED_COLUMN_NAME` = 'id'
+		]])
+		local exists = queryResult and result.getNumber(queryResult, "count") > 0
+		if queryResult then
+			result.free(queryResult)
+		end
+		return exists
+	end
+
+	if not db.query([[
+		CREATE TABLE IF NOT EXISTS `player_supplystash` (
+			`player_id` INT NOT NULL,
+			`itemtype` SMALLINT UNSIGNED NOT NULL,
+			`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+			`amount` INT UNSIGNED NOT NULL DEFAULT 0,
+			PRIMARY KEY (`player_id`, `itemtype`, `tier`),
+			CONSTRAINT `player_supplystash_player_fk`
+				FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8
+	]]) then
+		return false
+	end
+
+	if not columnExists("tier") and not db.query(
+		"ALTER TABLE `player_supplystash` ADD COLUMN `tier` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `itemtype`"
+	) then
+		return false
+	end
+
+	local primaryKey = primaryKeySignature()
+	if primaryKey ~= "player_id,itemtype,tier" then
+		local query
+		if primaryKey == "" then
+			query = "ALTER TABLE `player_supplystash` ADD PRIMARY KEY (`player_id`, `itemtype`, `tier`)"
+		else
+			query = "ALTER TABLE `player_supplystash` DROP PRIMARY KEY, ADD PRIMARY KEY (`player_id`, `itemtype`, `tier`)"
+		end
+		if not db.query(query) or primaryKeySignature() ~= "player_id,itemtype,tier" then
+			logMigration("Failed to enforce the Supply Stash primary key; existing data was left untouched")
+			return false
+		end
+	end
+
+	if not hasPlayerForeignKey() then
+		if not db.query([[
+			DELETE `stash` FROM `player_supplystash` AS `stash`
+			LEFT JOIN `players` AS `player` ON `player`.`id` = `stash`.`player_id`
+			WHERE `player`.`id` IS NULL
+		]]) or not db.query([[
+			ALTER TABLE `player_supplystash`
+			ADD CONSTRAINT `player_supplystash_player_fk`
+			FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
+		]]) then
+			return false
+		end
+	end
+
+	return true
 end

--- a/data/migrations/61.lua
+++ b/data/migrations/61.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/data/scripts/actions/systems/supply_stash.lua
+++ b/data/scripts/actions/systems/supply_stash.lua
@@ -10,12 +10,7 @@ function action.onUse(player, item, fromPosition, target, toPosition, isHotkey)
         return true
     end
 
-    if not CustomSupplyStash then
-        player:sendCancelMessage("The supply stash is not available.")
-        return true
-    end
-
-    if not CustomSupplyStash.open then
+    if not CustomSupplyStash or not CustomSupplyStash.open then
         player:sendCancelMessage("The supply stash is not available.")
         return true
     end
@@ -28,7 +23,7 @@ function action.onUse(player, item, fromPosition, target, toPosition, isHotkey)
         depotId = tonumber(ok and value or nil) or 0
     end
 
-    local ok, err = pcall(function()
+    local ok = pcall(function()
         CustomSupplyStash.open(player, depotId)
     end)
 

--- a/data/scripts/creaturescripts/others/custom_bestiary.lua
+++ b/data/scripts/creaturescripts/others/custom_bestiary.lua
@@ -175,18 +175,31 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 	end
 
 	for playerGuid, player in pairs(players) do
-		local killsToAdd = 1
+		local oldKills
+		local newKills
+		local charmPointsAwarded = false
+		if Game.takeBestiaryKill then
+			local handled
+			handled, oldKills, newKills, charmPointsAwarded = Game.takeBestiaryKill(player, raceId, creature:getId())
+			if not handled then
+				goto continue
+			end
+		else
+			oldKills, newKills = addBestiaryKill(player, playerGuid, raceId, 1)
+		end
+
+		local bonusKills = 0
 		local doubleChance = TaskBoard and TaskBoard.getBountyTalismanBonus and
 			TaskBoard.getBountyTalismanBonus(player, raceId, 3) or 0
 		if doubleChance > 0 and math.random(1, 10000) <= doubleChance then
-			killsToAdd = 2
+			bonusKills = 1
+			_, newKills = addBestiaryKill(player, playerGuid, raceId, bonusKills)
 		end
-		local oldKills, newKills = addBestiaryKill(player, playerGuid, raceId, killsToAdd)
 		local oldProgress = CustomBestiary.getProgress(entry, oldKills)
 		local newProgress = CustomBestiary.getProgress(entry, newKills)
 
 		if CustomBestiary.updateKillCache then
-			CustomBestiary.updateKillCache(playerGuid, raceId, killsToAdd, oldKills, newKills)
+			CustomBestiary.updateKillCache(playerGuid, raceId, 1 + bonusKills, oldKills, newKills)
 		elseif CustomBestiary.invalidatePlayer then
 			CustomBestiary.invalidatePlayer(playerGuid)
 		end
@@ -196,7 +209,11 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		elseif CustomBestiary.sendTracker then
 			CustomBestiary.sendTracker(player)
 		end
-		if oldKills < entry.toKill and newKills >= entry.toKill then
+		if charmPointsAwarded then
+			if CustomBestiary.updateCharmPointCache then
+				CustomBestiary.updateCharmPointCache(playerGuid, entry.charmPoints)
+			end
+		elseif oldKills < entry.toKill and newKills >= entry.toKill then
 			addPlayerCharmPoints(playerGuid, entry.charmPoints)
 		end
 		if CustomBestiary.sendProgress then
@@ -205,6 +222,8 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		if newProgress > oldProgress then
 			sendBestiaryUnlockMessage(player, entry, newProgress)
 		end
+
+		::continue::
 	end
 	return true
 end

--- a/data/scripts/creaturescripts/others/custom_bestiary.lua
+++ b/data/scripts/creaturescripts/others/custom_bestiary.lua
@@ -182,7 +182,8 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 			local handled
 			handled, oldKills, newKills, charmPointsAwarded = Game.takeBestiaryKill(player, raceId, creature:getId())
 			if not handled then
-				goto continue
+				oldKills, newKills = addBestiaryKill(player, playerGuid, raceId, 1)
+				charmPointsAwarded = false
 			end
 		else
 			oldKills, newKills = addBestiaryKill(player, playerGuid, raceId, 1)
@@ -222,8 +223,6 @@ function bestiaryKill.onDeath(creature, corpse, killer, mostDamageKiller, lastHi
 		if newProgress > oldProgress then
 			sendBestiaryUnlockMessage(player, entry, newProgress)
 		end
-
-		::continue::
 	end
 	return true
 end

--- a/data/scripts/lib/custom_bestiary.lua
+++ b/data/scripts/lib/custom_bestiary.lua
@@ -257,7 +257,8 @@ function CustomBestiary.registerMonster(monsterType, mask)
 
 	CustomBestiary.monstersByRaceId[raceId] = entry
 	if Game.registerBestiaryMonsterData then
-		Game.registerBestiaryMonsterData(entry.raceId, entry.name, entry.toKill, entry.secondUnlock, entry.charmPoints,
+		Game.registerBestiaryMonsterData(entry.raceId, entry.name, entry.toKill, entry.firstUnlock, entry.secondUnlock,
+			entry.charmPoints,
 			entry.outfit.type or 0, entry.outfit.head or 0, entry.outfit.body or 0,
 			entry.outfit.legs or 0, entry.outfit.feet or 0, entry.outfit.addons or 0)
 	end

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -85,15 +85,9 @@ local function clamp(value, minValue, maxValue)
 	return value
 end
 
-local function getSeasonStore()
-	return kv.scoped("battlepass"):scoped("season")
-end
-
 local function getSeason()
 	local seasonConfig = config.season or {}
-	local store = getSeasonStore()
 	local configuredId = tostring(seasonConfig.id or "season")
-	local activeConfigId = store:get("configId")
 	local epoch = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonEpoch)) or -1
 	local beginTime = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt)) or -1
 
@@ -105,10 +99,6 @@ local function getSeason()
 		end
 		Game.setStorageValue(GlobalStorageKeys.battlePassSeasonEpoch, epoch)
 		Game.setStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt, beginTime)
-	end
-
-	if activeConfigId ~= configuredId then
-		store:set("configId", configuredId)
 	end
 
 	local durationDays = math.max(1, tonumber(seasonConfig.durationDays) or 35)
@@ -181,7 +171,6 @@ local function loadState(player)
 
 	if type(state) ~= "table" or state.seasonId ~= season.id then
 		state = resetStateForSeason(season)
-		player:setStorageValue(PlayerStorageKeys.battlePassSeasonEpoch, season.epoch)
 	else
 		ensureStateTables(state)
 	end
@@ -674,13 +663,10 @@ local rewardTypes = {
 	prey = 7,
 	xpBoost = 8,
 	regeneration = 9,
-	overloadForge = 10,
-	instantReward = 11,
 	boostedExercise = 12,
 	charms = 13,
 	outfit = 14,
 	extraSkill = 15,
-	elementalOutfit = 16,
 	multiItem = 17,
 	choiceItem = 18,
 }
@@ -744,9 +730,6 @@ local function makeReward(step, freeReward, definition)
 		if #reward.randomValues == 0 then
 			reward.randomValues = makeOutfitValues(definition.female)
 		end
-	elseif definition.type == "elementalOutfit" then
-		reward.maleOutfit = definition.maleOutfit or {}
-		reward.femaleOutfit = definition.femaleOutfit or {}
 	end
 
 	return reward
@@ -895,34 +878,61 @@ local function addItemsToBattlePassInbox(player, items)
 		return false, "Your Battle Pass inbox is not available."
 	end
 
+	local normalizedItems = {}
 	local neededSlots = 0
 	for _, entry in ipairs(items) do
-		local itemType = ItemType(entry.itemId)
-		if not itemType or itemType:getId() ~= entry.itemId then
+		if type(entry) ~= "table" then
 			return false, "This season has an invalid reward item configured."
 		end
-		neededSlots = neededSlots + (itemType:isStackable() and 1 or entry.count)
+
+		local itemId = tonumber(entry.itemId) or 0
+		local count = math.max(1, math.floor(tonumber(entry.count) or 1))
+		local charges = math.max(0, math.floor(tonumber(entry.charges) or 0))
+		local itemType = ItemType(itemId)
+		if not itemType or itemType:getId() ~= itemId then
+			return false, "This season has an invalid reward item configured."
+		end
+
+		local stackSize = itemType:isStackable() and math.max(1, itemType:getStackSize()) or 1
+		neededSlots = neededSlots + math.ceil(count / stackSize)
+		normalizedItems[#normalizedItems + 1] = {
+			itemId = itemId,
+			count = count,
+			charges = charges,
+			stackSize = stackSize,
+		}
 	end
 	if inbox:getEmptySlots() < neededSlots then
 		return false, "Your Battle Pass inbox does not have enough room for this reward."
 	end
 
-	for _, entry in ipairs(items) do
-		local itemType = ItemType(entry.itemId)
-		local deliveries = itemType:isStackable() and 1 or entry.count
-		local amount = itemType:isStackable() and entry.count or 1
-		for _ = 1, deliveries do
+	local deliveredItems = {}
+	local deliveryFlags = FLAG_NOLIMIT | FLAG_IGNOREAUTOSTACK
+	local function rollbackDeliveredItems()
+		for index = #deliveredItems, 1, -1 do
+			deliveredItems[index]:remove()
+		end
+	end
+
+	for _, entry in ipairs(normalizedItems) do
+		local remaining = entry.count
+		while remaining > 0 do
+			local amount = math.min(remaining, entry.stackSize)
 			local item = Game.createItem(entry.itemId, amount)
 			if not item then
+				rollbackDeliveredItems()
 				return false, "Could not create the reward item."
 			end
-			if entry.charges and entry.charges > 0 then
+			if entry.charges > 0 then
 				item:setAttribute(ITEM_ATTRIBUTE_CHARGES, entry.charges)
 			end
-			if inbox:addItemEx(item, INDEX_WHEREEVER, FLAG_NOLIMIT) ~= RETURNVALUE_NOERROR then
+			if inbox:addItemEx(item, INDEX_WHEREEVER, deliveryFlags) ~= RETURNVALUE_NOERROR then
 				item:remove()
+				rollbackDeliveredItems()
 				return false, "Your Battle Pass inbox does not have enough room for this reward."
 			end
+			deliveredItems[#deliveredItems + 1] = item
+			remaining = remaining - amount
 		end
 	end
 	return true
@@ -1382,7 +1392,6 @@ function BattlePassSystem.resetPlayer(player)
 		return false, "Player not found."
 	end
 	getStore(player):remove("state")
-	player:setStorageValue(PlayerStorageKeys.battlePassSeasonEpoch, -1)
 	local state, store, season, daily = loadState(player)
 	saveState(store, state)
 	if supportsCustomNetwork(player) then
@@ -1435,11 +1444,9 @@ function BattlePassSystem.unlockShop(player)
 end
 
 function BattlePassSystem.startNewSeason()
-	local seasonStore = getSeasonStore()
 	local currentEpoch = tonumber(Game.getStorageValue(GlobalStorageKeys.battlePassSeasonEpoch)) or 0
 	Game.setStorageValue(GlobalStorageKeys.battlePassSeasonEpoch, math.max(1, currentEpoch + 1))
 	Game.setStorageValue(GlobalStorageKeys.battlePassSeasonStartedAt, os.time())
-	seasonStore:set("configId", tostring(config.season.id or "season"))
 
 	for _, onlinePlayer in ipairs(Game.getPlayers()) do
 		BattlePassSystem.resetPlayer(onlinePlayer)

--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -888,6 +888,9 @@ local function addItemsToBattlePassInbox(player, items)
 		local itemId = tonumber(entry.itemId) or 0
 		local count = math.max(1, math.floor(tonumber(entry.count) or 1))
 		local charges = math.max(0, math.floor(tonumber(entry.charges) or 0))
+		if itemId <= 0 then
+			return false, "This season has an invalid reward item configured."
+		end
 		local itemType = ItemType(itemId)
 		if not itemType or itemType:getId() ~= itemId then
 			return false, "This season has an invalid reward item configured."

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -1367,13 +1367,13 @@ local function buildMarketDescriptions(itemId)
 end
 
 local function fetchMarketStatistics(itemId, actionType)
-	local since = os.time() - (MARKET_STATISTICS_DAYS * 24 * 60 * 60)
+	local since = os.time() - ((MARKET_STATISTICS_DAYS - 1) * 24 * 60 * 60)
 	local firstDay = math.floor(since / 86400) * 86400
 	return Game.getMarketStatistics(itemId, actionType, firstDay, MARKET_STATISTICS_DAYS)
 end
 
 local function refreshMarketStatistics()
-	local since = os.time() - (MARKET_STATISTICS_DAYS * 24 * 60 * 60)
+	local since = os.time() - ((MARKET_STATISTICS_DAYS - 1) * 24 * 60 * 60)
 	local firstDay = math.floor(since / 86400) * 86400
 	return Game.refreshMarketStatistics(firstDay, MARKET_STATE_ACCEPTED)
 end

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -151,22 +151,6 @@ local function hasSerializedAttributes(attributes)
 	return type(attributes) == "string" and #attributes > 0
 end
 
--- Provide a SQL literal representing an empty serialized attributes value.
--- @return SQL expression for an empty attributes value; uses `db.escapeBlob("", 0)` when available, otherwise the empty-string literal `''`.
-local function emptyAttributesSql()
-	return db.escapeBlob and db.escapeBlob("", 0) or "''"
-end
-
--- Escapes serialized item attributes for safe SQL insertion, or returns the SQL used to represent empty attributes.
--- @param attributes Serialized attributes string, or nil/empty when there are no serialized attributes.
--- @return SQL expression suitable for inserting the attributes into a query (`db.escapeBlob(attributes, #attributes)` is used when available, otherwise `db.escapeString(attributes)`); returns the database-specific empty-attributes SQL when attributes are not serialized.
-local function escapeAttributes(attributes)
-	if hasSerializedAttributes(attributes) then
-		return db.escapeBlob and db.escapeBlob(attributes, #attributes) or db.escapeString(attributes)
-	end
-	return emptyAttributesSql()
-end
-
 -- Rollback a DB-claimed offer (used when delivery fails after DB claim).
 -- For full-amount offers (deleted): tries to re-INSERT with original data.
 -- Restores a market offer in the database after a previously claimed (deleted or reduced) offer.
@@ -176,22 +160,10 @@ end
 -- @param acceptedAmount Number of units to restore to the offer.
 -- @return The result of the database query (truthy on success, `false` on failure).
 local function rollbackOfferClaim(offer, acceptedAmount)
-	if acceptedAmount >= offer.amount then
-		-- Full offer was DELETE'd — restore it
-		return db.query(
-			"INSERT INTO `market_offers` (`id`, `player_id`, `sale`, `itemtype`, `amount`, `created`, `anonymous`, `price`, `tier`, `attributes`) VALUES (" ..
-			offer.id .. ", " .. offer.playerId .. ", " .. offer.sale .. ", " .. offer.itemId .. ", " ..
-			offer.amount .. ", " .. offer.created .. ", " .. (offer.anonymous and 1 or 0) .. ", " .. offer.price .. ", " ..
-			math.max(0, math.min(10, tonumber(offer.tier) or 0)) .. ", " ..
-			escapeAttributes(offer.attributes) .. ")"
-		)
-	else
-		-- Partial offer: restore subtracted amount
-		return db.query(
-			"UPDATE `market_offers` SET `amount` = `amount` + " .. acceptedAmount ..
-			" WHERE `id` = " .. offer.id
-		)
-	end
+	return Game.restoreMarketOffer(
+		offer.id, offer.playerId, offer.sale, offer.itemId, offer.amount, offer.created,
+		offer.anonymous, offer.price, offer.tier, offer.attributes, acceptedAmount
+	)
 end
 
 local blockedItems = {}
@@ -232,129 +204,6 @@ local function clamp(value, minValue, maxValue)
 		return maxValue
 	end
 	return value
-end
-
-local tableExistsCache = {}
-
--- Determine whether a database table with the given name exists.
--- @param name The name of the database table to check.
--- @return `true` if the table exists, `false` otherwise.
-local function tableExists(name)
-	if tableExistsCache[name] ~= nil then
-		return tableExistsCache[name]
-	end
-
-	local exists = true
-	if db.tableExists then
-		exists = db.tableExists(name)
-	end
-	tableExistsCache[name] = exists
-	return exists
-end
-
--- Checks whether a given column exists in the specified database table.
--- @return `true` if the column exists in the table, `false` otherwise.
-local function columnExists(tableName, columnName)
-	local resultId = db.storeQuery("SHOW COLUMNS FROM `" .. tableName .. "` LIKE " .. db.escapeString(columnName))
-	if resultId ~= false then
-		result.free(resultId)
-		return true
-	end
-	return false
-end
-
--- Ensures a column exists on a database table by adding it when missing.
--- Does nothing if the table does not exist or the column is already present.
--- @param tableName The name of the database table.
--- @param columnName The name of the column to ensure exists.
--- @param definition The SQL column definition (e.g. "INT NOT NULL DEFAULT 0").
-local function ensureColumn(tableName, columnName, definition)
-	if not tableExists(tableName) or columnExists(tableName, columnName) then
-		return
-	end
-	db.query("ALTER TABLE `" .. tableName .. "` ADD COLUMN `" .. columnName .. "` " .. definition)
-end
-
--- Retrieve the serialized attributes value for a given result row and column, if present.
--- Prefers a stream-backed column when available; otherwise reads the column as a string.
--- @param resultId The result row identifier returned by a query.
--- @param columnName Optional column name to read (default: "attributes").
--- @return The serialized attributes string when the column contains non-empty serialized data, `nil` otherwise.
-local function getResultAttributes(resultId, columnName)
-	columnName = columnName or "attributes"
-	if result.getStream then
-		local attributes, size = result.getStream(resultId, columnName)
-		if attributes and (tonumber(size) or 0) > 0 then
-			return attributes
-		end
-		return nil
-	end
-
-	local attributes = result.getDataString(resultId, columnName)
-	if hasSerializedAttributes(attributes) then
-		return attributes
-	end
-	return nil
-end
-
--- Ensures the market-related database schema exists and adds required columns.
--- Creates `market_offers`, `market_history`, and `market_statistics` tables when absent,
--- and guarantees the presence of `attributes` and `tier` columns on `market_offers`
--- and the `tier` column on `market_history`.
--- This function has no return value and performs schema mutations as side effects.
-local function ensureTables()
-	db.query([[
-		CREATE TABLE IF NOT EXISTS `market_offers` (
-			`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-			`player_id` INT NOT NULL,
-			`sale` TINYINT(1) NOT NULL DEFAULT 0,
-			`itemtype` SMALLINT UNSIGNED NOT NULL,
-			`amount` SMALLINT UNSIGNED NOT NULL,
-			`created` INT UNSIGNED NOT NULL,
-			`anonymous` TINYINT(1) NOT NULL DEFAULT 0,
-			`price` INT UNSIGNED NOT NULL DEFAULT 0,
-			`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
-			`attributes` MEDIUMBLOB NULL,
-			PRIMARY KEY (`id`),
-			KEY `idx_market_offers_itemtype_sale` (`itemtype`, `sale`),
-			KEY `idx_market_offers_player` (`player_id`)
-		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8
-	]])
-
-	ensureColumn("market_offers", "attributes", "MEDIUMBLOB NULL")
-	ensureColumn("market_offers", "tier", "TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `price`")
-
-	db.query([[
-		CREATE TABLE IF NOT EXISTS `market_history` (
-			`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-			`player_id` INT NOT NULL,
-			`sale` TINYINT(1) NOT NULL DEFAULT 0,
-			`itemtype` SMALLINT UNSIGNED NOT NULL,
-			`amount` SMALLINT UNSIGNED NOT NULL,
-			`price` INT UNSIGNED NOT NULL DEFAULT 0,
-			`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
-			`expires_at` INT UNSIGNED NOT NULL,
-			`inserted` INT UNSIGNED NOT NULL,
-			`state` TINYINT UNSIGNED NOT NULL,
-			PRIMARY KEY (`id`),
-			KEY `idx_market_history_player` (`player_id`)
-		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8
-	]])
-
-	ensureColumn("market_history", "tier", "TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `price`")
-
-	db.query([[
-		CREATE TABLE IF NOT EXISTS `market_statistics` (
-			`itemtype` SMALLINT UNSIGNED NOT NULL,
-			`sale` TINYINT(1) NOT NULL DEFAULT 0,
-			`day` INT UNSIGNED NOT NULL,
-			`transactions` INT UNSIGNED NOT NULL DEFAULT 0,
-			`total_price` BIGINT UNSIGNED NOT NULL DEFAULT 0,
-			`highest_price` INT UNSIGNED NOT NULL DEFAULT 0,
-			`lowest_price` INT UNSIGNED NOT NULL DEFAULT 0,
-			PRIMARY KEY (`itemtype`, `sale`, `day`)
-		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8
-	]])
 end
 
 local function getOfferDuration()
@@ -847,26 +696,6 @@ local function getDepotBoxes(player)
 	return boxes
 end
 
-local function getDepotItemAmount(player, itemId)
-	local itemType = ItemType(itemId)
-	if not itemType or itemType:getId() == 0 then
-		return 0
-	end
-
-	local amount = 0
-	for _, box in ipairs(getDepotBoxes(player)) do
-		for _, item in ipairs(box:getItems(true)) do
-			if item:getId() == itemId then
-				amount = amount + getItemTradeCount(item, itemType)
-				if amount >= 0xFFFF then
-					return 0xFFFF
-				end
-			end
-		end
-	end
-	return clamp(amount, 0, 0xFFFF)
-end
-
 local itemTypeStackableCache = {}
 
 -- Builds a map of the player's depot item quantities, keyed by itemId and by itemId:tier.
@@ -914,6 +743,23 @@ end
 local function buildMarketEnterEntries(depotMap)
 	local entries = {}
 	depotMap = depotMap or {}
+	local tierAmountsByItem = {}
+
+	for key, amount in pairs(depotMap) do
+		if type(key) == "string" and amount > 0 then
+			local itemId, tier = key:match("^(%d+):(%d+)$")
+			itemId = tonumber(itemId)
+			tier = tonumber(tier)
+			if itemId and tier and tier > 0 and tier <= 10 then
+				local tierAmounts = tierAmountsByItem[itemId]
+				if not tierAmounts then
+					tierAmounts = {}
+					tierAmountsByItem[itemId] = tierAmounts
+				end
+				tierAmounts[tier] = amount
+			end
+		end
+	end
 
 	for _, entry in ipairs(marketItems) do
 		entries[#entries + 1] = {
@@ -924,16 +770,19 @@ local function buildMarketEnterEntries(depotMap)
 			tier = 0
 		}
 
-		for tier = 1, 10 do
-			local amount = depotMap[getDepotItemKey(entry.id, tier)] or 0
-			if amount > 0 then
-				entries[#entries + 1] = {
-					id = entry.id,
-					category = entry.category,
-					name = entry.name,
-					amount = amount,
-					tier = tier
-				}
+		local tierAmounts = tierAmountsByItem[entry.id]
+		if tierAmounts then
+			for tier = 1, 10 do
+				local amount = tierAmounts[tier]
+				if amount then
+					entries[#entries + 1] = {
+						id = entry.id,
+						category = entry.category,
+						name = entry.name,
+						amount = amount,
+						tier = tier
+					}
+				end
 			end
 		end
 	end
@@ -1071,34 +920,7 @@ local function removeDepotItemsWithAttributes(player, itemId, amount, tier)
 	return true, storedAttributes
 end
 
--- Attempts to remove the specified amount of an item from the player's depot for a market operation.
--- @param player The player object whose depot will be scanned.
--- @param itemId The item type id to remove.
--- @param amount The quantity to remove.
--- @return `true` if the requested amount was successfully removed/reserved, `false` otherwise.
-local function removeDepotItems(player, itemId, amount)
-	local ok = removeDepotItemsWithAttributes(player, itemId, amount)
-	return ok
-end
-
--- Get the number of active market offers for a player.
--- @param playerId The player's database id.
--- @return The count of offers for the player, or `0` if the `market_offers` table is missing or the query fails.
-local function getMarketOfferCount(playerId)
-	if not tableExists("market_offers") then
-		return 0
-	end
-
-	local resultId = db.storeQuery("SELECT COUNT(*) AS `total` FROM `market_offers` WHERE `player_id` = " .. playerId)
-	if resultId == false then
-		return 0
-	end
-
-	local total = result.getDataInt(resultId, "total")
-	result.free(resultId)
-	return total
-end
-
+-- Calculates the one-percent market fee, clamped to the protocol's 20..1000 range.
 local function calculateFee(price, amount)
 	local fee = math.ceil((price * amount) / 100)
 	if fee < 20 then
@@ -1107,69 +929,6 @@ local function calculateFee(price, amount)
 		return 1000
 	end
 	return fee
-end
-
--- Compute the next sequential inbox `sid` for the given player.
--- Queries `player_inboxitems` for the current maximum `sid` (defaulting to 100) and returns that value plus one.
--- @param playerId The numeric player identifier.
--- @return The next available inbox `sid` (integer).
-local function getNextInboxSid(playerId)
-	local sid = 100
-	local resultId = db.storeQuery("SELECT COALESCE(MAX(`sid`), 100) AS `sid` FROM `player_inboxitems` WHERE `player_id` = " .. playerId)
-	if resultId ~= false then
-		sid = result.getDataInt(resultId, "sid")
-		result.free(resultId)
-	end
-	return sid + 1
-end
-
--- Insert item(s) into the player's inbox DB table, splitting into stack-sized rows and storing serialized attributes when present.
--- Validates the item type and that the `player_inboxitems` table exists. If `attributes` are serialized, `amount` must be 1 and the attributes are stored in the row; otherwise the function splits `amount` into one or more rows using the item's stack size.
--- @param playerId The numeric database id of the player receiving the item(s).
--- @param itemId The item type id to insert.
--- @param amount The total quantity to insert.
--- @param attributes Serialized attributes string for the item instance, or nil/empty for no attributes.
--- @return `true` if all necessary rows were successfully inserted, `false` on validation failure or any DB error.
-local function insertInboxItem(playerId, itemId, amount, attributes)
-	if not tableExists("player_inboxitems") then
-		return false
-	end
-
-	local itemType = ItemType(itemId)
-	if not itemType or itemType:getId() == 0 then
-		return false
-	end
-
-	if hasSerializedAttributes(attributes) then
-		if amount ~= 1 then
-			return false
-		end
-
-		local sid = getNextInboxSid(playerId)
-		local query = "INSERT INTO `player_inboxitems` (`player_id`, `sid`, `pid`, `itemtype`, `count`, `attributes`) VALUES (" ..
-			playerId .. ", " .. sid .. ", 0, " .. itemId .. ", 1, " .. escapeAttributes(attributes) .. ")"
-		return db.query(query)
-	end
-
-	local remaining = amount
-	local sid = getNextInboxSid(playerId)
-	while remaining > 0 do
-		local count = 1
-		if itemType:isStackable() then
-			count = math.min(remaining, math.max(1, itemType:getStackSize()))
-		end
-
-		local attributesSql = emptyAttributesSql()
-		local query = "INSERT INTO `player_inboxitems` (`player_id`, `sid`, `pid`, `itemtype`, `count`, `attributes`) VALUES (" ..
-			playerId .. ", " .. sid .. ", 0, " .. itemId .. ", " .. count .. ", " .. attributesSql .. ")"
-		if not db.query(query) then
-			return false
-		end
-
-		remaining = remaining - count
-		sid = sid + 1
-	end
-	return true
 end
 
 -- Adds the specified item(s) into the provided inbox container, honoring stack sizes and serialized attributes.
@@ -1205,11 +964,18 @@ local function addItemToInbox(inbox, itemId, amount, attributes)
 
 	local stackSize = math.max(1, itemType:getStackSize())
 	local remaining = amount
+	local addedItems = {}
 	while remaining > 0 do
 		local count = itemType:isStackable() and math.min(remaining, stackSize) or 1
-		if not inbox:addItem(itemId, count, INDEX_WHEREEVER, FLAG_NOLIMIT) then
+		local item = inbox:addItem(itemId, count, INDEX_WHEREEVER, FLAG_NOLIMIT)
+		if not item then
+			for index = #addedItems, 1, -1 do
+				local added = addedItems[index]
+				added.item:remove(added.count)
+			end
 			return false
 		end
+		addedItems[#addedItems + 1] = { item = item, count = count }
 		remaining = remaining - count
 	end
 	return true
@@ -1282,7 +1048,7 @@ local function deliverItemToPlayer(playerId, playerName, itemId, amount, attribu
 			return true
 		end
 	end
-	return insertInboxItem(playerId, itemId, amount, attributes)
+	return Game.insertMarketInboxItem(playerId, itemId, amount, attributes)
 end
 
 -- Credits `amount` to a player's bank balance, preferring an online player object when available.
@@ -1301,11 +1067,11 @@ local function creditPlayerBank(playerId, playerName, amount)
 		return true
 	end
 
-	return db.query("UPDATE `players` SET `balance` = `balance` + " .. amount .. " WHERE `id` = " .. playerId)
+	return Game.creditMarketBank(playerId, amount)
 end
 
 -- Records a market offer event in the `market_history` table.
--- Inserts a history row if the `market_history` table exists; computes `expires_at` as `(created or now) + offerDuration` and clamps `tier` into the range 0..10.
+-- Computes `expires_at` as `(created or now) + offerDuration` and delegates the typed insert to C++.
 -- @param playerId Numeric id of the player who created or was affected by the offer.
 -- @param sale Numeric action code indicating buy or sell (e.g., `MARKET_ACTION_BUY` / `MARKET_ACTION_SELL`).
 -- @param itemId Numeric item type id involved in the offer.
@@ -1315,46 +1081,26 @@ end
 -- @param created Optional timestamp to use as the offer creation time; when omitted, the current time is used.
 -- @param tier Optional numeric tier for the item; will be coerced to an integer and clamped between 0 and 10.
 local function addHistory(playerId, sale, itemId, amount, price, state, created, tier)
-	if not tableExists("market_history") then
-		return
-	end
-
 	local now = os.time()
 	local expiresAt = (created or now) + getOfferDuration()
 	tier = math.max(0, math.min(10, tonumber(tier) or 0))
-	db.query("INSERT INTO `market_history` (`player_id`, `sale`, `itemtype`, `amount`, `price`, `tier`, `expires_at`, `inserted`, `state`) VALUES (" ..
-		playerId .. ", " .. sale .. ", " .. itemId .. ", " .. amount .. ", " .. price .. ", " .. tier .. ", " .. expiresAt .. ", " .. now .. ", " .. state .. ")")
+	return Game.addMarketHistory(playerId, sale, itemId, amount, price, tier, expiresAt, now, state)
 end
 
 -- Retrieves a market offer by its database ID, resolving stored attributes and deriving the effective tier from those attributes when present.
 -- @param offerId The offer database ID.
 -- @return A table with fields: `id`, `playerId`, `sale`, `itemId`, `amount`, `created`, `anonymous`, `price`, `tier`, `attributes`, `playerName`; or `nil` if the offer does not exist.
 local function fetchOfferById(offerId)
-	local resultId = db.storeQuery("SELECT mo.`id`, mo.`player_id`, mo.`sale`, mo.`itemtype`, mo.`amount`, mo.`created`, mo.`anonymous`, mo.`price`, mo.`tier`, mo.`attributes`, p.`name` AS `player_name` FROM `market_offers` mo INNER JOIN `players` p ON p.`id` = mo.`player_id` WHERE mo.`id` = " .. offerId .. " LIMIT 1")
-	if resultId == false then
+	local offer = Game.getMarketOffer(offerId)
+	if not offer then
 		return nil
 	end
-
-	local offer = {
-		id = result.getDataInt(resultId, "id"),
-		playerId = result.getDataInt(resultId, "player_id"),
-		sale = result.getDataInt(resultId, "sale"),
-		itemId = result.getDataInt(resultId, "itemtype"),
-		amount = result.getDataInt(resultId, "amount"),
-		created = result.getDataInt(resultId, "created"),
-		anonymous = result.getDataInt(resultId, "anonymous") ~= 0,
-		price = result.getDataInt(resultId, "price"),
-		tier = result.getDataInt(resultId, "tier"),
-		attributes = getResultAttributes(resultId),
-		playerName = result.getDataString(resultId, "player_name")
-	}
 	offer.tier = getOfferTier(offer.itemId, offer.tier, offer.attributes)
-	result.free(resultId)
 	return offer
 end
 
--- Parses the result of an SQL query and returns a list of market offers built from its rows.
--- @param query The SQL query string expected to select offer rows (columns: id, player_id, sale, itemtype, amount, created, anonymous, price, tier, player_name and any attributes blob).
+-- Resolves the effective tier for offers returned by the C++ persistence layer.
+-- @param offers Market offer tables returned by Game market methods.
 -- @return A numeric-indexed table of offer tables. Each offer contains:
 --   - id: offer id.
 --   - playerId: owner player id.
@@ -1368,32 +1114,10 @@ end
 --   - attributes: serialized attributes blob (or `nil`).
 --   - playerName: owner name string.
 --   - state: offer state (set to `MARKET_STATE_ACTIVE` for returned rows).
-local function fetchOffers(query)
-	local offers = {}
-	local resultId = db.storeQuery(query)
-	if resultId == false then
-		return offers
+local function resolveOfferTiers(offers)
+	for _, offer in ipairs(offers) do
+		offer.tier = getOfferTier(offer.itemId, offer.tier, offer.attributes)
 	end
-
-	repeat
-		offers[#offers + 1] = {
-			id = result.getDataInt(resultId, "id"),
-			playerId = result.getDataInt(resultId, "player_id"),
-			sale = result.getDataInt(resultId, "sale"),
-			itemId = result.getDataInt(resultId, "itemtype"),
-			amount = result.getDataInt(resultId, "amount"),
-			created = result.getDataInt(resultId, "created"),
-			anonymous = result.getDataInt(resultId, "anonymous") ~= 0,
-			price = result.getDataInt(resultId, "price"),
-			tier = result.getDataInt(resultId, "tier"),
-			attributes = getResultAttributes(resultId),
-			playerName = result.getDataString(resultId, "player_name"),
-			state = MARKET_STATE_ACTIVE
-		}
-		offers[#offers].tier = getOfferTier(offers[#offers].itemId, offers[#offers].tier, offers[#offers].attributes)
-	until not result.next(resultId)
-
-	result.free(resultId)
 	return offers
 end
 
@@ -1412,34 +1136,7 @@ end
 --   - playerName: player name string (empty here).
 --   - state: history state code.
 local function fetchHistory(playerId)
-	local offers = {}
-	if not tableExists("market_history") then
-		return offers
-	end
-
-	local resultId = db.storeQuery("SELECT `id`, `player_id`, `sale`, `itemtype`, `amount`, `price`, `tier`, `inserted`, `state` FROM `market_history` WHERE `player_id` = " .. playerId .. " ORDER BY `inserted` DESC LIMIT " .. MARKET_MAX_PACKET_OFFERS)
-	if resultId == false then
-		return offers
-	end
-
-	repeat
-		offers[#offers + 1] = {
-			id = result.getDataInt(resultId, "id"),
-			playerId = result.getDataInt(resultId, "player_id"),
-			sale = result.getDataInt(resultId, "sale"),
-			itemId = result.getDataInt(resultId, "itemtype"),
-			amount = result.getDataInt(resultId, "amount"),
-			created = result.getDataInt(resultId, "inserted"),
-			anonymous = false,
-			price = result.getDataInt(resultId, "price"),
-			tier = result.getDataInt(resultId, "tier"),
-			playerName = "",
-			state = result.getDataInt(resultId, "state")
-		}
-	until not result.next(resultId)
-
-	result.free(resultId)
-	return offers
+	return Game.getMarketHistory(playerId, MARKET_MAX_PACKET_OFFERS)
 end
 
 -- Writes a market offer's serialized fields into the output packet.
@@ -1670,53 +1367,15 @@ local function buildMarketDescriptions(itemId)
 end
 
 local function fetchMarketStatistics(itemId, actionType)
-	local stats = {}
-	if not tableExists("market_statistics") then
-		return stats
-	end
-
 	local since = os.time() - (MARKET_STATISTICS_DAYS * 24 * 60 * 60)
 	local firstDay = math.floor(since / 86400) * 86400
-	local query = "SELECT `day`, `transactions`, `total_price`, `highest_price`, `lowest_price` FROM `market_statistics` " ..
-		"WHERE `itemtype` = " .. itemId .. " AND `sale` = " .. actionType .. " AND `day` >= " .. firstDay ..
-		" ORDER BY `day` ASC LIMIT " .. MARKET_STATISTICS_DAYS
-
-	local resultId = db.storeQuery(query)
-	if resultId == false then
-		return stats
-	end
-
-	repeat
-		stats[#stats + 1] = {
-			day = result.getDataInt(resultId, "day"),
-			transactions = result.getDataInt(resultId, "transactions"),
-			totalPrice = result.getDataLong(resultId, "total_price"),
-			highestPrice = result.getDataInt(resultId, "highest_price"),
-			lowestPrice = result.getDataInt(resultId, "lowest_price")
-		}
-	until not result.next(resultId)
-
-	result.free(resultId)
-	return stats
+	return Game.getMarketStatistics(itemId, actionType, firstDay, MARKET_STATISTICS_DAYS)
 end
 
 local function refreshMarketStatistics()
-	if not tableExists("market_history") or not tableExists("market_statistics") then
-		return false
-	end
-
 	local since = os.time() - (MARKET_STATISTICS_DAYS * 24 * 60 * 60)
 	local firstDay = math.floor(since / 86400) * 86400
-	db.query("DELETE FROM `market_statistics`")
-
-	return db.query(
-		"REPLACE INTO `market_statistics` (`itemtype`, `sale`, `day`, `transactions`, `total_price`, `highest_price`, `lowest_price`) " ..
-		"SELECT `itemtype`, `sale`, FLOOR(`inserted` / 86400) * 86400 AS `stat_day`, COUNT(*) AS `transactions`, " ..
-		"CASE WHEN SUM(`amount`) > 0 THEN FLOOR((SUM(`price` * `amount`) / SUM(`amount`)) * COUNT(*)) ELSE 0 END AS `total_price`, " ..
-		"MAX(`price`) AS `highest_price`, MIN(`price`) AS `lowest_price` FROM `market_history` " ..
-		"WHERE `state` = " .. MARKET_STATE_ACCEPTED .. " AND `inserted` >= " .. firstDay ..
-		" GROUP BY `itemtype`, `sale`, FLOOR(`inserted` / 86400) * 86400"
-	)
+	return Game.refreshMarketStatistics(firstDay, MARKET_STATE_ACCEPTED)
 end
 
 local function writeStatistics(out, stats)
@@ -1749,8 +1408,7 @@ local function sendMarketBrowse(player, browseId)
 	local playerId = player:getGuid()
 
 	if browseId == MARKET_REQUEST_MY_OFFERS then
-		local query = "SELECT mo.`id`, mo.`player_id`, mo.`sale`, mo.`itemtype`, mo.`amount`, mo.`created`, mo.`anonymous`, mo.`price`, mo.`tier`, mo.`attributes`, p.`name` AS `player_name` FROM `market_offers` mo INNER JOIN `players` p ON p.`id` = mo.`player_id` WHERE mo.`player_id` = " .. playerId .. " ORDER BY mo.`created` DESC LIMIT " .. MARKET_MAX_PACKET_OFFERS
-		for _, offer in ipairs(fetchOffers(query)) do
+		for _, offer in ipairs(resolveOfferTiers(Game.getOwnMarketOffers(playerId, MARKET_MAX_PACKET_OFFERS))) do
 			if offer.sale == MARKET_ACTION_BUY then
 				buyOffers[#buyOffers + 1] = offer
 			else
@@ -1766,8 +1424,8 @@ local function sendMarketBrowse(player, browseId)
 			end
 		end
 	elseif marketItemsById[browseId] then
-		buyOffers = fetchOffers("SELECT mo.`id`, mo.`player_id`, mo.`sale`, mo.`itemtype`, mo.`amount`, mo.`created`, mo.`anonymous`, mo.`price`, mo.`tier`, mo.`attributes`, p.`name` AS `player_name` FROM `market_offers` mo INNER JOIN `players` p ON p.`id` = mo.`player_id` WHERE mo.`itemtype` = " .. browseId .. " AND mo.`sale` = " .. MARKET_ACTION_BUY .. " ORDER BY mo.`price` DESC, mo.`created` ASC LIMIT " .. MARKET_MAX_PACKET_OFFERS)
-		sellOffers = fetchOffers("SELECT mo.`id`, mo.`player_id`, mo.`sale`, mo.`itemtype`, mo.`amount`, mo.`created`, mo.`anonymous`, mo.`price`, mo.`tier`, mo.`attributes`, p.`name` AS `player_name` FROM `market_offers` mo INNER JOIN `players` p ON p.`id` = mo.`player_id` WHERE mo.`itemtype` = " .. browseId .. " AND mo.`sale` = " .. MARKET_ACTION_SELL .. " ORDER BY mo.`price` ASC, mo.`created` ASC LIMIT " .. MARKET_MAX_PACKET_OFFERS)
+		buyOffers = resolveOfferTiers(Game.getItemMarketOffers(browseId, MARKET_ACTION_BUY, MARKET_MAX_PACKET_OFFERS))
+		sellOffers = resolveOfferTiers(Game.getItemMarketOffers(browseId, MARKET_ACTION_SELL, MARKET_MAX_PACKET_OFFERS))
 	else
 		sendMarketMessage(player, "This item cannot be traded on the market.")
 		return
@@ -1808,7 +1466,7 @@ local function sendMarketEnter(player, depotMap)
 	local playerGuid = player:getGuid()
 	local offers = offerCountCache[playerGuid]
 	if offers == nil then
-		offers = clamp(getMarketOfferCount(playerGuid), 0, MARKET_MAX_OFFERS)
+		offers = clamp(Game.getMarketOfferCount(playerGuid), 0, MARKET_MAX_OFFERS)
 		offerCountCache[playerGuid] = offers
 	end
 	local chunkIndex = 0
@@ -1878,16 +1536,16 @@ local function refreshMarket(player, browseId, depotMap)
 end
 
 -- Expires market offers whose lifetime has elapsed, atomically claims them from the database, returns funds or items to the offer owners, and records the expiration in market history.
--- Skips execution if the configured expire-check interval has not passed or if the `market_offers` table is absent. For each claimed offer this function attempts to credit the seller/buyer (money or item delivery), clears the per-player offer count cache on success, and on delivery failure restores the offer so it can be retried.
+-- Skips execution if the configured expire-check interval has not passed. For each claimed offer this function attempts to credit the seller/buyer, clears the per-player offer count cache on success, and restores the offer on delivery failure.
 local function expireOffers()
 	local now = os.time()
-	if now - lastExpireCheck < MARKET_EXPIRE_CHECK_INTERVAL or not tableExists("market_offers") then
+	if now - lastExpireCheck < MARKET_EXPIRE_CHECK_INTERVAL then
 		return
 	end
 	lastExpireCheck = now
 
 	local expiredBefore = now - getOfferDuration()
-	local offers = fetchOffers("SELECT mo.`id`, mo.`player_id`, mo.`sale`, mo.`itemtype`, mo.`amount`, mo.`created`, mo.`anonymous`, mo.`price`, mo.`tier`, mo.`attributes`, p.`name` AS `player_name` FROM `market_offers` mo INNER JOIN `players` p ON p.`id` = mo.`player_id` WHERE mo.`created` <= " .. expiredBefore .. " ORDER BY mo.`created` ASC LIMIT 100")
+	local offers = resolveOfferTiers(Game.getExpiredMarketOffers(expiredBefore, 100))
 	for _, offer in ipairs(offers) do
 		local offerKey = "offer:" .. offer.id
 		-- Skip offers currently being processed by another handler
@@ -1895,7 +1553,7 @@ local function expireOffers()
 			logInfo("[CustomMarket] Skipping expire for locked offer " .. offer.id)
 		else
 			-- Atomically claim the offer before returning goods
-			local claimed = db.query("DELETE FROM `market_offers` WHERE `id` = " .. offer.id)
+			local claimed = Game.claimMarketOffer(offer.id, offer.amount, offer.amount)
 			if claimed then
 				local returned = true
 				if offer.sale == MARKET_ACTION_BUY then
@@ -1937,7 +1595,7 @@ local function validateOfferPayload(player, actionType, itemId, amount, price)
 		return false, "Invalid price."
 	end
 
-	if getMarketOfferCount(player:getGuid()) >= MARKET_MAX_OFFERS then
+	if Game.getMarketOfferCount(player:getGuid()) >= MARKET_MAX_OFFERS then
 		return false, "You have too many active market offers."
 	end
 
@@ -2013,7 +1671,7 @@ function createHandler.onReceive(player, msg)
 	local itemId = msg:getU16()
 	local amount = msg:getU16()
 	local price = msg:getU32()
-	local anonymous = msg:getByte() ~= 0 and 1 or 0
+	local anonymous = msg:getByte() ~= 0
 	local requestedTier = nil
 	if msg:len() - msg:tell() >= 1 then
 		requestedTier = math.max(0, math.min(10, tonumber(msg:getByte()) or 0))
@@ -2084,10 +1742,10 @@ function createHandler.onReceive(player, msg)
 	end
 
 	local now = os.time()
-	local ok = db.query("INSERT INTO `market_offers` (`player_id`, `sale`, `itemtype`, `amount`, `created`, `anonymous`, `price`, `tier`, `attributes`) VALUES (" ..
-		player:getGuid() .. ", " .. actionType .. ", " .. itemId .. ", " .. amount .. ", " .. now .. ", " .. anonymous .. ", " .. price .. ", " ..
-		math.max(0, math.min(10, tonumber(offerTier) or 0)) .. ", " ..
-		escapeAttributes(offerAttributes) .. ")")
+	local ok = Game.createMarketOffer(
+		player:getGuid(), actionType, itemId, amount, now, anonymous, price,
+		math.max(0, math.min(10, tonumber(offerTier) or 0)), offerAttributes
+	)
 	if not ok then
 		if actionType == MARKET_ACTION_BUY then
 			refundPlayerMarketMoney(player, payment)
@@ -2148,23 +1806,30 @@ function cancelHandler.onReceive(player, msg)
 	end
 
 	-- Atomically claim (delete) the offer BEFORE returning goods
-	if not db.query("DELETE FROM `market_offers` WHERE `id` = " .. offer.id .. " AND `player_id` = " .. player:getGuid()) then
+	if not Game.claimMarketOffer(offer.id, offer.amount, offer.amount, player:getGuid()) then
 		releaseMultipleLocks({ offerKey, playerKey })
 		sendMarketMessage(player, "Could not cancel the market offer.")
 		return
 	end
-	offerCountCache[player:getGuid()] = nil
 
 	-- Return goods after safe DB claim
+	local returned = true
 	if offer.sale == MARKET_ACTION_BUY then
 		player:setBankBalance(player:getBankBalance() + offer.price * offer.amount)
 	else
 		-- Use deliverItemToPlayer (inbox/depot) instead of raw addItem
-		if not deliverItemToPlayer(player:getGuid(), player:getName(), offer.itemId, offer.amount, offer.attributes) then
-			logError("[CustomMarket] Failed to return cancelled sell offer " .. offer.id .. " items to player " .. player:getName())
-		end
+		returned = deliverItemToPlayer(player:getGuid(), player:getName(), offer.itemId, offer.amount, offer.attributes)
 	end
 
+	if not returned then
+		rollbackOfferClaim(offer, offer.amount)
+		releaseMultipleLocks({ offerKey, playerKey })
+		logError("[CustomMarket] Failed to return cancelled sell offer " .. offer.id .. " items to player " .. player:getName())
+		sendMarketMessage(player, "Could not return the market offer items.")
+		return
+	end
+
+	offerCountCache[player:getGuid()] = nil
 	addHistory(player:getGuid(), offer.sale, offer.itemId, offer.amount, offer.price, MARKET_STATE_CANCELLED, offer.created, offer.tier)
 	releaseMultipleLocks({ offerKey, playerKey })
 	sendMarketMessage(player, "Market offer cancelled.")
@@ -2242,20 +1907,7 @@ function acceptHandler.onReceive(player, msg)
 	-- STEP 1: Atomically claim the offer in DB BEFORE any item/money
 	-- transfer. This is the core anti-dupe guarantee.
 	-- ================================================================
-	local dbClaimed
-	if amount == offer.amount then
-		-- Full accept: DELETE with amount guard so a concurrent op can't sneak in
-		dbClaimed = db.query(
-			"DELETE FROM `market_offers` WHERE `id` = " .. offer.id ..
-			" AND `amount` = " .. offer.amount
-		)
-	else
-		-- Partial accept: UPDATE with guard that amount is still sufficient
-		dbClaimed = db.query(
-			"UPDATE `market_offers` SET `amount` = `amount` - " .. amount ..
-			" WHERE `id` = " .. offer.id .. " AND `amount` >= " .. amount
-		)
-	end
+	local dbClaimed = Game.claimMarketOffer(offer.id, offer.amount, amount)
 
 	if not dbClaimed then
 		releaseMultipleLocks({ offerKey, buyerKey, ownerKey })
@@ -2377,7 +2029,6 @@ function marketSessionInit.onLogin(player)
 end
 marketSessionInit:register()
 
-ensureTables()
 loadMarketCatalog()
 refreshMarketStatistics()
 

--- a/data/scripts/network/prey_system/prey_system.lua
+++ b/data/scripts/network/prey_system/prey_system.lua
@@ -75,7 +75,6 @@ local RESOURCE_INVENTORY = 1
 local RESOURCE_PREY = 10
 
 local preyCache = {}
-local preySchemaChecked = false
 
 local function supportsCustomNetwork(player)
 	return player and player.isUsingOtClient and player:isUsingOtClient()
@@ -89,33 +88,6 @@ local function isPreySlotUnlocked(player, slot)
 	return slot ~= PREY_PERMANENT_SLOT
 		or player:getStorageValue(PREY_STORAGE_PERMANENT_SLOT) == 1
 end
-
-local function ensurePreySchema()
-	if preySchemaChecked then
-		return
-	end
-
-	local query = db.storeQuery(
-		"SELECT COUNT(*) AS `count` FROM `information_schema`.`COLUMNS`"
-		.. " WHERE `TABLE_SCHEMA` = DATABASE()"
-		.. " AND `TABLE_NAME` = 'player_prey'"
-		.. " AND `COLUMN_NAME` = 'list_reroll_used'"
-	)
-	local exists = false
-	if query ~= false then
-		exists = result.getDataInt(query, "count") > 0
-		result.free(query)
-	end
-
-	if not exists then
-		db.query("ALTER TABLE `player_prey` ADD `list_reroll_used` TINYINT(1) NOT NULL DEFAULT 0")
-	end
-
-	preySchemaChecked = true
-end
-
--- Schema maintenance belongs to startup, never to a player's login callback.
-ensurePreySchema()
 
 PreySystem = PreySystem or {}
 PreySystem.BONUS_DAMAGE_BOOST = PREY_BONUS_DMG_BOOST
@@ -189,32 +161,12 @@ local function parseMonsterList(rawList)
 end
 
 local function getPlayerBonusRerolls(player)
-	if player.getPreyWildcards then
-		return math.min(player:getPreyWildcards(), PREY_MAX_WILDCARDS)
-	end
-
-	local resultId = db.storeQuery("SELECT `bonus_rerolls` FROM `players` WHERE `id` = " .. player:getGuid())
-	if resultId == false then
-		return 0
-	end
-
-	local rerolls = math.min(result.getDataInt(resultId, "bonus_rerolls"), PREY_MAX_WILDCARDS)
-	result.free(resultId)
-	return math.max(rerolls, 0)
+	return math.min(player:getPreyWildcards(), PREY_MAX_WILDCARDS)
 end
 
 local function setPlayerBonusRerolls(player, rerolls)
 	rerolls = math.min(math.max(tonumber(rerolls) or 0, 0), PREY_MAX_WILDCARDS)
-	if player.setPreyWildcards then
-		player:setPreyWildcards(rerolls)
-		return rerolls
-	end
-
-	db.query(string.format(
-		"UPDATE `players` SET `bonus_rerolls` = %d WHERE `id` = %d",
-		rerolls,
-		player:getGuid()
-	))
+	player:setPreyWildcards(rerolls)
 	return rerolls
 end
 
@@ -270,15 +222,12 @@ local function loadPreyFromDB(playerGuid)
 	return data
 end
 
-local function saveSlotToDB(playerGuid, slot, slotData, wildcards)
-	ensurePreySchema()
+local PREY_SLOT_INSERT = "INSERT INTO `player_prey` (`player_id`, `slot`, `state`, `monster_name`, `bonus_type`, `bonus_value`, `time_left`, `list_monsters`, `reroll_at`, `wildcards`, `list_reroll_used`) VALUES "
+local PREY_SLOT_UPSERT = " ON DUPLICATE KEY UPDATE `state` = VALUES(`state`), `monster_name` = VALUES(`monster_name`), `bonus_type` = VALUES(`bonus_type`), `bonus_value` = VALUES(`bonus_value`), `time_left` = VALUES(`time_left`), `list_monsters` = VALUES(`list_monsters`), `reroll_at` = VALUES(`reroll_at`), `wildcards` = VALUES(`wildcards`), `list_reroll_used` = VALUES(`list_reroll_used`)"
 
-	db.asyncQuery(string.format(
-		"INSERT INTO `player_prey` (`player_id`, `slot`, `state`, `monster_name`, `bonus_type`, `bonus_value`, `time_left`, `list_monsters`, `reroll_at`, `wildcards`, `list_reroll_used`) " ..
-		"VALUES (%d, %d, %d, %s, %d, %d, %d, %s, %d, %d, %d) " ..
-		"ON DUPLICATE KEY UPDATE `state` = VALUES(`state`), `monster_name` = VALUES(`monster_name`), `bonus_type` = VALUES(`bonus_type`), " ..
-		"`bonus_value` = VALUES(`bonus_value`), `time_left` = VALUES(`time_left`), `list_monsters` = VALUES(`list_monsters`), " ..
-		"`reroll_at` = VALUES(`reroll_at`), `wildcards` = VALUES(`wildcards`), `list_reroll_used` = VALUES(`list_reroll_used`)",
+local function serializeSlotValues(playerGuid, slot, slotData)
+	return string.format(
+		"(%d, %d, %d, %s, %d, %d, %d, %s, %d, 0, %d)",
 		playerGuid,
 		slot,
 		slotData.state,
@@ -288,9 +237,12 @@ local function saveSlotToDB(playerGuid, slot, slotData, wildcards)
 		slotData.time_left,
 		db.escapeString(serializeMonsterList(slotData.list_monsters)),
 		slotData.reroll_at,
-		0,
 		slotData.list_reroll_used and 1 or 0
-	))
+	)
+end
+
+local function saveSlotToDB(playerGuid, slot, slotData)
+	db.asyncQuery(PREY_SLOT_INSERT .. serializeSlotValues(playerGuid, slot, slotData) .. PREY_SLOT_UPSERT)
 end
 
 local function saveAllSlots(player)
@@ -300,9 +252,11 @@ local function saveAllSlots(player)
 	end
 
 	local guid = player:getGuid()
+	local values = {}
 	for slot = 0, PREY_SLOTS - 1 do
-		saveSlotToDB(guid, slot, prey.slots[slot], prey.wildcards)
+		values[#values + 1] = serializeSlotValues(guid, slot, prey.slots[slot])
 	end
+	db.asyncQuery(PREY_SLOT_INSERT .. table.concat(values, ",") .. PREY_SLOT_UPSERT)
 end
 
 local function getPlayerPrey(player)
@@ -312,10 +266,7 @@ local function getPlayerPrey(player)
 		preyCache[playerId] = loadPreyFromDB(player:getGuid())
 	end
 
-	local wildcards = preyCache[playerId].wildcards
-	if firstLoad or player.getPreyWildcards then
-		wildcards = getPlayerBonusRerolls(player)
-	end
+	local wildcards = getPlayerBonusRerolls(player)
 	if firstLoad and wildcards == 0 and preyCache[playerId].legacyWildcards > 0 then
 		setPlayerBonusRerolls(player, preyCache[playerId].legacyWildcards)
 		wildcards = preyCache[playerId].legacyWildcards
@@ -703,7 +654,7 @@ local function sendSlotUpdate(player, slot, wildcardRaceIds)
 	writeSlot(out, player, slot, prey.slots[slot], wildcardRaceIds)
 	syncPreyCombatBonuses(player, prey)
 	local sent = out:sendToPlayer(player)
-	saveSlotToDB(player:getGuid(), slot, prey.slots[slot], prey.wildcards)
+	saveSlotToDB(player:getGuid(), slot, prey.slots[slot])
 	return sent
 end
 
@@ -819,7 +770,7 @@ local function initializeEmptySlots(player)
 	local prey = getPlayerPrey(player)
 	for slot = 0, PREY_SLOTS - 1 do
 		if isPreySlotUnlocked(player, slot) and initializeSlot(player, slot) then
-			saveSlotToDB(player:getGuid(), slot, prey.slots[slot], prey.wildcards)
+			saveSlotToDB(player:getGuid(), slot, prey.slots[slot])
 			changed = true
 		end
 	end
@@ -1081,9 +1032,7 @@ local function preyTick()
 				if changed then
 					prey.saveTicker = (prey.saveTicker or 0) + 1
 					if prey.saveTicker >= 60 then
-						for slot = 0, PREY_SLOTS - 1 do
-							saveSlotToDB(player:getGuid(), slot, prey.slots[slot], prey.wildcards)
-						end
+						saveAllSlots(player)
 						prey.saveTicker = 0
 					end
 				end

--- a/data/scripts/network/supply_stash/supplystash.lua
+++ b/data/scripts/network/supply_stash/supplystash.lua
@@ -63,186 +63,49 @@ local function supportsCustomNetwork(player)
 	return player and player.isUsingOtClient and player:isUsingOtClient()
 end
 
-local function logError(message)
-	if logger and logger.error then
-		logger.error(message)
-	else
-		print(message)
-	end
-end
-
-local function runSchemaQuery(query, errorMessage)
-	local ok, result = pcall(db.query, query)
-	if not ok or not result then
-		logError("[SupplyStash] " .. errorMessage)
+local function tileHasSupplyStashAccess(tile)
+	if not tile then
 		return false
 	end
-	return true
+	if tile:getItemByType(ITEM_TYPE_DEPOT) then
+		return true
+	end
+	return tile.getItemById and tile:getItemById(SUPPLY_STASH_ITEM_ID) ~= nil
 end
 
--- Checks whether a given column name exists in the specified database table.
--- @param tableName The name of the database table to inspect.
--- @param columnName The column name to look for (pattern is matched with SQL LIKE).
--- @return `true` if the column exists in the table, `false` otherwise.
-local function tableColumnExists(tableName, columnName)
-	local resultId = db.storeQuery("SHOW COLUMNS FROM `" .. tableName .. "` LIKE " .. db.escapeString(columnName))
-	if resultId then
-		result.free(resultId)
+local function hasCurrentSupplyStashAccess(player)
+	if not player then
+		return false
+	end
+
+	local position = player:getPosition()
+	local playerTile = Tile(position)
+	if not playerTile or not playerTile:hasFlag(TILESTATE_PROTECTIONZONE) then
+		return false
+	end
+	if tileHasSupplyStashAccess(playerTile) then
 		return true
+	end
+
+	for x = -1, 1 do
+		for y = -1, 1 do
+			if x ~= 0 or y ~= 0 then
+				local tile = Tile(Position(position.x + x, position.y + y, position.z))
+				if tileHasSupplyStashAccess(tile) then
+					return true
+				end
+			end
+		end
 	end
 	return false
 end
 
-local function tableForeignKeyExists(tableName, constraintName)
-	local resultId = db.storeQuery(
-		"SELECT `CONSTRAINT_NAME` FROM `information_schema`.`TABLE_CONSTRAINTS` WHERE `CONSTRAINT_SCHEMA` = DATABASE() " ..
-		"AND `TABLE_NAME` = " .. db.escapeString(tableName) ..
-		" AND `CONSTRAINT_NAME` = " .. db.escapeString(constraintName) ..
-		" AND `CONSTRAINT_TYPE` = 'FOREIGN KEY' LIMIT 1"
-	)
-	if resultId then
-		result.free(resultId)
+local function ensureSupplyStashAccess(player)
+	if hasCurrentSupplyStashAccess(player) then
 		return true
 	end
+	player:sendCancelMessage("Supply stash closed. You need to be near a depot.")
 	return false
-end
-
-local function addSupplyStashForeignKey(tableName, errorMessage)
-	return runSchemaQuery(
-		"ALTER TABLE `" .. tableName .. "` ADD CONSTRAINT `player_supplystash_player_fk` " ..
-		"FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE",
-		errorMessage
-	)
-end
-
--- Returns the primary key column signature for the `player_supplystash` table as a comma-separated string.
--- @return A string containing primary key column names in index order (e.g., "player_id,itemtype,tier"). Returns an empty string if the table has no PRIMARY index or cannot be queried.
-local function getSupplyStashPrimaryKeySignature()
-	local indexes = {}
-	local resultId = db.storeQuery("SHOW INDEX FROM `player_supplystash` WHERE `Key_name` = 'PRIMARY'")
-	if resultId then
-		repeat
-			indexes[#indexes + 1] = {
-				seq = result.getDataInt(resultId, "Seq_in_index"),
-				column = result.getDataString(resultId, "Column_name")
-			}
-		until not result.next(resultId)
-		result.free(resultId)
-	end
-
-	table.sort(indexes, function(a, b)
-		return a.seq < b.seq
-	end)
-
-	local columns = {}
-	for _, index in ipairs(indexes) do
-		columns[#columns + 1] = index.column
-	end
-	return table.concat(columns, ",")
-end
-
--- Rebuilds the `player_supplystash` table to ensure a composite primary key that includes `tier` and migrates existing rows, aggregating amounts by `(player_id, itemtype, tier)`.
--- @return `true` if the table was successfully rebuilt and migrated, `false` otherwise.
-local function rebuildSupplyStashTable()
-	db.query("DROP TABLE IF EXISTS `player_supplystash_tier_migration`")
-	local droppedOriginalForeignKey = false
-	if tableForeignKeyExists("player_supplystash", "player_supplystash_player_fk") then
-		if not runSchemaQuery("ALTER TABLE `player_supplystash` DROP FOREIGN KEY `player_supplystash_player_fk`", "Could not drop old supply stash foreign key for migration.") then
-			return false
-		end
-		droppedOriginalForeignKey = true
-	end
-
-	local function restoreOriginalForeignKey()
-		if droppedOriginalForeignKey and not tableForeignKeyExists("player_supplystash", "player_supplystash_player_fk") then
-			addSupplyStashForeignKey("player_supplystash", "Could not restore old supply stash foreign key after failed migration.")
-		end
-	end
-
-	if not runSchemaQuery([[
-		CREATE TABLE `player_supplystash_tier_migration` (
-			`player_id` INT NOT NULL,
-			`itemtype` SMALLINT UNSIGNED NOT NULL,
-			`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
-			`amount` INT UNSIGNED NOT NULL DEFAULT 0,
-			PRIMARY KEY (`player_id`, `itemtype`, `tier`),
-			CONSTRAINT `player_supplystash_player_fk`
-				FOREIGN KEY (`player_id`) REFERENCES `players` (`id`)
-				ON DELETE CASCADE
-		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
-	]], "Could not create tier migration table.") then
-		restoreOriginalForeignKey()
-		db.query("DROP TABLE IF EXISTS `player_supplystash_tier_migration`")
-		return false
-	end
-
-	if not runSchemaQuery([[
-		INSERT INTO `player_supplystash_tier_migration` (`player_id`, `itemtype`, `tier`, `amount`)
-		SELECT ps.`player_id`, ps.`itemtype`, COALESCE(ps.`tier`, 0), SUM(ps.`amount`)
-		FROM `player_supplystash` ps
-		INNER JOIN `players` p ON p.`id` = ps.`player_id`
-		WHERE ps.`amount` > 0
-		GROUP BY ps.`player_id`, ps.`itemtype`, COALESCE(ps.`tier`, 0)
-	]], "Could not copy supply stash rows into tier migration table.") then
-		restoreOriginalForeignKey()
-		db.query("DROP TABLE IF EXISTS `player_supplystash_tier_migration`")
-		return false
-	end
-
-	if not runSchemaQuery("DROP TABLE `player_supplystash`", "Could not drop old supply stash table.") then
-		restoreOriginalForeignKey()
-		db.query("DROP TABLE IF EXISTS `player_supplystash_tier_migration`")
-		return false
-	end
-	return runSchemaQuery("RENAME TABLE `player_supplystash_tier_migration` TO `player_supplystash`", "Could not rename tier migration table.")
-end
-
--- Ensures the `player_supplystash` table has a composite primary key on `player_id,itemtype,tier`, altering or rebuilding the table if necessary.
--- This may modify the database schema to enforce the correct primary key.
--- @return `true` if the primary key is configured as `player_id,itemtype,tier`, `false` otherwise.
-local function ensureSupplyStashPrimaryKey()
-	if getSupplyStashPrimaryKeySignature() == "player_id,itemtype,tier" then
-		return true
-	end
-
-	if runSchemaQuery("ALTER TABLE `player_supplystash` DROP PRIMARY KEY, ADD PRIMARY KEY (`player_id`, `itemtype`, `tier`)", "Could not alter supply stash primary key; trying table rebuild.") and
-			getSupplyStashPrimaryKeySignature() == "player_id,itemtype,tier" then
-		return true
-	end
-
-	return rebuildSupplyStashTable()
-end
-
--- Ensures the database schema for the supply stash exists and is up-to-date.
--- Creates the `player_supplystash` table if missing (columns: `player_id`, `itemtype`, `tier`, `amount`),
--- guarantees the `tier` column exists, and enforces the composite primary key (`player_id`, `itemtype`, `tier`)
--- along with the foreign key constraint to `players(id)`.
-local function ensureTables()
-	if not runSchemaQuery([[
-		CREATE TABLE IF NOT EXISTS `player_supplystash` (
-			`player_id` INT NOT NULL,
-			`itemtype` SMALLINT UNSIGNED NOT NULL,
-			`tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
-			`amount` INT UNSIGNED NOT NULL DEFAULT 0,
-			PRIMARY KEY (`player_id`, `itemtype`, `tier`),
-			CONSTRAINT `player_supplystash_player_fk`
-				FOREIGN KEY (`player_id`) REFERENCES `players` (`id`)
-				ON DELETE CASCADE
-		) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
-	]], "Could not create supply stash table.") then
-		return false
-	end
-
-	if not tableColumnExists("player_supplystash", "tier") then
-		if not runSchemaQuery("ALTER TABLE `player_supplystash` ADD COLUMN `tier` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `itemtype`", "Could not add tier column to supply stash table.") then
-			return false
-		end
-	end
-	if not ensureSupplyStashPrimaryKey() then
-		logError("[SupplyStash] Could not ensure supply stash primary key.")
-		return false
-	end
-	return true
 end
 
 -- Get the ItemType corresponding to the provided item id or nil when the id is invalid or the item type does not exist.
@@ -553,23 +416,11 @@ end
 -- @return An array of tables { itemId = <number>, tier = <number>, amount = <number> } for each stored entry; `amount` is clamped to at most 0xFFFFFFFF.
 local function getRows(player)
 	local rows = {}
-	local resultId = db.storeQuery(
-		"SELECT `itemtype`, `tier`, `amount` FROM `player_supplystash` WHERE `player_id` = " ..
-		player:getGuid() .. " AND `amount` > 0 ORDER BY `itemtype` ASC, `tier` ASC"
-	)
-
-	if resultId then
-		repeat
-			local itemId = result.getDataInt(resultId, "itemtype")
-			local tier = result.getDataInt(resultId, "tier")
-			local amount = result.getDataLong and result.getDataLong(resultId, "amount") or result.getDataInt(resultId, "amount")
-			if isSupplyItem(itemId) and amount > 0 then
-				rows[#rows + 1] = {itemId = itemId, tier = tier, amount = math.min(amount, 0xFFFFFFFF)}
-			end
-		until not result.next(resultId)
-		result.free(resultId)
+	for _, row in ipairs(Game.getSupplyStashRows(player:getGuid()) or {}) do
+		if isSupplyItem(row.itemId) and row.amount > 0 then
+			rows[#rows + 1] = row
+		end
 	end
-
 	return rows
 end
 
@@ -608,25 +459,6 @@ local function sendStash(player)
 	return msg:sendToPlayer(player)
 end
 
--- Retrieves the stored amount for a specific item and tier in the player's supply stash.
--- @param player The player whose stash is queried.
--- @param itemId The item type id to query.
--- @param tier Tier of the item; values are clamped to the range 0..10.
--- @return The stored amount for the (itemId, tier) entry, or 0 if none exists.
-local function getStoredAmount(player, itemId, tier)
-	local amount = 0
-	tier = math.max(0, math.min(10, tonumber(tier) or 0))
-	local resultId = db.storeQuery(
-		"SELECT `amount` FROM `player_supplystash` WHERE `player_id` = " ..
-		player:getGuid() .. " AND `itemtype` = " .. itemId .. " AND `tier` = " .. tier .. " LIMIT 1"
-	)
-	if resultId then
-		amount = result.getDataLong and result.getDataLong(resultId, "amount") or result.getDataInt(resultId, "amount")
-		result.free(resultId)
-	end
-	return amount
-end
-
 -- Adds `amount` to the stored quantity for the given player's item and tier, creating a row if none exists.
 -- @param player The player whose stash will be modified.
 -- @param itemId The item type id to increment.
@@ -634,12 +466,7 @@ end
 -- @param tier The item tier; values are clamped to the range 0..10.
 -- @return The database query result on success, `false` on failure.
 local function addStoredAmount(player, itemId, amount, tier)
-	tier = math.max(0, math.min(10, tonumber(tier) or 0))
-	return db.query(string.format(
-		"INSERT INTO `player_supplystash` (`player_id`, `itemtype`, `tier`, `amount`) VALUES (%d, %d, %d, %d) " ..
-		"ON DUPLICATE KEY UPDATE `amount` = `amount` + VALUES(`amount`)",
-		player:getGuid(), itemId, tier, amount
-	))
+	return Game.addSupplyStashAmount(player:getGuid(), itemId, amount, tier)
 end
 
 -- Decrease the stored quantity for a specific item and tier in a player's supply stash.
@@ -649,15 +476,11 @@ end
 -- @param tier The item tier; coerced to an integer in the range 0..10.
 -- @return The result of the database update query.
 local function removeStoredAmount(player, itemId, amount, tier)
-	tier = math.max(0, math.min(10, tonumber(tier) or 0))
-	return db.query(string.format(
-		"UPDATE `player_supplystash` SET `amount` = `amount` - %d WHERE `player_id` = %d AND `itemtype` = %d AND `tier` = %d AND `amount` >= %d",
-		amount, player:getGuid(), itemId, tier, amount
-	))
+	return Game.removeSupplyStashAmount(player:getGuid(), itemId, amount, tier)
 end
 
 local function cleanupEmptyRows(player)
-	db.query("DELETE FROM `player_supplystash` WHERE `player_id` = " .. player:getGuid() .. " AND `amount` = 0")
+	return Game.cleanupSupplyStash(player:getGuid())
 end
 
 local function collectSupplyItems(container, list)
@@ -876,14 +699,8 @@ local function withdraw(player, itemId, amount, tier)
 		return true
 	end
 
-	if getStoredAmount(player, itemId, tier) < amount then
-		player:sendCancelMessage("You do not have enough items in your supply stash.")
-		sendStash(player)
-		return true
-	end
-
 	if not removeStoredAmount(player, itemId, amount, tier) then
-		player:sendCancelMessage("Could not remove the items from your supply stash.")
+		player:sendCancelMessage("You do not have enough items in your supply stash.")
 		sendStash(player)
 		return true
 	end
@@ -896,7 +713,7 @@ local function withdraw(player, itemId, amount, tier)
 		return true
 	end
 
-	db.query("DELETE FROM `player_supplystash` WHERE `player_id` = " .. player:getGuid() .. " AND `amount` = 0")
+	cleanupEmptyRows(player)
 	sendStash(player)
 	return true
 end
@@ -904,7 +721,7 @@ end
 local handler = PacketHandler(OPCODE_SUPPLY_STASH_REQUEST)
 
 -- Handles incoming supply stash request packets and dispatches open, stow-all, and withdraw actions.
--- Ensures database tables exist, verifies the player uses the custom network client, and sends appropriate responses or cancel messages.
+-- Verifies the custom client and nearby depot access before changing stash contents.
 -- @param player The player who sent the packet.
 -- @param msg The incoming network message containing the action and any parameters.
 -- @return `true` to indicate the packet was handled.
@@ -929,17 +746,21 @@ function handler.onReceive(player, msg)
 		return true
 	end
 
-	if not ensureTables() then
-		player:sendCancelMessage("Supply stash is temporarily unavailable.")
-		return true
-	end
-
 	if action == ACTION_OPEN then
+		if not hasCurrentSupplyStashAccess(player) then
+			player:sendCancelMessage("You need to be near a depot to open the supply stash.")
+			return true
+		end
 		setSupplyStashDepotId(player, getPlayerLastDepotId(player))
 		sendStash(player)
 	elseif action == ACTION_STOW_ALL then
-		stowAll(player)
+		if ensureSupplyStashAccess(player) then
+			stowAll(player)
+		end
 	elseif action == ACTION_WITHDRAW then
+		if not ensureSupplyStashAccess(player) then
+			return true
+		end
 		if not NetworkGuard.canRead(msg, 6) then
 			return true
 		end
@@ -963,21 +784,31 @@ end
 
 handler:register()
 
+local supplyStashSessionCleanup = CreatureEvent("CustomSupplyStashSessionCleanup")
+function supplyStashSessionCleanup.onLogout(player)
+	supplyStashDepotSessions[player:getId()] = nil
+	return true
+end
+supplyStashSessionCleanup:register()
+
+local supplyStashSessionInit = CreatureEvent("CustomSupplyStashSessionInit")
+function supplyStashSessionInit.onLogin(player)
+	player:registerEvent("CustomSupplyStashSessionCleanup")
+	return true
+end
+supplyStashSessionInit:register()
+
 CustomSupplyStash = {
 	open = function(player, depotId)
 		if not supportsCustomNetwork(player) then
 			return false
 		end
 
-		if not ensureTables() then
-			player:sendCancelMessage("Supply stash is temporarily unavailable.")
+		if not hasCurrentSupplyStashAccess(player) then
+			player:sendCancelMessage("You need to be near a depot to open the supply stash.")
 			return false
 		end
 		setSupplyStashDepotId(player, depotId or getPlayerLastDepotId(player))
 		return sendStash(player)
-	end,
-	stowAll = stowAll,
-	withdraw = withdraw
+	end
 }
-
-ensureTables()

--- a/schema.sql
+++ b/schema.sql
@@ -283,11 +283,12 @@ CREATE TABLE IF NOT EXISTS `market_history` (
   `itemtype` smallint unsigned NOT NULL,
   `amount` smallint unsigned NOT NULL,
   `price` int unsigned NOT NULL DEFAULT '0',
+  `tier` tinyint unsigned NOT NULL DEFAULT '0',
   `expires_at` bigint unsigned NOT NULL,
   `inserted` bigint unsigned NOT NULL,
   `state` tinyint unsigned NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `player_id` (`player_id`, `sale`),
+  KEY `idx_market_history_player_inserted` (`player_id`, `inserted`),
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
@@ -300,10 +301,24 @@ CREATE TABLE IF NOT EXISTS `market_offers` (
   `created` bigint unsigned NOT NULL,
   `anonymous` tinyint NOT NULL DEFAULT '0',
   `price` int unsigned NOT NULL DEFAULT '0',
+  `tier` tinyint unsigned NOT NULL DEFAULT '0',
+  `attributes` mediumblob DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `sale` (`sale`,`itemtype`),
-  KEY `created` (`created`),
+  KEY `idx_market_offers_item_sale_price` (`itemtype`, `sale`, `price`, `created`),
+  KEY `idx_market_offers_player_created` (`player_id`, `created`),
+  KEY `idx_market_offers_created` (`created`),
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+
+CREATE TABLE IF NOT EXISTS `market_statistics` (
+  `itemtype` smallint unsigned NOT NULL,
+  `sale` tinyint NOT NULL DEFAULT '0',
+  `day` int unsigned NOT NULL,
+  `transactions` int unsigned NOT NULL DEFAULT '0',
+  `total_price` bigint unsigned NOT NULL DEFAULT '0',
+  `highest_price` int unsigned NOT NULL DEFAULT '0',
+  `lowest_price` int unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`itemtype`, `sale`, `day`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
 CREATE TABLE IF NOT EXISTS `players_online` (
@@ -703,7 +718,7 @@ CREATE TABLE IF NOT EXISTS `towns` (
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
-INSERT INTO server_config (config, value) VALUES ('db_version', '59'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO server_config (config, value) VALUES ('db_version', '60'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 CREATE TABLE IF NOT EXISTS guild_transactions (
   id SERIAL PRIMARY KEY,

--- a/schema.sql
+++ b/schema.sql
@@ -450,6 +450,16 @@ CREATE TABLE IF NOT EXISTS `player_storage` (
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
+CREATE TABLE IF NOT EXISTS `player_supplystash` (
+  `player_id` INT NOT NULL,
+  `itemtype` SMALLINT UNSIGNED NOT NULL,
+  `tier` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `amount` INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`player_id`, `itemtype`, `tier`),
+  CONSTRAINT `player_supplystash_player_fk`
+    FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+
 CREATE TABLE IF NOT EXISTS `player_bestiary_kills` (
   `player_id` INT NOT NULL,
   `raceid` SMALLINT UNSIGNED NOT NULL,
@@ -718,7 +728,7 @@ CREATE TABLE IF NOT EXISTS `towns` (
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
-INSERT INTO server_config (config, value) VALUES ('db_version', '60'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO server_config (config, value) VALUES ('db_version', '61'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 CREATE TABLE IF NOT EXISTS guild_transactions (
   id SERIAL PRIMARY KEY,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/map.cpp
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.cpp
 	${CMAKE_CURRENT_LIST_DIR}/market.cpp
+	${CMAKE_CURRENT_LIST_DIR}/stash.cpp
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monster.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
@@ -197,6 +198,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/map.h
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.h
 	${CMAKE_CURRENT_LIST_DIR}/market.h
+	${CMAKE_CURRENT_LIST_DIR}/stash.h
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.h
 	${CMAKE_CURRENT_LIST_DIR}/monster.h
 	${CMAKE_CURRENT_LIST_DIR}/monsters.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/mailbox.cpp
 	${CMAKE_CURRENT_LIST_DIR}/map.cpp
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.cpp
+	${CMAKE_CURRENT_LIST_DIR}/market.cpp
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monster.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
@@ -195,6 +196,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/mailbox.h
 	${CMAKE_CURRENT_LIST_DIR}/map.h
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.h
+	${CMAKE_CURRENT_LIST_DIR}/market.h
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.h
 	${CMAKE_CURRENT_LIST_DIR}/monster.h
 	${CMAKE_CURRENT_LIST_DIR}/monsters.h

--- a/src/bestiary_charm.cpp
+++ b/src/bestiary_charm.cpp
@@ -7,6 +7,7 @@
 
 #include "database.h"
 #include "game.h"
+#include "logger.h"
 #include "player.h"
 
 #include <algorithm>
@@ -104,14 +105,19 @@ BestiaryCharmSystem g_bestiaryCharmSystem;
 
 void BestiaryCharmSystem::registerMonster(BestiaryCreatureInfo info)
 {
-	if (info.raceId == 0) {
+	if (info.raceId == 0 || info.toKill == 0) {
+		LOG_ERROR("[Bestiary] Refusing invalid monster registration: raceId={}, name='{}', toKill={}",
+		          info.raceId, info.name, info.toKill);
 		return;
 	}
 
 	if (info.name.empty()) {
 		info.name = "?";
 	}
-	if (info.secondUnlock == 0 || info.secondUnlock > info.toKill) {
+	if (info.firstUnlock == 0 || info.firstUnlock > info.toKill) {
+		info.firstUnlock = info.toKill;
+	}
+	if (info.secondUnlock < info.firstUnlock || info.secondUnlock > info.toKill) {
 		info.secondUnlock = info.toKill;
 	}
 
@@ -125,6 +131,23 @@ std::optional<std::reference_wrapper<const BestiaryCreatureInfo>> BestiaryCharmS
 		return std::nullopt;
 	}
 	return std::cref(it->second);
+}
+
+uint8_t BestiaryCharmSystem::getProgress(const BestiaryCreatureInfo& info, uint32_t kills)
+{
+	if (kills == 0) {
+		return 0;
+	}
+	if (kills >= info.toKill) {
+		return 4;
+	}
+	if (kills >= info.secondUnlock) {
+		return 3;
+	}
+	if (kills >= info.firstUnlock) {
+		return 2;
+	}
+	return 1;
 }
 
 bool BestiaryCharmSystem::isMajorCharm(uint8_t charmId) const

--- a/src/bestiary_charm.h
+++ b/src/bestiary_charm.h
@@ -24,6 +24,7 @@ struct BestiaryCreatureInfo
 	uint16_t raceId = 0;
 	std::string name;
 	uint32_t toKill = 0;
+	uint32_t firstUnlock = 0;
 	uint32_t secondUnlock = 0;
 	uint16_t charmPoints = 0;
 	uint16_t lookType = 0;
@@ -44,6 +45,8 @@ class BestiaryCharmSystem
 {
 public:
 	void registerMonster(BestiaryCreatureInfo info);
+	[[nodiscard]] std::optional<std::reference_wrapper<const BestiaryCreatureInfo>> getMonster(uint16_t raceId) const;
+	[[nodiscard]] static uint8_t getProgress(const BestiaryCreatureInfo& info, uint32_t kills);
 	BestiaryCharmActionResult handleCharmAction(Player& player, uint8_t charmId, uint8_t action, uint16_t raceId) const;
 
 	[[nodiscard]] bool isMajorCharm(uint8_t charmId) const;
@@ -73,7 +76,6 @@ private:
 	[[nodiscard]] bool removeGold(Player& player, uint64_t amount) const;
 	[[nodiscard]] uint8_t getAssignedCharmCount(const CharmStateMap& states) const;
 	[[nodiscard]] uint32_t getSpentMajorCharmPoints(const CharmStateMap& states) const;
-	[[nodiscard]] std::optional<std::reference_wrapper<const BestiaryCreatureInfo>> getMonster(uint16_t raceId) const;
 	[[nodiscard]] bool writeCharmStates(uint32_t playerGuid, const CharmStateMap& states) const;
 	[[nodiscard]] bool restoreCharmStates(uint32_t playerGuid, const CharmStateMap& states) const;
 	[[nodiscard]] bool restoreCharmStatesAndResources(uint32_t playerGuid, const CharmStateMap& states,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -10,8 +10,10 @@
 #include "game.h"
 #include "monster.h"
 #include "performance_metrics.h"
+#include "player.h"
 #include "scheduler.h"
 #include "scriptmanager.h"
+#include "bestiary_charm.h"
 #include "instance_utils.h"
 #include "tools.h"
 
@@ -561,6 +563,60 @@ void Creature::onDeath()
 					experienceMap[attacker] = gainExp;
 				} else {
 					tmpIt->second += gainExp;
+				}
+			}
+		}
+	}
+
+	// Keep the Bestiary base kill on the game thread and independent from Lua event
+	// registration. Recipient selection intentionally mirrors the former Lua onDeath:
+	// last hit and most damage resolve a player summon to its master, while the damage
+	// map contributes direct players only. GUID deduplication gives one base kill per
+	// player and death; party sharing is deliberately not introduced here.
+	if (Monster* monster = getMonster(); monster && !monster->isSummon() &&
+	    ConfigManager::getBoolean(ConfigManager::BESTIARY_SYSTEM_ENABLED)) {
+		const MonsterType* monsterType = monster->getMonsterType();
+		const uint32_t monsterRaceId = monsterType ? monsterType->raceId : 0;
+		if (monsterType && monsterRaceId > 0 && monsterRaceId <= std::numeric_limits<uint16_t>::max()) {
+			const uint16_t raceId = static_cast<uint16_t>(monsterRaceId);
+			const auto registeredMonster = g_bestiaryCharmSystem.getMonster(raceId);
+			if (registeredMonster) {
+				std::unordered_map<uint32_t, std::shared_ptr<Player>> recipients;
+				auto addPlayerOwner = [&recipients](const std::shared_ptr<Creature>& attacker) {
+					if (!attacker) {
+						return;
+					}
+
+					std::shared_ptr<Creature> owner = attacker;
+					if (!owner->getPlayer()) {
+						owner = owner->getMasterShared();
+					}
+					if (!owner || !owner->getPlayer()) {
+						return;
+					}
+
+					if (auto player = g_game.getPlayerByID(owner->getID())) {
+						recipients.try_emplace(player->getGUID(), std::move(player));
+					}
+				};
+
+				addPlayerOwner(lastHitCreature);
+				addPlayerOwner(mostDamageCreature);
+				for (const auto& [attackerId, _] : damageMap) {
+					auto attacker = g_game.getCreatureByIDShared(attackerId);
+					if (attacker && attacker->getPlayer()) {
+						addPlayerOwner(attacker);
+					}
+				}
+
+				const BestiaryCreatureInfo& info = registeredMonster->get();
+				for (const auto& [_, player] : recipients) {
+					const auto [oldCount, newCount] = player->addBestiaryKillCount(raceId, 1);
+					const bool completed = oldCount < info.toKill && newCount >= info.toKill;
+					if (completed) {
+						player->addBestiaryCharmPoints(info.charmPoints);
+					}
+					player->setPendingBestiaryKill({getID(), raceId, oldCount, newCount, completed});
 				}
 			}
 		}

--- a/src/luagame.cpp
+++ b/src/luagame.cpp
@@ -19,6 +19,7 @@
 #include "tools.h"
 #include "logger.h"
 #include "market.h"
+#include "stash.h"
 #include "zones.h"
 #include <fmt/format.h>
 
@@ -1397,6 +1398,47 @@ int luaGameInsertMarketInboxItem(lua_State* L)
 	return 1;
 }
 
+int luaGameGetSupplyStashRows(lua_State* L)
+{
+	// Game.getSupplyStashRows(playerId)
+	const auto rows = Stash::getRows(getInteger<uint32_t>(L, 1));
+	lua_createtable(L, static_cast<int>(rows.size()), 0);
+	int index = 0;
+	for (const StashRecord& row : rows) {
+		lua_createtable(L, 0, 3);
+		setField(L, "itemId", row.itemId);
+		setField(L, "tier", row.tier);
+		setField(L, "amount", row.amount);
+		lua_rawseti(L, -2, ++index);
+	}
+	return 1;
+}
+
+int luaGameAddSupplyStashAmount(lua_State* L)
+{
+	// Game.addSupplyStashAmount(playerId, itemId, amount[, tier = 0])
+	pushBoolean(L, Stash::addAmount(
+		getInteger<uint32_t>(L, 1), getInteger<uint16_t>(L, 2), getInteger<uint32_t>(L, 3),
+		Stash::normalizeTier(getInteger<uint32_t>(L, 4, 0))));
+	return 1;
+}
+
+int luaGameRemoveSupplyStashAmount(lua_State* L)
+{
+	// Game.removeSupplyStashAmount(playerId, itemId, amount[, tier = 0])
+	pushBoolean(L, Stash::removeAmount(
+		getInteger<uint32_t>(L, 1), getInteger<uint16_t>(L, 2), getInteger<uint32_t>(L, 3),
+		Stash::normalizeTier(getInteger<uint32_t>(L, 4, 0))));
+	return 1;
+}
+
+int luaGameCleanupSupplyStash(lua_State* L)
+{
+	// Game.cleanupSupplyStash(playerId)
+	pushBoolean(L, Stash::cleanup(getInteger<uint32_t>(L, 1)));
+	return 1;
+}
+
 int luaGameRegisterBestiaryMonsterData(lua_State* L)
 {
 	// Game.registerBestiaryMonsterData(raceId, name, toKill, firstUnlock, secondUnlock, charmPoints, lookType, lookHead, lookBody, lookLegs, lookFeet, lookAddons)
@@ -1618,6 +1660,10 @@ void LuaScriptInterface::registerGame()
 	registerMethod("Game", "refreshMarketStatistics", luaGameRefreshMarketStatistics);
 	registerMethod("Game", "creditMarketBank", luaGameCreditMarketBank);
 	registerMethod("Game", "insertMarketInboxItem", luaGameInsertMarketInboxItem);
+	registerMethod("Game", "getSupplyStashRows", luaGameGetSupplyStashRows);
+	registerMethod("Game", "addSupplyStashAmount", luaGameAddSupplyStashAmount);
+	registerMethod("Game", "removeSupplyStashAmount", luaGameRemoveSupplyStashAmount);
+	registerMethod("Game", "cleanupSupplyStash", luaGameCleanupSupplyStash);
 	registerMethod("Game", "registerBestiaryMonsterData", luaGameRegisterBestiaryMonsterData);
 	registerMethod("Game", "handleBestiaryCharmAction", luaGameHandleBestiaryCharmAction);
 	registerMethod("Game", "getBestiaryKills", luaGameGetBestiaryKills);

--- a/src/luagame.cpp
+++ b/src/luagame.cpp
@@ -18,6 +18,7 @@
 #include "talkaction.h"
 #include "tools.h"
 #include "logger.h"
+#include "market.h"
 #include "zones.h"
 #include <fmt/format.h>
 
@@ -1206,6 +1207,196 @@ int luaGameSetWorldTime(lua_State* L)
 	return 1;
 }
 
+void pushMarketOffer(lua_State* L, const MarketOfferRecord& offer)
+{
+	lua_createtable(L, 0, 12);
+	setField(L, "id", offer.id);
+	setField(L, "playerId", offer.playerId);
+	setField(L, "sale", offer.sale);
+	setField(L, "itemId", offer.itemId);
+	setField(L, "amount", offer.amount);
+	setField(L, "created", offer.created);
+	pushBoolean(L, offer.anonymous);
+	lua_setfield(L, -2, "anonymous");
+	setField(L, "price", offer.price);
+	setField(L, "tier", offer.tier);
+	if (!offer.attributes.empty()) {
+		setField(L, "attributes", offer.attributes);
+	}
+	setField(L, "playerName", offer.playerName);
+	setField(L, "state", offer.state);
+}
+
+void pushMarketOffers(lua_State* L, const std::vector<MarketOfferRecord>& offers)
+{
+	lua_createtable(L, static_cast<int>(offers.size()), 0);
+	int index = 0;
+	for (const MarketOfferRecord& offer : offers) {
+		pushMarketOffer(L, offer);
+		lua_rawseti(L, -2, ++index);
+	}
+}
+
+int luaGameGetMarketOfferCount(lua_State* L)
+{
+	// Game.getMarketOfferCount(playerId)
+	lua_pushinteger(L, Market::getOfferCount(getInteger<uint32_t>(L, 1)));
+	return 1;
+}
+
+int luaGameGetMarketOffer(lua_State* L)
+{
+	// Game.getMarketOffer(offerId)
+	const auto offer = Market::getOffer(getInteger<uint32_t>(L, 1));
+	if (!offer) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	pushMarketOffer(L, *offer);
+	return 1;
+}
+
+int luaGameGetOwnMarketOffers(lua_State* L)
+{
+	// Game.getOwnMarketOffers(playerId[, limit = 250])
+	pushMarketOffers(L, Market::getOwnOffers(
+		getInteger<uint32_t>(L, 1), getInteger<uint32_t>(L, 2, Market::MAX_PACKET_OFFERS)));
+	return 1;
+}
+
+int luaGameGetItemMarketOffers(lua_State* L)
+{
+	// Game.getItemMarketOffers(itemId, sale[, limit = 250])
+	pushMarketOffers(L, Market::getItemOffers(
+		getInteger<uint16_t>(L, 1), getInteger<uint8_t>(L, 2),
+		getInteger<uint32_t>(L, 3, Market::MAX_PACKET_OFFERS)));
+	return 1;
+}
+
+int luaGameGetExpiredMarketOffers(lua_State* L)
+{
+	// Game.getExpiredMarketOffers(createdBefore[, limit = 100])
+	pushMarketOffers(L, Market::getExpiredOffers(
+		getInteger<uint32_t>(L, 1), getInteger<uint32_t>(L, 2, Market::MAX_EXPIRED_OFFERS)));
+	return 1;
+}
+
+int luaGameGetMarketHistory(lua_State* L)
+{
+	// Game.getMarketHistory(playerId[, limit = 250])
+	pushMarketOffers(L, Market::getHistory(
+		getInteger<uint32_t>(L, 1), getInteger<uint32_t>(L, 2, Market::MAX_PACKET_OFFERS)));
+	return 1;
+}
+
+int luaGameGetMarketStatistics(lua_State* L)
+{
+	// Game.getMarketStatistics(itemId, sale, firstDay[, limit = 30])
+	const auto statistics = Market::getStatistics(
+		getInteger<uint16_t>(L, 1), getInteger<uint8_t>(L, 2), getInteger<uint32_t>(L, 3),
+		getInteger<uint32_t>(L, 4, Market::MAX_STATISTIC_DAYS));
+	lua_createtable(L, static_cast<int>(statistics.size()), 0);
+	int index = 0;
+	for (const MarketStatisticRecord& statistic : statistics) {
+		lua_createtable(L, 0, 5);
+		setField(L, "day", statistic.day);
+		setField(L, "transactions", statistic.transactions);
+		setField(L, "totalPrice", statistic.totalPrice);
+		setField(L, "highestPrice", statistic.highestPrice);
+		setField(L, "lowestPrice", statistic.lowestPrice);
+		lua_rawseti(L, -2, ++index);
+	}
+	return 1;
+}
+
+int luaGameCreateMarketOffer(lua_State* L)
+{
+	// Game.createMarketOffer(playerId, sale, itemId, amount, created, anonymous, price, tier[, attributes])
+	MarketOfferRecord offer;
+	offer.playerId = getInteger<uint32_t>(L, 1);
+	offer.sale = getInteger<uint8_t>(L, 2);
+	offer.itemId = getInteger<uint16_t>(L, 3);
+	offer.amount = getInteger<uint32_t>(L, 4);
+	offer.created = getInteger<uint32_t>(L, 5);
+	offer.anonymous = getBoolean(L, 6);
+	offer.price = getInteger<uint32_t>(L, 7);
+	offer.tier = Market::normalizeTier(getInteger<uint32_t>(L, 8));
+	if (lua_isstring(L, 9)) {
+		offer.attributes = getString(L, 9);
+	}
+	pushBoolean(L, Market::createOffer(offer));
+	return 1;
+}
+
+int luaGameClaimMarketOffer(lua_State* L)
+{
+	// Game.claimMarketOffer(offerId, expectedAmount, acceptedAmount[, ownerId = 0])
+	pushBoolean(L, Market::claimOffer(
+		getInteger<uint32_t>(L, 1), getInteger<uint32_t>(L, 2), getInteger<uint32_t>(L, 3),
+		getInteger<uint32_t>(L, 4, 0)));
+	return 1;
+}
+
+int luaGameRestoreMarketOffer(lua_State* L)
+{
+	// Game.restoreMarketOffer(id, playerId, sale, itemId, amount, created, anonymous, price, tier, attributes,
+	//                         acceptedAmount)
+	MarketOfferRecord offer;
+	offer.id = getInteger<uint32_t>(L, 1);
+	offer.playerId = getInteger<uint32_t>(L, 2);
+	offer.sale = getInteger<uint8_t>(L, 3);
+	offer.itemId = getInteger<uint16_t>(L, 4);
+	offer.amount = getInteger<uint32_t>(L, 5);
+	offer.created = getInteger<uint32_t>(L, 6);
+	offer.anonymous = getBoolean(L, 7);
+	offer.price = getInteger<uint32_t>(L, 8);
+	offer.tier = Market::normalizeTier(getInteger<uint32_t>(L, 9));
+	if (lua_isstring(L, 10)) {
+		offer.attributes = getString(L, 10);
+	}
+	pushBoolean(L, Market::restoreOffer(offer, getInteger<uint32_t>(L, 11)));
+	return 1;
+}
+
+int luaGameAddMarketHistory(lua_State* L)
+{
+	// Game.addMarketHistory(playerId, sale, itemId, amount, price, tier, expiresAt, inserted, state)
+	pushBoolean(L, Market::addHistory(
+		getInteger<uint32_t>(L, 1), getInteger<uint8_t>(L, 2), getInteger<uint16_t>(L, 3),
+		getInteger<uint32_t>(L, 4), getInteger<uint32_t>(L, 5), getInteger<uint8_t>(L, 6),
+		getInteger<uint32_t>(L, 7), getInteger<uint32_t>(L, 8), getInteger<uint8_t>(L, 9)));
+	return 1;
+}
+
+int luaGameRefreshMarketStatistics(lua_State* L)
+{
+	// Game.refreshMarketStatistics(firstDay, acceptedState)
+	pushBoolean(L, Market::refreshStatistics(
+		getInteger<uint32_t>(L, 1), getInteger<uint8_t>(L, 2)));
+	return 1;
+}
+
+int luaGameCreditMarketBank(lua_State* L)
+{
+	// Game.creditMarketBank(playerId, amount)
+	pushBoolean(L, Market::creditBank(
+		getInteger<uint32_t>(L, 1), getInteger<uint64_t>(L, 2)));
+	return 1;
+}
+
+int luaGameInsertMarketInboxItem(lua_State* L)
+{
+	// Game.insertMarketInboxItem(playerId, itemId, amount[, attributes])
+	std::string attributes;
+	if (lua_isstring(L, 4)) {
+		attributes = getString(L, 4);
+	}
+	pushBoolean(L, Market::insertInboxItems(
+		getInteger<uint32_t>(L, 1), getInteger<uint16_t>(L, 2), getInteger<uint32_t>(L, 3), attributes));
+	return 1;
+}
+
 int luaGameRegisterBestiaryMonsterData(lua_State* L)
 {
 	// Game.registerBestiaryMonsterData(raceId, name, toKill, firstUnlock, secondUnlock, charmPoints, lookType, lookHead, lookBody, lookLegs, lookFeet, lookAddons)
@@ -1413,6 +1604,20 @@ void LuaScriptInterface::registerGame()
 	registerTable("Game");
 	registerMethod("Game", "getLightState", luaGameGetLightState);
 	registerMethod("Game", "setWorldTime", luaGameSetWorldTime);
+	registerMethod("Game", "getMarketOfferCount", luaGameGetMarketOfferCount);
+	registerMethod("Game", "getMarketOffer", luaGameGetMarketOffer);
+	registerMethod("Game", "getOwnMarketOffers", luaGameGetOwnMarketOffers);
+	registerMethod("Game", "getItemMarketOffers", luaGameGetItemMarketOffers);
+	registerMethod("Game", "getExpiredMarketOffers", luaGameGetExpiredMarketOffers);
+	registerMethod("Game", "getMarketHistory", luaGameGetMarketHistory);
+	registerMethod("Game", "getMarketStatistics", luaGameGetMarketStatistics);
+	registerMethod("Game", "createMarketOffer", luaGameCreateMarketOffer);
+	registerMethod("Game", "claimMarketOffer", luaGameClaimMarketOffer);
+	registerMethod("Game", "restoreMarketOffer", luaGameRestoreMarketOffer);
+	registerMethod("Game", "addMarketHistory", luaGameAddMarketHistory);
+	registerMethod("Game", "refreshMarketStatistics", luaGameRefreshMarketStatistics);
+	registerMethod("Game", "creditMarketBank", luaGameCreditMarketBank);
+	registerMethod("Game", "insertMarketInboxItem", luaGameInsertMarketInboxItem);
 	registerMethod("Game", "registerBestiaryMonsterData", luaGameRegisterBestiaryMonsterData);
 	registerMethod("Game", "handleBestiaryCharmAction", luaGameHandleBestiaryCharmAction);
 	registerMethod("Game", "getBestiaryKills", luaGameGetBestiaryKills);

--- a/src/luagame.cpp
+++ b/src/luagame.cpp
@@ -1208,21 +1208,23 @@ int luaGameSetWorldTime(lua_State* L)
 
 int luaGameRegisterBestiaryMonsterData(lua_State* L)
 {
-	// Game.registerBestiaryMonsterData(raceId, name, toKill, secondUnlock, charmPoints, lookType, lookHead, lookBody, lookLegs, lookFeet, lookAddons)
+	// Game.registerBestiaryMonsterData(raceId, name, toKill, firstUnlock, secondUnlock, charmPoints, lookType, lookHead, lookBody, lookLegs, lookFeet, lookAddons)
 	BestiaryCreatureInfo info;
 	info.raceId = getInteger<uint16_t>(L, 1);
 	info.name = getString(L, 2);
 	info.toKill = getInteger<uint32_t>(L, 3);
-	if (lua_gettop(L) >= 11) {
-		info.secondUnlock = getInteger<uint32_t>(L, 4);
-		info.charmPoints = getInteger<uint16_t>(L, 5);
-		info.lookType = getInteger<uint16_t>(L, 6, 0);
-		info.lookHead = getInteger<uint8_t>(L, 7, 0);
-		info.lookBody = getInteger<uint8_t>(L, 8, 0);
-		info.lookLegs = getInteger<uint8_t>(L, 9, 0);
-		info.lookFeet = getInteger<uint8_t>(L, 10, 0);
-		info.lookAddons = getInteger<uint8_t>(L, 11, 0);
+	if (lua_gettop(L) >= 12) {
+		info.firstUnlock = getInteger<uint32_t>(L, 4);
+		info.secondUnlock = getInteger<uint32_t>(L, 5);
+		info.charmPoints = getInteger<uint16_t>(L, 6);
+		info.lookType = getInteger<uint16_t>(L, 7, 0);
+		info.lookHead = getInteger<uint8_t>(L, 8, 0);
+		info.lookBody = getInteger<uint8_t>(L, 9, 0);
+		info.lookLegs = getInteger<uint8_t>(L, 10, 0);
+		info.lookFeet = getInteger<uint8_t>(L, 11, 0);
+		info.lookAddons = getInteger<uint8_t>(L, 12, 0);
 	} else {
+		info.firstUnlock = 1;
 		info.secondUnlock = info.toKill;
 		info.charmPoints = getInteger<uint16_t>(L, 4);
 		info.lookType = getInteger<uint16_t>(L, 5, 0);
@@ -1301,6 +1303,30 @@ int luaGameAddBestiaryKill(lua_State* L)
 	lua_pushinteger(L, oldCount);
 	lua_pushinteger(L, newCount);
 	return 2;
+}
+
+int luaGameTakeBestiaryKill(lua_State* L)
+{
+	// Game.takeBestiaryKill(player, raceId, victimId) -> handled, oldCount, newCount, charmPointsAwarded
+	Player* player = getPlayer(L, 1);
+	const uint16_t raceId = getInteger<uint16_t>(L, 2);
+	const uint32_t victimId = getInteger<uint32_t>(L, 3);
+	if (!player) {
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	const auto result = player->takePendingBestiaryKill(victimId, raceId);
+	if (!result) {
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	pushBoolean(L, true);
+	lua_pushinteger(L, result->oldCount);
+	lua_pushinteger(L, result->newCount);
+	pushBoolean(L, result->charmPointsAwarded);
+	return 4;
 }
 
 int luaGameSetBestiaryKillCount(lua_State* L)
@@ -1392,6 +1418,7 @@ void LuaScriptInterface::registerGame()
 	registerMethod("Game", "getBestiaryKills", luaGameGetBestiaryKills);
 	registerMethod("Game", "getBestiaryKillCount", luaGameGetBestiaryKillCount);
 	registerMethod("Game", "addBestiaryKill", luaGameAddBestiaryKill);
+	registerMethod("Game", "takeBestiaryKill", luaGameTakeBestiaryKill);
 	registerMethod("Game", "setBestiaryKillCount", luaGameSetBestiaryKillCount);
 	registerMethod("Game", "getBestiaryCharmPoints", luaGameGetBestiaryCharmPoints);
 	registerMethod("Game", "addBestiaryCharmPoints", luaGameAddBestiaryCharmPoints);

--- a/src/market.cpp
+++ b/src/market.cpp
@@ -1,0 +1,324 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "market.h"
+
+#include "database.h"
+#include "item.h"
+
+namespace {
+
+constexpr std::string_view OFFER_COLUMNS =
+	"mo.`id`, mo.`player_id`, mo.`sale`, mo.`itemtype`, mo.`amount`, mo.`created`, mo.`anonymous`, "
+	"mo.`price`, mo.`tier`, mo.`attributes`, p.`name` AS `player_name`";
+
+uint32_t clampLimit(uint32_t limit, uint32_t maximum)
+{
+	return std::clamp<uint32_t>(limit, 1, maximum);
+}
+
+MarketOfferRecord readOffer(const DBResult_ptr& result)
+{
+	MarketOfferRecord offer;
+	offer.id = result->getNumber<uint32_t>("id");
+	offer.playerId = result->getNumber<uint32_t>("player_id");
+	offer.sale = result->getNumber<uint8_t>("sale");
+	offer.itemId = result->getNumber<uint16_t>("itemtype");
+	offer.amount = result->getNumber<uint32_t>("amount");
+	offer.created = result->getNumber<uint32_t>("created");
+	offer.anonymous = result->getNumber<uint8_t>("anonymous") != 0;
+	offer.price = result->getNumber<uint32_t>("price");
+	offer.tier = Market::normalizeTier(result->getNumber<uint32_t>("tier"));
+	offer.attributes = std::string(result->getString("attributes"));
+	offer.playerName = std::string(result->getString("player_name"));
+	return offer;
+}
+
+std::string escapedAttributes(Database& db, const std::string& attributes)
+{
+	return db.escapeBlob(attributes.data(), static_cast<uint32_t>(attributes.size()));
+}
+
+bool affectedExactlyOne(Database& db, std::string query)
+{
+	return db.executeQuery(query) && db.getAffectedRows() == 1;
+}
+
+} // namespace
+
+uint8_t Market::normalizeTier(uint32_t tier)
+{
+	return static_cast<uint8_t>(std::min<uint32_t>(tier, MAX_ITEM_TIER));
+}
+
+uint32_t Market::getOfferCount(uint32_t playerId)
+{
+	const DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
+		"SELECT COUNT(*) AS `total` FROM `market_offers` WHERE `player_id` = {:d}", playerId));
+	return result ? result->getNumber<uint32_t>("total") : 0;
+}
+
+std::optional<MarketOfferRecord> Market::getOffer(uint32_t offerId)
+{
+	const DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
+		"SELECT {:s} FROM `market_offers` AS mo INNER JOIN `players` AS p ON p.`id` = mo.`player_id` "
+		"WHERE mo.`id` = {:d} LIMIT 1",
+		OFFER_COLUMNS, offerId));
+	if (!result) {
+		return std::nullopt;
+	}
+	return readOffer(result);
+}
+
+std::vector<MarketOfferRecord> Market::fetchOffers(const std::string& query, uint32_t limit)
+{
+	std::vector<MarketOfferRecord> offers;
+	const DBResult_ptr result = Database::getInstance().storeQuery(query);
+	if (!result) {
+		return offers;
+	}
+
+	offers.reserve(limit);
+	do {
+		offers.emplace_back(readOffer(result));
+	} while (offers.size() < limit && result->next());
+	return offers;
+}
+
+std::vector<MarketOfferRecord> Market::getOwnOffers(uint32_t playerId, uint32_t limit)
+{
+	limit = clampLimit(limit, MAX_PACKET_OFFERS);
+	return fetchOffers(fmt::format(
+		"SELECT {:s} FROM `market_offers` AS mo INNER JOIN `players` AS p ON p.`id` = mo.`player_id` "
+		"WHERE mo.`player_id` = {:d} ORDER BY mo.`created` DESC LIMIT {:d}",
+		OFFER_COLUMNS, playerId, limit), limit);
+}
+
+std::vector<MarketOfferRecord> Market::getItemOffers(uint16_t itemId, uint8_t sale, uint32_t limit)
+{
+	limit = clampLimit(limit, MAX_PACKET_OFFERS);
+	if (sale > 1) {
+		return {};
+	}
+
+	const std::string_view priceOrder = sale == 0 ? "DESC" : "ASC";
+	return fetchOffers(fmt::format(
+		"SELECT {:s} FROM `market_offers` AS mo INNER JOIN `players` AS p ON p.`id` = mo.`player_id` "
+		"WHERE mo.`itemtype` = {:d} AND mo.`sale` = {:d} ORDER BY mo.`price` {:s}, mo.`created` ASC LIMIT {:d}",
+		OFFER_COLUMNS, itemId, sale, priceOrder, limit), limit);
+}
+
+std::vector<MarketOfferRecord> Market::getExpiredOffers(uint32_t createdBefore, uint32_t limit)
+{
+	limit = clampLimit(limit, MAX_EXPIRED_OFFERS);
+	return fetchOffers(fmt::format(
+		"SELECT {:s} FROM `market_offers` AS mo INNER JOIN `players` AS p ON p.`id` = mo.`player_id` "
+		"WHERE mo.`created` <= {:d} ORDER BY mo.`created` ASC LIMIT {:d}",
+		OFFER_COLUMNS, createdBefore, limit), limit);
+}
+
+std::vector<MarketOfferRecord> Market::getHistory(uint32_t playerId, uint32_t limit)
+{
+	limit = clampLimit(limit, MAX_PACKET_OFFERS);
+	std::vector<MarketOfferRecord> offers;
+	const DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
+		"SELECT `id`, `player_id`, `sale`, `itemtype`, `amount`, `price`, `tier`, `inserted`, `state` "
+		"FROM `market_history` WHERE `player_id` = {:d} ORDER BY `inserted` DESC LIMIT {:d}",
+		playerId, limit));
+	if (!result) {
+		return offers;
+	}
+
+	offers.reserve(limit);
+	do {
+		MarketOfferRecord offer;
+		offer.id = result->getNumber<uint32_t>("id");
+		offer.playerId = result->getNumber<uint32_t>("player_id");
+		offer.sale = result->getNumber<uint8_t>("sale");
+		offer.itemId = result->getNumber<uint16_t>("itemtype");
+		offer.amount = result->getNumber<uint32_t>("amount");
+		offer.created = result->getNumber<uint32_t>("inserted");
+		offer.price = result->getNumber<uint32_t>("price");
+		offer.tier = normalizeTier(result->getNumber<uint32_t>("tier"));
+		offer.state = result->getNumber<uint8_t>("state");
+		offers.emplace_back(std::move(offer));
+	} while (offers.size() < limit && result->next());
+	return offers;
+}
+
+std::vector<MarketStatisticRecord> Market::getStatistics(uint16_t itemId, uint8_t sale,
+	                                                                 uint32_t firstDay, uint32_t limit)
+{
+	limit = clampLimit(limit, MAX_STATISTIC_DAYS);
+	if (sale > 1) {
+		return {};
+	}
+
+	std::vector<MarketStatisticRecord> statistics;
+	const DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
+		"SELECT `day`, `transactions`, `total_price`, `highest_price`, `lowest_price` FROM `market_statistics` "
+		"WHERE `itemtype` = {:d} AND `sale` = {:d} AND `day` >= {:d} ORDER BY `day` ASC LIMIT {:d}",
+		itemId, sale, firstDay, limit));
+	if (!result) {
+		return statistics;
+	}
+
+	statistics.reserve(limit);
+	do {
+		statistics.emplace_back(MarketStatisticRecord{
+			result->getNumber<uint32_t>("day"),
+			result->getNumber<uint32_t>("transactions"),
+			result->getNumber<uint64_t>("total_price"),
+			result->getNumber<uint32_t>("highest_price"),
+			result->getNumber<uint32_t>("lowest_price")
+		});
+	} while (statistics.size() < limit && result->next());
+	return statistics;
+}
+
+bool Market::createOffer(const MarketOfferRecord& offer)
+{
+	if (offer.playerId == 0 || offer.itemId == 0 || offer.amount == 0 || offer.price == 0 || offer.sale > 1 ||
+	    (!offer.attributes.empty() && offer.amount != 1)) {
+		return false;
+	}
+
+	Database& db = Database::getInstance();
+	return db.executeQuery(fmt::format(
+		"INSERT INTO `market_offers` (`player_id`, `sale`, `itemtype`, `amount`, `created`, `anonymous`, "
+		"`price`, `tier`, `attributes`) VALUES ({:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:s})",
+		offer.playerId, offer.sale, offer.itemId, offer.amount, offer.created, offer.anonymous ? 1 : 0,
+		offer.price, normalizeTier(offer.tier), escapedAttributes(db, offer.attributes)));
+}
+
+bool Market::claimOffer(uint32_t offerId, uint32_t expectedAmount, uint32_t acceptedAmount,
+	                                uint32_t ownerId)
+{
+	if (offerId == 0 || expectedAmount == 0 || acceptedAmount == 0 || acceptedAmount > expectedAmount) {
+		return false;
+	}
+
+	Database& db = Database::getInstance();
+	const std::string ownerGuard = ownerId == 0 ? std::string() : fmt::format(" AND `player_id` = {:d}", ownerId);
+	if (acceptedAmount == expectedAmount) {
+		return affectedExactlyOne(db, fmt::format(
+			"DELETE FROM `market_offers` WHERE `id` = {:d} AND `amount` = {:d}{:s}",
+			offerId, expectedAmount, ownerGuard));
+	}
+
+	return affectedExactlyOne(db, fmt::format(
+		"UPDATE `market_offers` SET `amount` = `amount` - {:d} "
+		"WHERE `id` = {:d} AND `amount` = {:d}{:s}",
+		acceptedAmount, offerId, expectedAmount, ownerGuard));
+}
+
+bool Market::restoreOffer(const MarketOfferRecord& offer, uint32_t acceptedAmount)
+{
+	if (offer.id == 0 || offer.playerId == 0 || offer.itemId == 0 || offer.amount == 0 || acceptedAmount == 0 ||
+	    acceptedAmount > offer.amount || offer.sale > 1 || (!offer.attributes.empty() && offer.amount != 1)) {
+		return false;
+	}
+
+	Database& db = Database::getInstance();
+	if (acceptedAmount == offer.amount) {
+		return affectedExactlyOne(db, fmt::format(
+			"INSERT INTO `market_offers` (`id`, `player_id`, `sale`, `itemtype`, `amount`, `created`, `anonymous`, "
+			"`price`, `tier`, `attributes`) VALUES ({:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:s})",
+			offer.id, offer.playerId, offer.sale, offer.itemId, offer.amount, offer.created,
+			offer.anonymous ? 1 : 0, offer.price, normalizeTier(offer.tier),
+			escapedAttributes(db, offer.attributes)));
+	}
+
+	return affectedExactlyOne(db, fmt::format(
+		"UPDATE `market_offers` SET `amount` = `amount` + {:d} WHERE `id` = {:d}",
+		acceptedAmount, offer.id));
+}
+
+bool Market::addHistory(uint32_t playerId, uint8_t sale, uint16_t itemId, uint32_t amount,
+	                                uint32_t price, uint8_t tier, uint32_t expiresAt, uint32_t inserted,
+	                                uint8_t state)
+{
+	if (playerId == 0 || itemId == 0 || amount == 0 || price == 0 || sale > 1) {
+		return false;
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"INSERT INTO `market_history` (`player_id`, `sale`, `itemtype`, `amount`, `price`, `tier`, "
+		"`expires_at`, `inserted`, `state`) VALUES ({:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d})",
+		playerId, sale, itemId, amount, price, normalizeTier(tier), expiresAt, inserted, state));
+}
+
+bool Market::refreshStatistics(uint32_t firstDay, uint8_t acceptedState)
+{
+	return DBTransaction::executeWithinTransactionRollbackOnFailure([=]() {
+		Database& db = Database::getInstance();
+		return db.executeQuery("DELETE FROM `market_statistics`") && db.executeQuery(fmt::format(
+			"INSERT INTO `market_statistics` (`itemtype`, `sale`, `day`, `transactions`, `total_price`, "
+			"`highest_price`, `lowest_price`) "
+			"SELECT `itemtype`, `sale`, FLOOR(`inserted` / 86400) * 86400, COUNT(*), "
+			"CASE WHEN SUM(`amount`) > 0 THEN FLOOR((SUM(`price` * `amount`) / SUM(`amount`)) * COUNT(*)) ELSE 0 END, "
+			"MAX(`price`), MIN(`price`) FROM `market_history` WHERE `state` = {:d} AND `inserted` >= {:d} "
+			"GROUP BY `itemtype`, `sale`, FLOOR(`inserted` / 86400) * 86400",
+			acceptedState, firstDay));
+	});
+}
+
+bool Market::creditBank(uint32_t playerId, uint64_t amount)
+{
+	if (amount == 0) {
+		return true;
+	}
+	if (playerId == 0) {
+		return false;
+	}
+
+	Database& db = Database::getInstance();
+	return affectedExactlyOne(db, fmt::format(
+		"UPDATE `players` SET `balance` = `balance` + {:d} WHERE `id` = {:d}", amount, playerId));
+}
+
+bool Market::insertInboxItems(uint32_t playerId, uint16_t itemId, uint32_t amount,
+	                                      const std::string& attributes)
+{
+	const ItemType& itemType = Item::items[itemId];
+	if (playerId == 0 || itemType.id == 0 || amount == 0 || (!attributes.empty() && amount != 1)) {
+		return false;
+	}
+
+	return DBTransaction::executeWithinTransactionRollbackOnFailure([&]() {
+		Database& db = Database::getInstance();
+		if (!db.storeQuery(fmt::format("SELECT `id` FROM `players` WHERE `id` = {:d} FOR UPDATE", playerId))) {
+			return false;
+		}
+
+		const DBResult_ptr result = db.storeQuery(fmt::format(
+			"SELECT COALESCE(MAX(`sid`), 100) AS `sid` FROM `player_inboxitems` WHERE `player_id` = {:d}",
+			playerId));
+		if (!result) {
+			return false;
+		}
+
+		uint64_t sid = result->getNumber<uint64_t>("sid") + 1;
+		const uint32_t stackSize = itemType.stackable ? std::max<uint32_t>(1, itemType.stackSize) : 1;
+		const uint32_t rowCount = attributes.empty() ? 1 + ((amount - 1) / stackSize) : 1;
+		if (sid + rowCount > std::numeric_limits<uint32_t>::max()) {
+			return false;
+		}
+
+		const std::string attributesSql = escapedAttributes(db, attributes);
+		DBInsert insert(
+			"INSERT INTO `player_inboxitems` (`player_id`, `sid`, `pid`, `itemtype`, `count`, `attributes`) VALUES ");
+		uint32_t remaining = amount;
+		while (remaining > 0) {
+			const uint32_t count = std::min<uint32_t>(remaining, stackSize);
+			if (!insert.addRow(fmt::format("{:d}, {:d}, 0, {:d}, {:d}, {:s}",
+			                              playerId, sid++, itemId, count, attributesSql))) {
+				return false;
+			}
+			remaining -= count;
+		}
+		return insert.execute();
+	});
+}

--- a/src/market.h
+++ b/src/market.h
@@ -1,0 +1,71 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_MARKET_H
+#define FS_MARKET_H
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+struct MarketOfferRecord
+{
+	uint32_t id = 0;
+	uint32_t playerId = 0;
+	uint8_t sale = 0;
+	uint16_t itemId = 0;
+	uint32_t amount = 0;
+	uint32_t created = 0;
+	bool anonymous = false;
+	uint32_t price = 0;
+	uint8_t tier = 0;
+	std::string attributes;
+	std::string playerName;
+	uint8_t state = 0;
+};
+
+struct MarketStatisticRecord
+{
+	uint32_t day = 0;
+	uint32_t transactions = 0;
+	uint64_t totalPrice = 0;
+	uint32_t highestPrice = 0;
+	uint32_t lowestPrice = 0;
+};
+
+class Market
+{
+public:
+	static constexpr uint32_t MAX_PACKET_OFFERS = 250;
+	static constexpr uint32_t MAX_EXPIRED_OFFERS = 100;
+	static constexpr uint32_t MAX_STATISTIC_DAYS = 30;
+	static constexpr uint8_t MAX_ITEM_TIER = 10;
+
+	[[nodiscard]] static uint8_t normalizeTier(uint32_t tier);
+	[[nodiscard]] static uint32_t getOfferCount(uint32_t playerId);
+	[[nodiscard]] static std::optional<MarketOfferRecord> getOffer(uint32_t offerId);
+	[[nodiscard]] static std::vector<MarketOfferRecord> getOwnOffers(uint32_t playerId, uint32_t limit);
+	[[nodiscard]] static std::vector<MarketOfferRecord> getItemOffers(uint16_t itemId, uint8_t sale, uint32_t limit);
+	[[nodiscard]] static std::vector<MarketOfferRecord> getExpiredOffers(uint32_t createdBefore, uint32_t limit);
+	[[nodiscard]] static std::vector<MarketOfferRecord> getHistory(uint32_t playerId, uint32_t limit);
+	[[nodiscard]] static std::vector<MarketStatisticRecord> getStatistics(uint16_t itemId, uint8_t sale,
+	                                                                    uint32_t firstDay, uint32_t limit);
+
+	[[nodiscard]] static bool createOffer(const MarketOfferRecord& offer);
+	[[nodiscard]] static bool claimOffer(uint32_t offerId, uint32_t expectedAmount, uint32_t acceptedAmount,
+	                                     uint32_t ownerId = 0);
+	[[nodiscard]] static bool restoreOffer(const MarketOfferRecord& offer, uint32_t acceptedAmount);
+	[[nodiscard]] static bool addHistory(uint32_t playerId, uint8_t sale, uint16_t itemId, uint32_t amount,
+	                                     uint32_t price, uint8_t tier, uint32_t expiresAt, uint32_t inserted,
+	                                     uint8_t state);
+	[[nodiscard]] static bool refreshStatistics(uint32_t firstDay, uint8_t acceptedState);
+	[[nodiscard]] static bool creditBank(uint32_t playerId, uint64_t amount);
+	[[nodiscard]] static bool insertInboxItems(uint32_t playerId, uint16_t itemId, uint32_t amount,
+	                                           const std::string& attributes);
+
+private:
+	[[nodiscard]] static std::vector<MarketOfferRecord> fetchOffers(const std::string& query, uint32_t limit);
+};
+
+#endif // FS_MARKET_H

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1708,6 +1708,32 @@ void Player::clearBestiaryDirty()
 	bestiaryDirtyRaceRevisions.clear();
 }
 
+void Player::setPendingBestiaryKill(BestiaryKillResult result)
+{
+	constexpr size_t maxPendingBestiaryKills = 16;
+	std::erase_if(pendingBestiaryKills, [&result](const BestiaryKillResult& pending) {
+		return pending.victimId == result.victimId;
+	});
+	pendingBestiaryKills.push_back(result);
+	while (pendingBestiaryKills.size() > maxPendingBestiaryKills) {
+		pendingBestiaryKills.pop_front();
+	}
+}
+
+std::optional<Player::BestiaryKillResult> Player::takePendingBestiaryKill(uint32_t victimId, uint16_t raceId)
+{
+	const auto it = std::ranges::find_if(pendingBestiaryKills, [victimId, raceId](const BestiaryKillResult& pending) {
+		return pending.victimId == victimId && pending.raceId == raceId;
+	});
+	if (it == pendingBestiaryKills.end()) {
+		return {};
+	}
+
+	BestiaryKillResult result = *it;
+	pendingBestiaryKills.erase(it);
+	return result;
+}
+
 void Player::setStorageValue(const uint32_t key, const std::optional<int64_t> value, const bool isSpawn /* = false*/)
 {
 	const auto oldValue = getStorageValue(key);

--- a/src/player.h
+++ b/src/player.h
@@ -25,8 +25,10 @@
 #include "kv/kv.h"
 #include <algorithm>
 #include <array>
+#include <deque>
 #include <limits>
 #include <map>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -225,6 +227,16 @@ public:
 	BestiaryDirtySnapshot getBestiaryDirtySnapshot() const;
 	void acknowledgeBestiaryDirty(const BestiaryDirtySnapshot& snapshot);
 	void clearBestiaryDirty();
+	struct BestiaryKillResult
+	{
+		uint32_t victimId = 0;
+		uint16_t raceId = 0;
+		uint32_t oldCount = 0;
+		uint32_t newCount = 0;
+		bool charmPointsAwarded = false;
+	};
+	void setPendingBestiaryKill(BestiaryKillResult result);
+	std::optional<BestiaryKillResult> takePendingBestiaryKill(uint32_t victimId, uint16_t raceId);
 	bool getSaveFlag() const { return saveFlag; }
 	void setSaveFlag(bool value) { saveFlag = value; }
 	bool canSeeInvisibility() const override { return hasFlag(PlayerFlag_CanSenseInvisibility) || group->access; }
@@ -1712,6 +1724,7 @@ private:
 	std::unordered_set<uint16_t> modifiedBestiaryRaceIds;
 	std::unordered_map<uint16_t, uint64_t> bestiaryDirtyRaceRevisions;
 	uint64_t bestiaryDirtyRevision = 0;
+	std::deque<BestiaryKillResult> pendingBestiaryKills;
 	std::unique_ptr<WeaponProficiency> m_weaponProficiency;
 	std::weak_ptr<Item> writeItem;
 	std::weak_ptr<House> editHouse;

--- a/src/stash.cpp
+++ b/src/stash.cpp
@@ -1,0 +1,74 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "stash.h"
+
+#include "database.h"
+
+uint8_t Stash::normalizeTier(uint32_t tier)
+{
+	return static_cast<uint8_t>(std::min<uint32_t>(tier, MAX_ITEM_TIER));
+}
+
+std::vector<StashRecord> Stash::getRows(uint32_t playerId)
+{
+	std::vector<StashRecord> rows;
+	if (playerId == 0) {
+		return rows;
+	}
+
+	const DBResult_ptr result = Database::getInstance().storeQuery(fmt::format(
+		"SELECT `itemtype`, `tier`, `amount` FROM `player_supplystash` "
+		"WHERE `player_id` = {:d} AND `amount` > 0 ORDER BY `itemtype` ASC, `tier` ASC",
+		playerId));
+	if (!result) {
+		return rows;
+	}
+
+	do {
+		rows.emplace_back(StashRecord{
+			result->getNumber<uint16_t>("itemtype"),
+			normalizeTier(result->getNumber<uint32_t>("tier")),
+			result->getNumber<uint32_t>("amount")
+		});
+	} while (result->next());
+	return rows;
+}
+
+bool Stash::addAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier)
+{
+	if (playerId == 0 || itemId == 0 || amount == 0) {
+		return false;
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"INSERT INTO `player_supplystash` (`player_id`, `itemtype`, `tier`, `amount`) "
+		"VALUES ({:d}, {:d}, {:d}, {:d}) "
+		"ON DUPLICATE KEY UPDATE `amount` = `amount` + VALUES(`amount`)",
+		playerId, itemId, normalizeTier(tier), amount));
+}
+
+bool Stash::removeAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier)
+{
+	if (playerId == 0 || itemId == 0 || amount == 0) {
+		return false;
+	}
+
+	Database& db = Database::getInstance();
+	return db.executeQuery(fmt::format(
+		"UPDATE `player_supplystash` SET `amount` = `amount` - {:d} "
+		"WHERE `player_id` = {:d} AND `itemtype` = {:d} AND `tier` = {:d} AND `amount` >= {:d}",
+		amount, playerId, itemId, normalizeTier(tier), amount)) && db.getAffectedRows() == 1;
+}
+
+bool Stash::cleanup(uint32_t playerId)
+{
+	if (playerId == 0) {
+		return false;
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND `amount` = 0", playerId));
+}

--- a/src/stash.h
+++ b/src/stash.h
@@ -1,0 +1,29 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_STASH_H
+#define FS_STASH_H
+
+#include <cstdint>
+#include <vector>
+
+struct StashRecord
+{
+	uint16_t itemId = 0;
+	uint8_t tier = 0;
+	uint32_t amount = 0;
+};
+
+class Stash
+{
+public:
+	static constexpr uint8_t MAX_ITEM_TIER = 10;
+
+	[[nodiscard]] static uint8_t normalizeTier(uint32_t tier);
+	[[nodiscard]] static std::vector<StashRecord> getRows(uint32_t playerId);
+	[[nodiscard]] static bool addAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
+	[[nodiscard]] static bool removeAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
+	[[nodiscard]] static bool cleanup(uint32_t playerId);
+};
+
+#endif // FS_STASH_H

--- a/src/tests/test_bestiary.cpp
+++ b/src/tests/test_bestiary.cpp
@@ -84,4 +84,23 @@ TEST_CASE(bestiary_kills_are_saturated_dirty_and_consumed_once)
 	CHECK(saturated == std::numeric_limits<uint32_t>::max());
 }
 
+TEST_CASE(bestiary_first_kill_is_recorded_when_race_id_is_patched_after_death)
+{
+	Player player(nullptr);
+	player.clearBestiaryDirty();
+
+	constexpr uint32_t victimId = 1002;
+	constexpr uint16_t patchedRaceId = 2764;
+
+	// Death processing could not queue a pending kill because the monster had no race ID yet.
+	CHECK(!player.takePendingBestiaryKill(victimId, patchedRaceId).has_value());
+
+	// Name-based Lua resolution patches the race ID and must fall back to the normal add path.
+	const auto [oldCount, newCount] = player.addBestiaryKillCount(patchedRaceId, 1);
+	CHECK(oldCount == 0);
+	CHECK(newCount == 1);
+	CHECK(player.getBestiaryKillCount(patchedRaceId) == 1);
+	CHECK(player.getBestiaryDirtySnapshot().modifiedRaceIds.contains(patchedRaceId));
+}
+
 TFS_TEST_MAIN()

--- a/src/tests/test_bestiary.cpp
+++ b/src/tests/test_bestiary.cpp
@@ -16,7 +16,7 @@ void ensureItemTypesLoaded()
 
 	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
 	                       "data/items/items.otb";
-	CHECK(Item::items.loadFromOtb(itemsPath.string()));
+	REQUIRE(Item::items.loadFromOtb(itemsPath.string()));
 }
 
 } // namespace
@@ -69,7 +69,7 @@ TEST_CASE(bestiary_registration_uses_race_id_as_legacy_identity)
 	system.registerMonster(replacement);
 
 	const auto registered = system.getMonster(2764);
-	CHECK(registered.has_value());
+	REQUIRE(registered.has_value());
 	CHECK(registered->get().name == "Night Harpy");
 }
 

--- a/src/tests/test_bestiary.cpp
+++ b/src/tests/test_bestiary.cpp
@@ -1,9 +1,25 @@
 #include "../otpch.h"
 
 #include "../bestiary_charm.h"
+#include "../item.h"
 #include "../player.h"
 
 #include "test_support.h"
+
+namespace {
+
+void ensureItemTypesLoaded()
+{
+	if (Item::items.size() != 0) {
+		return;
+	}
+
+	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+	                       "data/items/items.otb";
+	CHECK(Item::items.loadFromOtb(itemsPath.string()));
+}
+
+} // namespace
 
 TEST_CASE(bestiary_progress_matches_legacy_lua_thresholds)
 {
@@ -53,12 +69,13 @@ TEST_CASE(bestiary_registration_uses_race_id_as_legacy_identity)
 	system.registerMonster(replacement);
 
 	const auto registered = system.getMonster(2764);
-	REQUIRE(registered.has_value());
+	CHECK(registered.has_value());
 	CHECK(registered->get().name == "Night Harpy");
 }
 
 TEST_CASE(bestiary_kills_are_saturated_dirty_and_consumed_once)
 {
+	ensureItemTypesLoaded();
 	Player player(nullptr);
 	player.clearBestiaryDirty();
 
@@ -86,6 +103,7 @@ TEST_CASE(bestiary_kills_are_saturated_dirty_and_consumed_once)
 
 TEST_CASE(bestiary_first_kill_is_recorded_when_race_id_is_patched_after_death)
 {
+	ensureItemTypesLoaded();
 	Player player(nullptr);
 	player.clearBestiaryDirty();
 

--- a/src/tests/test_bestiary.cpp
+++ b/src/tests/test_bestiary.cpp
@@ -1,0 +1,87 @@
+#include "../otpch.h"
+
+#include "../bestiary_charm.h"
+#include "../player.h"
+
+#include "test_support.h"
+
+TEST_CASE(bestiary_progress_matches_legacy_lua_thresholds)
+{
+	BestiaryCreatureInfo info;
+	info.toKill = 3;
+	info.firstUnlock = 1;
+	info.secondUnlock = 2;
+
+	CHECK(BestiaryCharmSystem::getProgress(info, 0) == 0);
+	CHECK(BestiaryCharmSystem::getProgress(info, 1) == 2);
+	CHECK(BestiaryCharmSystem::getProgress(info, 2) == 3);
+	CHECK(BestiaryCharmSystem::getProgress(info, 3) == 4);
+	CHECK(BestiaryCharmSystem::getProgress(info, 4) == 4);
+}
+
+TEST_CASE(bestiary_progress_keeps_discovery_before_first_unlock)
+{
+	BestiaryCreatureInfo info;
+	info.toKill = 100;
+	info.firstUnlock = 10;
+	info.secondUnlock = 50;
+
+	CHECK(BestiaryCharmSystem::getProgress(info, 0) == 0);
+	CHECK(BestiaryCharmSystem::getProgress(info, 1) == 1);
+	CHECK(BestiaryCharmSystem::getProgress(info, 9) == 1);
+	CHECK(BestiaryCharmSystem::getProgress(info, 10) == 2);
+	CHECK(BestiaryCharmSystem::getProgress(info, 49) == 2);
+	CHECK(BestiaryCharmSystem::getProgress(info, 50) == 3);
+	CHECK(BestiaryCharmSystem::getProgress(info, 99) == 3);
+	CHECK(BestiaryCharmSystem::getProgress(info, 100) == 4);
+	CHECK(BestiaryCharmSystem::getProgress(info, 101) == 4);
+}
+
+TEST_CASE(bestiary_registration_uses_race_id_as_legacy_identity)
+{
+	BestiaryCharmSystem system;
+	BestiaryCreatureInfo first;
+	first.raceId = 2764;
+	first.name = "Day Night Harpy";
+	first.toKill = 2500;
+	first.firstUnlock = 100;
+	first.secondUnlock = 1000;
+	system.registerMonster(first);
+
+	BestiaryCreatureInfo replacement = first;
+	replacement.name = "Night Harpy";
+	system.registerMonster(replacement);
+
+	const auto registered = system.getMonster(2764);
+	REQUIRE(registered.has_value());
+	CHECK(registered->get().name == "Night Harpy");
+}
+
+TEST_CASE(bestiary_kills_are_saturated_dirty_and_consumed_once)
+{
+	Player player(nullptr);
+	player.clearBestiaryDirty();
+
+	const auto [oldCount, newCount] = player.addBestiaryKillCount(35, 1);
+	CHECK(oldCount == 0);
+	CHECK(newCount == 1);
+	CHECK(player.getBestiaryKillCount(35) == 1);
+	CHECK(player.getBestiaryDirtySnapshot().modifiedRaceIds.contains(35));
+
+	player.setPendingBestiaryKill({1001, 35, oldCount, newCount, false});
+	CHECK(!player.takePendingBestiaryKill(1002, 35).has_value());
+	CHECK(!player.takePendingBestiaryKill(1001, 36).has_value());
+	const auto result = player.takePendingBestiaryKill(1001, 35);
+	CHECK(result.has_value());
+	CHECK(result->oldCount == 0);
+	CHECK(result->newCount == 1);
+	CHECK(!result->charmPointsAwarded);
+	CHECK(!player.takePendingBestiaryKill(1001, 35).has_value());
+
+	player.setBestiaryKillCount(35, std::numeric_limits<uint32_t>::max() - 1);
+	const auto [beforeSaturation, saturated] = player.addBestiaryKillCount(35, 10);
+	CHECK(beforeSaturation == std::numeric_limits<uint32_t>::max() - 1);
+	CHECK(saturated == std::numeric_limits<uint32_t>::max());
+}
+
+TFS_TEST_MAIN()

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -263,6 +263,7 @@
     <ClCompile Include="..\src\map.cpp" />
     <ClCompile Include="..\src\mapcache.cpp" />
     <ClCompile Include="..\src\market.cpp" />
+    <ClCompile Include="..\src\stash.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -380,6 +381,7 @@
     <ClInclude Include="..\src\map.h" />
     <ClInclude Include="..\src\mapcache.h" />
     <ClInclude Include="..\src\market.h" />
+    <ClInclude Include="..\src\stash.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -262,6 +262,7 @@
     <ClCompile Include="..\src\main.cpp" />
     <ClCompile Include="..\src\map.cpp" />
     <ClCompile Include="..\src\mapcache.cpp" />
+    <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -378,6 +379,7 @@
     <ClInclude Include="..\src\mailbox.h" />
     <ClInclude Include="..\src\map.h" />
     <ClInclude Include="..\src\mapcache.h" />
+    <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -41,6 +41,7 @@
     <ClCompile Include="..\src\luascript.cpp" />
     <ClCompile Include="..\src\mailbox.cpp" />
     <ClCompile Include="..\src\map.cpp" />
+    <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -263,6 +264,7 @@
     <ClInclude Include="..\src\luascript.h" />
     <ClInclude Include="..\src\mailbox.h" />
     <ClInclude Include="..\src\map.h" />
+    <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -42,6 +42,7 @@
     <ClCompile Include="..\src\mailbox.cpp" />
     <ClCompile Include="..\src\map.cpp" />
     <ClCompile Include="..\src\market.cpp" />
+    <ClCompile Include="..\src\stash.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -265,6 +266,7 @@
     <ClInclude Include="..\src\mailbox.h" />
     <ClInclude Include="..\src\map.h" />
     <ClInclude Include="..\src\market.h" />
+    <ClInclude Include="..\src\stash.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />


### PR DESCRIPTION
## What changed

- Restore player and summon kill attribution in the C++ Bestiary path.
- Update the player cache once and preserve dirty database persistence.
- Keep progress thresholds and outfit unlock state synchronized.
- Add regression coverage for progression and kill ownership.

## Root cause

The C++ migration no longer reproduced every state update performed by the previous Lua pipeline, so kills could reach storage without keeping runtime progression and client unlock state consistent.

## Validation

- Lua syntax validation passed.
- Targeted Bestiary tests were added.
- In-game kill progression and outfit unlock were confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tiered market offers with attributes, plus offer/history/statistics support.
  - Implemented per-player supply stash using tiered quantities and depot-based storage.
  - Added proximity-gated supply stash access and session cleanup on login/logout.

- **Bug Fixes**
  - Improved Bestiary unlock/progress handling and charm point awarding logic.
  - Fixed Bestiary kill crediting to prevent duplicate/missed rewards and ensured pending kill consumption is correct.
  - Hardened monster registration validation to reject invalid configuration.

- **Changes**
  - Updated battlepass season state/reset behavior to stop writing the prior season marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->