### PR TITLE
feat: add portable interactive server console and safe restart support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/otpch.cpp
 	${CMAKE_CURRENT_LIST_DIR}/actions.cpp
 	${CMAKE_CURRENT_LIST_DIR}/admin.cpp
+	${CMAKE_CURRENT_LIST_DIR}/admin_console.cpp
 	${CMAKE_CURRENT_LIST_DIR}/ban.cpp
 	${CMAKE_CURRENT_LIST_DIR}/baseevents.cpp
 	${CMAKE_CURRENT_LIST_DIR}/bestiary_charm.cpp
@@ -144,6 +145,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/account.h
 	${CMAKE_CURRENT_LIST_DIR}/actions.h
 	${CMAKE_CURRENT_LIST_DIR}/admin.h
+	${CMAKE_CURRENT_LIST_DIR}/admin_console.h
 	${CMAKE_CURRENT_LIST_DIR}/astraclient.h
 	${CMAKE_CURRENT_LIST_DIR}/ban.h
 	${CMAKE_CURRENT_LIST_DIR}/baseevents.h

--- a/src/admin_console.cpp
+++ b/src/admin_console.cpp
@@ -138,6 +138,8 @@ void AdminConsole::run(std::stop_token stopToken)
 	}
 #endif
 
+	std::string command;
+
 	while (!stopToken.stop_requested()) {
 #ifndef _WIN32
 		pollfd inputPoll{STDIN_FILENO, POLLIN, 0};
@@ -154,9 +156,25 @@ void AdminConsole::run(std::stop_token stopToken)
 		if ((inputPoll.revents & (POLLIN | POLLHUP)) == 0) {
 			break;
 		}
-#endif
 
-		std::string command;
+		char ch;
+		const ssize_t bytesRead = read(STDIN_FILENO, &ch, 1);
+		if (bytesRead < 0 && errno == EINTR) {
+			continue;
+		}
+		if (bytesRead != 1) {
+			break;
+		}
+		if (stopToken.stop_requested()) {
+			break;
+		}
+		if (ch == '\n' || ch == '\r') {
+			processCommand(std::move(command));
+			command.clear();
+		} else {
+			command += ch;
+		}
+#else
 		if (!std::getline(std::cin, command)) {
 			break;
 		}
@@ -164,6 +182,8 @@ void AdminConsole::run(std::stop_token stopToken)
 			break;
 		}
 		processCommand(std::move(command));
+		command.clear();
+#endif
 	}
 
 	running.store(false, std::memory_order_release);

--- a/src/admin_console.cpp
+++ b/src/admin_console.cpp
@@ -1,0 +1,264 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "admin_console.h"
+
+#include "game.h"
+#include "logger.h"
+#include "otserv.h"
+#include "tasks.h"
+#include "tools.h"
+
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
+#include <cerrno>
+#include <poll.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+bool isInteractiveInput()
+{
+#ifdef _WIN32
+	return _isatty(_fileno(stdin)) != 0;
+#else
+	return isatty(STDIN_FILENO) != 0;
+#endif
+}
+
+std::string_view gameStateName(GameState_t state)
+{
+	switch (state) {
+		case GAME_STATE_STARTUP:
+			return "startup";
+		case GAME_STATE_INIT:
+			return "initializing";
+		case GAME_STATE_NORMAL:
+			return "online";
+		case GAME_STATE_CLOSED:
+			return "closed";
+		case GAME_STATE_SHUTDOWN:
+			return "shutting down";
+		case GAME_STATE_CLOSING:
+			return "closing";
+		case GAME_STATE_MAINTAIN:
+			return "maintenance";
+	}
+	return "unknown";
+}
+
+void printHelp()
+{
+	LOG_INFO("Console commands: help, status, players, save (S), restart (R), shutdown (Q)");
+}
+
+} // namespace
+
+AdminConsole::~AdminConsole()
+{
+	stop();
+}
+
+bool AdminConsole::start()
+{
+	if (!isInteractiveInput() || running.exchange(true, std::memory_order_acq_rel)) {
+		return false;
+	}
+
+#ifdef _WIN32
+	const HANDLE inputHandle = GetStdHandle(STD_INPUT_HANDLE);
+	DWORD inputMode = 0;
+	if (inputHandle != nullptr && inputHandle != INVALID_HANDLE_VALUE &&
+	    GetConsoleMode(inputHandle, &inputMode) != 0) {
+		originalInputMode = inputMode;
+		const DWORD interactiveMode = inputMode | ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT;
+		restoreInputMode = interactiveMode != inputMode && SetConsoleMode(inputHandle, interactiveMode) != 0;
+	}
+#endif
+
+	inputThread = std::jthread([this](std::stop_token stopToken) { run(stopToken); });
+	LOG_INFO("Interactive console enabled. Type 'help' and press ENTER to list commands.");
+	return true;
+}
+
+void AdminConsole::stop()
+{
+	[[maybe_unused]] const bool wasRunning = running.exchange(false, std::memory_order_acq_rel);
+
+	if (inputThread.joinable()) {
+		inputThread.request_stop();
+#ifdef _WIN32
+		if (wasRunning) {
+			// Queue an empty line so a pending std::getline returns immediately.
+			// This also closes the race where cancellation happens just before getline starts.
+			const HANDLE inputHandle = GetStdHandle(STD_INPUT_HANDLE);
+			if (inputHandle != nullptr && inputHandle != INVALID_HANDLE_VALUE) {
+				INPUT_RECORD enterRecords[2]{};
+				for (INPUT_RECORD& record : enterRecords) {
+					record.EventType = KEY_EVENT;
+					record.Event.KeyEvent.wRepeatCount = 1;
+					record.Event.KeyEvent.wVirtualKeyCode = VK_RETURN;
+					record.Event.KeyEvent.uChar.UnicodeChar = L'\r';
+				}
+				enterRecords[0].Event.KeyEvent.bKeyDown = TRUE;
+				enterRecords[1].Event.KeyEvent.bKeyDown = FALSE;
+				DWORD recordsWritten = 0;
+				if (WriteConsoleInputW(inputHandle, enterRecords, 2, &recordsWritten) == 0 || recordsWritten != 2) {
+					CancelSynchronousIo(inputThread.native_handle());
+				}
+			}
+		}
+#endif
+		inputThread.join();
+	}
+
+#ifdef _WIN32
+	if (restoreInputMode) {
+		const HANDLE inputHandle = GetStdHandle(STD_INPUT_HANDLE);
+		if (inputHandle != nullptr && inputHandle != INVALID_HANDLE_VALUE) {
+			SetConsoleMode(inputHandle, originalInputMode);
+		}
+		restoreInputMode = false;
+	}
+#endif
+}
+
+void AdminConsole::run(std::stop_token stopToken)
+{
+#ifdef _WIN32
+	const HANDLE inputHandle = GetStdHandle(STD_INPUT_HANDLE);
+	if (inputHandle == nullptr || inputHandle == INVALID_HANDLE_VALUE) {
+		running.store(false, std::memory_order_release);
+		return;
+	}
+#endif
+
+	while (!stopToken.stop_requested()) {
+#ifndef _WIN32
+		pollfd inputPoll{STDIN_FILENO, POLLIN, 0};
+		const int pollResult = poll(&inputPoll, 1, 200);
+		if (pollResult < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			break;
+		}
+		if (pollResult == 0) {
+			continue;
+		}
+		if ((inputPoll.revents & (POLLIN | POLLHUP)) == 0) {
+			break;
+		}
+#endif
+
+		std::string command;
+		if (!std::getline(std::cin, command)) {
+			break;
+		}
+		if (stopToken.stop_requested()) {
+			break;
+		}
+		processCommand(std::move(command));
+	}
+
+	running.store(false, std::memory_order_release);
+}
+
+void AdminConsole::processCommand(std::string command) const
+{
+	trimString(command);
+	toLowerCaseString(command);
+	if (command.empty()) {
+		return;
+	}
+
+	if (g_game.getGameState() == GAME_STATE_SHUTDOWN) {
+		return;
+	}
+
+	if (command == "help" || command == "h") {
+		printHelp();
+		return;
+	}
+
+	if (command == "status") {
+		g_dispatcher.addTask([]() {
+			const GameState_t state = g_game.getGameState();
+			if (state != GAME_STATE_SHUTDOWN) {
+				LOG_INFO("Server status: {} | Players online: {}", gameStateName(state), g_game.getPlayersOnline());
+			}
+		});
+		return;
+	}
+
+	if (command == "players") {
+		g_dispatcher.addTask([]() {
+			if (g_game.getGameState() == GAME_STATE_SHUTDOWN) {
+				return;
+			}
+
+			auto players = g_game.getPlayers();
+			std::vector<std::string> names;
+			names.reserve(players.size());
+			for (const auto& player : players) {
+				names.emplace_back(player->getName());
+			}
+			std::ranges::sort(names);
+
+			std::string playerList;
+			for (const std::string& name : names) {
+				if (!playerList.empty()) {
+					playerList += ", ";
+				}
+				playerList += name;
+			}
+			LOG_INFO("Online players ({}): {}", names.size(), playerList.empty() ? "none" : playerList);
+		});
+		return;
+	}
+
+	if (command == "save" || command == "s") {
+		g_dispatcher.addTask([]() {
+			const GameState_t state = g_game.getGameState();
+			if (state != GAME_STATE_NORMAL && state != GAME_STATE_CLOSED) {
+				LOG_WARN("Console save ignored while the server is {}.", gameStateName(state));
+				return;
+			}
+
+			LOG_INFO("Console save requested.");
+			g_game.saveGameState();
+			LOG_INFO("Console save completed.");
+		});
+		return;
+	}
+
+	if (command == "restart" || command == "r") {
+		g_dispatcher.addTask([]() {
+			if (g_game.getGameState() == GAME_STATE_SHUTDOWN) {
+				return;
+			}
+			LOG_INFO("Console restart requested. The server will shut down safely and relaunch.");
+			requestServerRestart();
+			g_game.setGameState(GAME_STATE_SHUTDOWN);
+		});
+		return;
+	}
+
+	if (command == "shutdown" || command == "q") {
+		g_dispatcher.addTask([]() {
+			if (g_game.getGameState() == GAME_STATE_SHUTDOWN) {
+				return;
+			}
+			LOG_INFO("Console shutdown requested.");
+			g_game.setGameState(GAME_STATE_SHUTDOWN);
+		});
+		return;
+	}
+
+	LOG_WARN("Unknown console command '{}'. Type 'help' to list commands.", command);
+}

--- a/src/admin_console.h
+++ b/src/admin_console.h
@@ -1,0 +1,31 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_ADMIN_CONSOLE_H
+#define FS_ADMIN_CONSOLE_H
+
+class AdminConsole
+{
+public:
+	AdminConsole() = default;
+	~AdminConsole();
+
+	AdminConsole(const AdminConsole&) = delete;
+	AdminConsole& operator=(const AdminConsole&) = delete;
+
+	bool start();
+	void stop();
+
+private:
+	void run(std::stop_token stopToken);
+	void processCommand(std::string command) const;
+
+	std::jthread inputThread;
+	std::atomic<bool> running{false};
+#ifdef _WIN32
+	unsigned long originalInputMode = 0;
+	bool restoreInputMode = false;
+#endif
+};
+
+#endif // FS_ADMIN_CONSOLE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,19 @@
 #include "otpch.h"
 
 #include "configmanager.h"
+#include "logger.h"
 #include "otserv.h"
 #include "outputmessage.h"
 #include "tools.h"
 
+#include <cerrno>
+
 #ifdef _WIN32
 #include <io.h>
+#include <process.h>
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 namespace {
@@ -47,6 +53,22 @@ void waitForInteractiveConsoleOnStartupFailure()
 void waitForInteractiveConsoleOnStartupFailure() {}
 #endif
 
+bool restartCurrentProcess(char* const* argv)
+{
+	fmt::print("Restarting server process...\n");
+	std::fflush(stdout);
+	shutdownLogger();
+
+#ifdef _WIN32
+	_execv(argv[0], argv);
+#else
+	execvp(argv[0], argv);
+#endif
+
+	fmt::print(stderr, "Failed to restart the server process: {}\n", std::strerror(errno));
+	return false;
+}
+
 } // namespace
 
 static bool argumentsHandler(const std::vector<std::string_view>& args)
@@ -85,7 +107,7 @@ static bool argumentsHandler(const std::vector<std::string_view>& args)
 	return true;
 }
 
-int main(int argc, const char** argv)
+int main(int argc, char** argv)
 {
 	std::vector<std::string_view> args(argv, argv + argc);
 	if (!argumentsHandler(args)) {
@@ -94,7 +116,13 @@ int main(int argc, const char** argv)
 
 	const int exitCode = startServer();
 	OutputMessagePool::drainPool();
-	if (exitCode != EXIT_SUCCESS) {
+	if (exitCode == SERVER_RESTART_EXIT_CODE) {
+		if (!restartCurrentProcess(argv)) {
+			waitForInteractiveConsoleOnStartupFailure();
+		}
+		return SERVER_RESTART_EXIT_CODE;
+	}
+	if (exitCode != EXIT_SUCCESS && exitCode != SERVER_RESTART_EXIT_CODE) {
 		waitForInteractiveConsoleOnStartupFailure();
 	}
 	return exitCode;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ bool restartCurrentProcess(char* const* argv)
 	shutdownLogger();
 
 #ifdef _WIN32
-	_execv(argv[0], argv);
+	_execvp(argv[0], argv);
 #else
 	execvp(argv[0], argv);
 #endif
@@ -119,10 +119,11 @@ int main(int argc, char** argv)
 	if (exitCode == SERVER_RESTART_EXIT_CODE) {
 		if (!restartCurrentProcess(argv)) {
 			waitForInteractiveConsoleOnStartupFailure();
+			return EXIT_FAILURE;
 		}
 		return SERVER_RESTART_EXIT_CODE;
 	}
-	if (exitCode != EXIT_SUCCESS && exitCode != SERVER_RESTART_EXIT_CODE) {
+	if (exitCode != EXIT_SUCCESS) {
 		waitForInteractiveConsoleOnStartupFailure();
 	}
 	return exitCode;

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -5,6 +5,7 @@
 
 #include "otserv.h"
 
+#include "admin_console.h"
 #include "configmanager.h"
 #include "console_styles.h"
 #include "databasemanager.h"
@@ -52,6 +53,7 @@ Vocations g_vocations;
 namespace {
 
 std::optional<double> startupMapLoadSeconds;
+std::atomic<bool> restartRequested{false};
 
 struct BootstrapOptions {
 	bool logToFile = false;
@@ -722,6 +724,7 @@ bool mainLoader(const std::shared_ptr<ServiceManager>& services, StartupRuntimeS
 int startServer()
 {
 	std::set_new_handler(badAllocationHandler);
+	restartRequested.store(false, std::memory_order_release);
 
 	auto serviceManager = std::make_shared<ServiceManager>();
 	StartupRuntimeState runtimeState;
@@ -737,6 +740,7 @@ int startServer()
 	const bool startupLoaded = mainLoader(serviceManager, runtimeState);
 
 	std::jthread serviceThread;
+	AdminConsole adminConsole;
 
 	if (startupLoaded && serviceManager->hasOpenServices()) {
 		// Configure reactor production limits: fairness, time budget, and backpressure
@@ -973,7 +977,9 @@ int startServer()
 		}
 #endif
 		startupCompleted = true;
+		adminConsole.start();
 		g_reactor.runLoop();
+		adminConsole.stop();
 		}
 	} else {
 		if (startupLoaded) {
@@ -1036,7 +1042,15 @@ int startServer()
 
 	// Cleanup MySQL connection and library
 	Database::shutdown();
-	return startupCompleted ? EXIT_SUCCESS : EXIT_FAILURE;
+	if (!startupCompleted) {
+		return EXIT_FAILURE;
+	}
+	return restartRequested.load(std::memory_order_acquire) ? SERVER_RESTART_EXIT_CODE : EXIT_SUCCESS;
+}
+
+void requestServerRestart()
+{
+	restartRequested.store(true, std::memory_order_release);
 }
 
 void printServerVersion()

--- a/src/otserv.h
+++ b/src/otserv.h
@@ -4,8 +4,11 @@
 #ifndef FS_OTSERV_H
 #define FS_OTSERV_H
 
+inline constexpr int SERVER_RESTART_EXIT_CODE = 75;
+
 void printServerVersion();
 void printServerLinks();
 int startServer();
+void requestServerRestart();
 
 #endif

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -180,6 +180,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\actions.cpp" />
     <ClCompile Include="..\src\admin.cpp" />
+    <ClCompile Include="..\src\admin_console.cpp" />
     <ClCompile Include="..\src\ban.cpp" />
     <ClCompile Include="..\src\baseevents.cpp" />
     <ClCompile Include="..\src\bestiary_charm.cpp" />
@@ -328,6 +329,7 @@
     <ClInclude Include="..\src\account.h" />
     <ClInclude Include="..\src\actions.h" />
     <ClInclude Include="..\src\admin.h" />
+    <ClInclude Include="..\src\admin_console.h" />
     <ClInclude Include="..\src\astraclient.h" />
     <ClInclude Include="..\src\fonticakclient.h" />
     <ClInclude Include="..\src\ban.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\actions.cpp" />
     <ClCompile Include="..\src\admin.cpp" />
+    <ClCompile Include="..\src\admin_console.cpp" />
     <ClCompile Include="..\src\ban.cpp" />
     <ClCompile Include="..\src\baseevents.cpp" />
     <ClCompile Include="..\src\bestiary_charm.cpp" />
@@ -220,6 +221,7 @@
     <ClInclude Include="..\src\account.h" />
     <ClInclude Include="..\src\actions.h" />
     <ClInclude Include="..\src\admin.h" />
+    <ClInclude Include="..\src\admin_console.h" />
     <ClInclude Include="..\src\astraclient.h" />
     <ClInclude Include="..\src\fonticakclient.h" />
     <ClInclude Include="..\src\ban.h" />


### PR DESCRIPTION
Add an interactive administrative console for Windows CMD, Windows Terminal, and Linux terminals.

Supported commands:
- help
- status
- players
- save / S
- restart / R
- shutdown / Q

Dispatch game-related commands through the main dispatcher to prevent the console input thread from modifying game state directly.

Enable line input and keyboard echo on Windows so typed commands remain visible. Safely unblock and stop the input thread during shutdown without waiting for additional user input.

Implement graceful process restart support using exit code 75. After the normal shutdown sequence saves the game, disconnects players, closes network services, and shuts down database workers, the server relaunches the same executable with its original command-line arguments.

Add Windows and Linux supervisor scripts that restart only when explicitly requested. Unexpected crashes remain stopped for manual inspection.

Update the CMake and Visual Studio build configurations to include the new administrative console sources.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive administrator console with commands for help, server status, player listings, saving, restarting, and shutting down.
  * Implemented restart support with server-controlled restart signaling and automatic process relaunch.
* **Bug Fixes**
  * Improved console lifecycle handling to ensure the console input stream is properly stopped and restored during shutdown, including Windows behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an interactive administrative console (`AdminConsole`) that runs in a background thread and accepts commands (`help`, `status`, `players`, `save`, `restart`, `shutdown`) via stdin, dispatching game-state changes through `g_dispatcher` to stay thread-safe. It also adds graceful restart support via exit code 75: after a clean shutdown, `main()` calls `execv`/`execvp` to replace the process image with the same binary.

- `AdminConsole` correctly handles Windows shutdown by injecting synthetic Enter key events to unblock `std::getline`, but provides no equivalent mechanism on Linux — a blocking `getline` after partial user input can stall shutdown until the 60-second watchdog force-kills the process.
- When `execv`/`execvp` fails, `main()` still returns `SERVER_RESTART_EXIT_CODE` (75) instead of `EXIT_FAILURE`; a supervisor script that maps exit code 75 to \"restart\" will loop indefinitely.

<h3>Confidence Score: 3/5</h3>

The core command-dispatch design is sound, but two defects in the shutdown/restart path can cause unclean exits or infinite supervisor loops.

The Linux input thread has no mechanism to unblock a blocking getline during shutdown — any partial user input leaves the thread stuck, causing the server to hang until the 60-second watchdog forcibly terminates with _Exit. Separately, if execv/execvp fails at restart time, main() still returns SERVER_RESTART_EXIT_CODE (75), which supervisor scripts interpret as a deliberate restart request and re-invoke the process, potentially looping forever. Both issues affect the shutdown/restart path directly introduced by this PR.

src/admin_console.cpp (Linux shutdown blocking) and src/main.cpp (restart failure exit code)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/admin_console.cpp | New interactive console implementation; Windows shutdown unblocking is well-handled via WriteConsoleInputW, but Linux lacks an equivalent mechanism to unblock a blocking getline during shutdown. |
| src/admin_console.h | Clean header declaring AdminConsole with proper move/copy deletion, atomic running flag, and platform-specific console mode fields. |
| src/main.cpp | Adds restart-on-exit-code-75 logic; failed execv/execvp still returns SERVER_RESTART_EXIT_CODE causing supervisor restart loops, and the secondary exit-code guard is dead code. |
| src/otserv.cpp | Wires AdminConsole lifetime around g_reactor.runLoop() and adds restartRequested atomic; shutdown ordering looks correct with adminConsole.stop() before dispatcher teardown. |
| src/otserv.h | Adds SERVER_RESTART_EXIT_CODE constant (75) and requestServerRestart() declaration; straightforward and correct. |
| src/CMakeLists.txt | Adds admin_console.cpp and admin_console.h to the CMake source and header lists; no issues. |
| vc18/theforgottenserver.vcxproj | Adds admin_console.cpp and admin_console.h to the Visual Studio project; no issues. |
| vc18/theforgottenserver.vcxproj.filters | Adds admin_console entries to project filters; no issues. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Main as main()
    participant SS as startServer()
    participant AC as AdminConsole
    participant IT as InputThread
    participant Disp as g_dispatcher
    participant Game as g_game

    Main->>SS: startServer()
    SS->>AC: adminConsole.start()
    AC->>IT: launch jthread (run loop)
    IT-->>AC: running (poll/getline loop)

    Note over IT,Disp: User types command
    IT->>Disp: addTask(lambda)
    Disp->>Game: setGameState / requestServerRestart()

    Note over Game: GAME_STATE_SHUTDOWN triggered
    Game->>Game: save, kick players, cleanup
    SS->>AC: adminConsole.stop()
    AC->>IT: request_stop()
    alt Windows
        AC->>IT: WriteConsoleInputW(Enter key) to unblock getline
    else Linux
        Note over AC,IT: No unblock mechanism — getline may hang
    end
    IT-->>AC: thread exits
    AC-->>SS: stop() returns

    SS->>Main: return exitCode
    alt "exitCode == SERVER_RESTART_EXIT_CODE (75)"
        Main->>Main: restartCurrentProcess(argv)
        alt execv/execvp succeeds
            Note over Main: process image replaced — new server starts
        else execv/execvp fails
            Main->>Main: return SERVER_RESTART_EXIT_CODE (bug: should be EXIT_FAILURE)
        end
    else "exitCode == EXIT_SUCCESS"
        Main->>Main: return EXIT_SUCCESS
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Main as main()
    participant SS as startServer()
    participant AC as AdminConsole
    participant IT as InputThread
    participant Disp as g_dispatcher
    participant Game as g_game

    Main->>SS: startServer()
    SS->>AC: adminConsole.start()
    AC->>IT: launch jthread (run loop)
    IT-->>AC: running (poll/getline loop)

    Note over IT,Disp: User types command
    IT->>Disp: addTask(lambda)
    Disp->>Game: setGameState / requestServerRestart()

    Note over Game: GAME_STATE_SHUTDOWN triggered
    Game->>Game: save, kick players, cleanup
    SS->>AC: adminConsole.stop()
    AC->>IT: request_stop()
    alt Windows
        AC->>IT: WriteConsoleInputW(Enter key) to unblock getline
    else Linux
        Note over AC,IT: No unblock mechanism — getline may hang
    end
    IT-->>AC: thread exits
    AC-->>SS: stop() returns

    SS->>Main: return exitCode
    alt "exitCode == SERVER_RESTART_EXIT_CODE (75)"
        Main->>Main: restartCurrentProcess(argv)
        alt execv/execvp succeeds
            Note over Main: process image replaced — new server starts
        else execv/execvp fails
            Main->>Main: return SERVER_RESTART_EXIT_CODE (bug: should be EXIT_FAILURE)
        end
    else "exitCode == EXIT_SUCCESS"
        Main->>Main: return EXIT_SUCCESS
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/admin_console.cpp:141-169
**Linux shutdown can hang indefinitely in `getline`**

On Linux, if a user has typed characters but not yet pressed Enter, `poll` returns `POLLIN` and `getline` is called. If `stop()` is then triggered (shutdown/restart), `request_stop()` sets the stop token but `getline` remains blocked waiting for a newline — there is no equivalent to the Windows `WriteConsoleInputW` Enter-injection to unblock it. `inputThread.join()` then hangs forever until the 60-second watchdog force-kills with `std::_Exit(EXIT_FAILURE)`.

A common fix is to close or reopen `stdin` on Linux before joining: e.g. `close(STDIN_FILENO)` from the `stop()` path, which causes any blocking read to return with EOF immediately.

### Issue 2 of 3
src/main.cpp:119-124
When `execv`/`execvp` fails and returns, `main()` still returns `SERVER_RESTART_EXIT_CODE` (75). Any supervisor script that maps exit code 75 to "restart the server" will re-invoke the process, which will immediately fail to exec again and return 75 again — an infinite restart loop. On failure the process should return `EXIT_FAILURE` so the supervisor stops.

```suggestion
	if (exitCode == SERVER_RESTART_EXIT_CODE) {
		if (!restartCurrentProcess(argv)) {
			waitForInteractiveConsoleOnStartupFailure();
			return EXIT_FAILURE;
		}
		return SERVER_RESTART_EXIT_CODE;
	}
```

### Issue 3 of 3
src/main.cpp:125-127
The condition `exitCode != SERVER_RESTART_EXIT_CODE` is unreachable: control only reaches this line when `exitCode != SERVER_RESTART_EXIT_CODE` (the `SERVER_RESTART_EXIT_CODE` branch above already returned). The redundant guard can be simplified.

```suggestion
	if (exitCode != EXIT_SUCCESS) {
		waitForInteractiveConsoleOnStartupFailure();
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add portable interactive server co..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/c24381a640ed655635652e4a33e20cb876f9bea0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45399871)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->