### PR TITLE
fix: harden delayed addEvent callbacks

### DIFF
--- a/data/lib/functions/exercise_training.lua
+++ b/data/lib/functions/exercise_training.lua
@@ -69,27 +69,40 @@ function LeaveTraining(playerId)
 	end
 end
 
-local function findPlayerWeaponById(player, weaponId)
+local function findContainerItemById(container, weaponId, weaponUid)
+	if not container or not container:isContainer() then
+		return nil
+	end
+
+	for i = 0, container:getSize() - 1 do
+		local item = container:getItem(i)
+		if item then
+			if item:getId() == weaponId and item:getUniqueId() == weaponUid then
+				return item
+			end
+
+			if item:isContainer() then
+				local found = findContainerItemById(item, weaponId, weaponUid)
+				if found then
+					return found
+				end
+			end
+		end
+	end
+
+	return nil
+end
+
+local function findPlayerWeaponById(player, weaponId, weaponUid)
 	for slot = CONST_SLOT_HEAD, CONST_SLOT_AMMO do
 		local item = player:getSlotItem(slot)
-		if item and item:getId() == weaponId then
+		if item and item:getId() == weaponId and item:getUniqueId() == weaponUid then
 			return item
 		end
 	end
 
 	local backpack = player:getSlotItem(CONST_SLOT_BACKPACK)
-	if not backpack then
-		return nil
-	end
-
-	for i = 0, backpack:getSize() - 1 do
-		local item = backpack:getItem(i)
-		if item and item:getId() == weaponId then
-			return item
-		end
-	end
-
-	return nil
+	return findContainerItemById(backpack, weaponId, weaponUid)
 end
 
 function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
@@ -121,12 +134,14 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
         return true
     end
 
-	local weapon = findPlayerWeaponById(player, weaponId)
+	local weapon = findPlayerWeaponById(player, weaponId, training.weaponUid)
 	if not weapon then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The training weapon is no longer available, the training has stopped.")
 		LeaveTraining(playerId)
 		return false
 	end
+
+	onExerciseTraining[playerId].weaponUid = weapon:getUniqueId()
 
 	if not isItemOwnedByPlayer(weapon, player) then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The training weapon is no longer yours, the training has stopped.")

--- a/data/lib/functions/exercise_training.lua
+++ b/data/lib/functions/exercise_training.lua
@@ -67,9 +67,29 @@ function LeaveTraining(playerId)
 		stopEvent(onExerciseTraining[playerId].event)
 		onExerciseTraining[playerId] = nil
 	end
+end
 
-	local player = Player(playerId)
-	return
+local function findPlayerWeaponById(player, weaponId)
+	for slot = CONST_SLOT_HEAD, CONST_SLOT_AMMO do
+		local item = player:getSlotItem(slot)
+		if item and item:getId() == weaponId then
+			return item
+		end
+	end
+
+	local backpack = player:getSlotItem(CONST_SLOT_BACKPACK)
+	if not backpack then
+		return nil
+	end
+
+	for i = 0, backpack:getSize() - 1 do
+		local item = backpack:getItem(i)
+		if item and item:getId() == weaponId then
+			return item
+		end
+	end
+
+	return nil
 end
 
 function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
@@ -80,6 +100,11 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
 
 	local training = onExerciseTraining[playerId]
 	if not training then
+		return false
+	end
+
+	if training.ownerGuid and training.ownerGuid ~= player:getGuid() then
+		LeaveTraining(playerId)
 		return false
 	end
 
@@ -96,8 +121,8 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
         return true
     end
 
-	local weapon = training.weapon
-	if not weapon or not weapon:isItem() or weapon:getId() ~= weaponId then
+	local weapon = findPlayerWeaponById(player, weaponId)
+	if not weapon then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The training weapon is no longer available, the training has stopped.")
 		LeaveTraining(playerId)
 		return false
@@ -154,6 +179,7 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
 
 	local vocation = player:getVocation()
 	onExerciseTraining[playerId].event = addEvent(ExerciseEvent, vocation:getAttackSpeed() / configManager.getNumber(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
+	onExerciseTraining[playerId].ownerGuid = player:getGuid()
 	return true
 end
 

--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -185,11 +185,20 @@ function doNpcSellItem(cid, itemid, amount, subType, ignoreCap, inBackpacks,
 end
 
 local func = function(cid, text, type, e, pcid)
-	if Player(pcid) then
-		local creature = Creature(cid)
-		creature:say(text, type, false, pcid, creature:getPosition())
+	local player = Player(pcid)
+	if not player then
 		e.done = true
+		return
 	end
+
+	local creature = Creature(cid)
+	if not creature then
+		e.done = true
+		return
+	end
+
+	creature:say(text, type, false, pcid, creature:getPosition())
+	e.done = true
 end
 
 function doCreatureSayWithDelay(cid, text, type, delay, e, pcid)

--- a/data/scripts/actions/items/exercise_training.lua
+++ b/data/scripts/actions/items/exercise_training.lua
@@ -60,13 +60,14 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 			return true
 		end
 
+		local playerGuid = player:getGuid()
 		onExerciseTraining[playerId] = {}
 		if not onExerciseTraining[playerId].event then
-			onExerciseTraining[playerId].weapon = item
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You started training with an exercise weapon.")
 			onExerciseTraining[playerId].event = addEvent(ExerciseEvent, 0, playerId, targetPos,
 			                                              item.itemid, targetId)
 			onExerciseTraining[playerId].dummyPos = targetPos
+			onExerciseTraining[playerId].ownerGuid = playerGuid
 			player:setStorageValue(PlayerStorageKeys.ExerciseDummyExhaust, os.time() + 30)
 		end
 		return true
@@ -82,6 +83,19 @@ for weaponId, weapon in pairs(ExerciseWeaponsTable) do
 end
 
 exerciseTraining:register()
+
+local exerciseTraining_Logout = CreatureEvent("ExerciseTraining_Logout")
+function exerciseTraining_Logout.onLogout(player)
+	local playerId = player:getId()
+	if onExerciseTraining[playerId] then
+		stopEvent(onExerciseTraining[playerId].event)
+		onExerciseTraining[playerId] = nil
+	end
+
+	return true
+end
+
+exerciseTraining_Logout:register()
 
 local exerciseTraining_Login = CreatureEvent("ExerciseTraining_Login")
 function exerciseTraining_Login.onLogin(player)

--- a/data/scripts/actions/items/exercise_training.lua
+++ b/data/scripts/actions/items/exercise_training.lua
@@ -61,6 +61,7 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 		end
 
 		local playerGuid = player:getGuid()
+		local weaponUid = item:getUniqueId()
 		onExerciseTraining[playerId] = {}
 		if not onExerciseTraining[playerId].event then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You started training with an exercise weapon.")
@@ -68,6 +69,7 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 			                                              item.itemid, targetId)
 			onExerciseTraining[playerId].dummyPos = targetPos
 			onExerciseTraining[playerId].ownerGuid = playerGuid
+			onExerciseTraining[playerId].weaponUid = weaponUid
 			player:setStorageValue(PlayerStorageKeys.ExerciseDummyExhaust, os.time() + 30)
 		end
 		return true

--- a/data/scripts/network/gamestore/gamestore.lua
+++ b/data/scripts/network/gamestore/gamestore.lua
@@ -182,14 +182,15 @@ end
 
 local function scheduleChangeNameKick(player)
 	local playerId = player:getId()
+	local playerName = player:getName()
 	player:sendTextMessage(MESSAGE_INFO_DESCR, CHANGE_NAME_SUCCESS_MESSAGE)
 
-	addEvent(function(id)
+	addEvent(function(id, expectedName)
 		local onlinePlayer = Player(id)
-		if onlinePlayer then
+		if onlinePlayer and onlinePlayer:getName() == expectedName then
 			onlinePlayer:remove()
 		end
-	end, CHANGE_NAME_KICK_DELAY, playerId)
+	end, CHANGE_NAME_KICK_DELAY, playerId, playerName)
 end
 
 local forbiddenNameWords = {


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed proper TFS Downgrades code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This pull request hardens delayed `addEvent` callbacks and improves object lifecycle validation.

The main changes are:

- Removes the persistent exercise weapon userdata reference from the Exercise Training system.
- Revalidates the player and exercise weapon during recurring training events.
- Associates the training session with the player's GUID.
- Cancels and clears the Exercise Training event immediately on logout.
- Validates the NPC/creature before executing delayed dialogue.
- Prevents delayed callbacks from attempting to call `say()` on a removed creature.
- Adds identity validation before the delayed GameStore name-change kick.
- Reduces the risk of stale callbacks running after logout or object removal.

These changes are focused on server stability and do not intentionally change gameplay behavior.

### Testing

- Lua changes reviewed for syntax and callback lifecycle safety.
- Delayed callback cancellation and nil validation were reviewed manually.
- Full runtime stress testing and sanitizer validation are still recommended before merging.

**Issues addressed:** No linked issue. This addresses delayed `addEvent` callback safety and potential crashes during logout, relog, or object removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exercise training now remains tied to the correct character and verifies the training weapon throughout the session.
  * Active training sessions are automatically stopped when a character logs out.
  * NPC dialogue callbacks now end safely when the related player or NPC is no longer available.
  * Character name changes now disconnect only the intended character, preventing unintended removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->