### PR TITLE
Fix critical crashes: damageMap/storageMap reentrant access and prema…

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -21,6 +21,9 @@ on:
       - CMakeLists.txt
       - CMakePresets.json
       - vcpkg.json
+      - vcpkg-configuration.json
+      - vcpkg-overlays/**
+      - tools/*.cmake
 
   pull_request:
     paths:
@@ -30,6 +33,9 @@ on:
       - CMakeLists.txt
       - CMakePresets.json
       - vcpkg.json
+      - vcpkg-configuration.json
+      - vcpkg-overlays/**
+      - tools/*.cmake
 
   workflow_dispatch:
 
@@ -64,7 +70,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/vcpkg_cache
-          key: vcpkg-windows-${{ hashFiles('vcpkg.json', 'CMakeLists.txt', '**/CMakeLists.txt', 'CMakePresets.json') }}
+          key: vcpkg-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-overlays/**', 'CMakeLists.txt', '**/CMakeLists.txt', 'CMakePresets.json') }}
           restore-keys: |
             vcpkg-windows-
 
@@ -81,7 +87,10 @@ jobs:
         with:
           configurePreset: vcpkg
           buildPreset: vcpkg
-          configurePresetAdditionalArgs: "['-GNinja', '-DCMAKE_BUILD_TYPE=Release', '-DCMAKE_C_COMPILER=cl', '-DCMAKE_CXX_COMPILER=cl', '-DCMAKE_C_COMPILER_LAUNCHER=sccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache', '-DVCPKG_TARGET_TRIPLET=x64-windows-static', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']"
+          configurePresetAdditionalArgs: "['-GNinja', '-DCMAKE_BUILD_TYPE=Release', '-DBUILD_TESTING=ON', '-DCMAKE_C_COMPILER=cl', '-DCMAKE_CXX_COMPILER=cl', '-DCMAKE_C_COMPILER_LAUNCHER=sccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache', '-DVCPKG_TARGET_TRIPLET=x64-windows-static', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']"
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
 
       - name: Upload build logs
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,20 +45,23 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             cmake ninja-build build-essential pkg-config \
+            patch \
             gcc g++ \
             libssl-dev zlib1g-dev libfmt-dev libspdlog-dev \
             libpugixml-dev libabsl-dev \
             libasio-dev \
             default-libmysqlclient-dev
 
-      - name: Build Lua 5.5 from source
+      - name: Build patched Lua 5.5 from source
         run: |
           curl -sSL https://www.lua.org/ftp/lua-5.5.0.tar.gz -o lua.tar.gz
           echo "57ccc32bbbd005cab75bcc52444052535af691789dba2b9016d5c50640d68b3d lua.tar.gz" | sha256sum -c
           tar xzf lua.tar.gz
           cd lua-5.5.0
+          patch -d src -p1 < "$GITHUB_WORKSPACE/tools/patches/lua-5.5.0-write-barrier.patch"
           make -j$(nproc) linux MYCFLAGS="-fPIC"
           sudo make install INSTALL_TOP=/usr/local
+          /usr/local/bin/lua -e 'local p={}; p.__newindex=p; collectgarbage(); local c=setmetatable({},p); c.__newindex={x="hello"}; collectgarbage("step"); assert(p.__newindex.x=="hello")'
           cd ..
           rm -rf lua-5.5.0 lua.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
       - 'cmake/**'
       - CMakeLists.txt
       - vcpkg.json
+      - 'tools/*.cmake'
+      - 'tools/patches/lua-5.5.0-write-barrier.patch'
       - '.github/workflows/build.yml'
   pull_request:
     branches:
@@ -20,6 +22,8 @@ on:
       - 'cmake/**'
       - CMakeLists.txt
       - vcpkg.json
+      - 'tools/*.cmake'
+      - 'tools/patches/lua-5.5.0-write-barrier.patch'
       - '.github/workflows/build.yml'
   workflow_dispatch:
 
@@ -99,6 +103,7 @@ jobs:
           -DENABLE_NATIVE_OPTIMIZATIONS=OFF
           -DENABLE_SLOW_TASK_DETECTION=OFF
           -DUSE_MIMALLOC=OFF
+          -DBUILD_TESTING=ON
           -DSKIP_GIT=OFF
           -DLUA_INCLUDE_DIR=/usr/local/include
           -DLUA_LIBRARY=/usr/local/lib/liblua.a
@@ -107,6 +112,9 @@ jobs:
 
       - name: Build
         run: cmake --build build --parallel $(nproc)
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
 
       - name: Verify binary
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,7 @@ on:
       - CMakeLists.txt
       - vcpkg.json
       - vcpkg-configuration.json
+      - "vcpkg-overlays/**"
 
   pull_request:
     branches:
@@ -30,6 +31,7 @@ on:
       - CMakeLists.txt
       - vcpkg.json
       - vcpkg-configuration.json
+      - "vcpkg-overlays/**"
 
   workflow_dispatch:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ endif()
 if (BUILD_TESTING)
     message(STATUS "Building unit tests")
     add_test(
+        NAME check_source_list_parity
         COMMAND ${CMAKE_COMMAND}
             -DPROJECT_SOURCE_DIR=${CMAKE_SOURCE_DIR}
             -P ${CMAKE_SOURCE_DIR}/tools/check-source-list-parity.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 option(ENABLE_ASAN "Enable AddressSanitizer for memory diagnostics" OFF)
 option(ENABLE_NATIVE_OPTIMIZATIONS "Enable -march=native/-mtune=native for local Release builds" ON)
+option(ENABLE_PACKET_BACKLOG_DIAGNOSTICS "Enable ProtocolGame packet backlog diagnostics" OFF)
 
 option(USE_LUAJIT "Use LuaJIT" OFF)
 if (USE_LUAJIT)
@@ -255,6 +256,11 @@ if (ENABLE_SLOW_TASK_DETECTION)
 endif()
 ### END SLOW TASK DETECTION ###
 
+if (ENABLE_PACKET_BACKLOG_DIAGNOSTICS)
+    ADD_DEFINITIONS(-DPROTOCOLGAME_BACKLOG_DIAGNOSTICS)
+    message(STATUS "ProtocolGame packet backlog diagnostics enabled")
+endif()
+
 if (BUILD_TESTING OR BUILD_BENCHMARKING)
     enable_testing()
 endif()
@@ -277,6 +283,12 @@ if (BUILD_TESTING)
         COMMAND ${CMAKE_COMMAND}
             -DPROJECT_SOURCE_DIR=${CMAKE_SOURCE_DIR}
             -P ${CMAKE_SOURCE_DIR}/tools/check-shared-get-escapes.cmake
+    )
+    add_test(
+        NAME check_protocolgame_handshake
+        COMMAND ${CMAKE_COMMAND}
+            -DPROJECT_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+            -P ${CMAKE_SOURCE_DIR}/tools/check-protocolgame-handshake.cmake
     )
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ENV VCPKG_ROOT=/opt/vcpkg
 ENV PATH="${VCPKG_ROOT}:${PATH}"
 # Instalar dependencias del proyecto
 WORKDIR /usr/src/forgottenserver-downgrade
-COPY vcpkg.json ./
+COPY vcpkg.json vcpkg-configuration.json ./
+COPY vcpkg-overlays ./vcpkg-overlays/
 # Pre-seed Lua's distfile to avoid transient vcpkg download timeouts in CI.
 RUN set -eux; \
     mkdir -p /opt/vcpkg/downloads; \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ Choose `true` or `false` for each key in `config.lua`. Bounty and Weekly Tasks r
 
 </details>
 
+### NPC System
+
+Two ready-to-use NPC systems are included. Select one with the `npcSystem` key in `config.lua`:
+
+| Value | NPC system |
+|---|---|
+| `"tfs"` | Default. Uses the standard TFS Lua/RevScript NPC libraries and NPCs from `data/npc/lua`. |
+| `"crystal"` | Uses the included Crystal Server 15.25 Lua/RevScript NPC libraries and NPC pack. |
+
+The default configuration is:
+
+```lua
+npcSystem = "tfs"
+```
+
+To use the Crystal Server NPCs, change only this value and restart the server:
+
+```lua
+npcSystem = "crystal"
+```
+
+Both Lua/RevScript NPC backends and their folders are already configured. An unknown value automatically falls back to `"tfs"`.
+
 ---
 
 ## Compilation

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Use the ClientID-compatible map editor for this source:
 
 ## Optional Systems
 
-Optional systems are listed in `config.lua.dist` and enabled in `config.lua`. Most remain disabled by default to preserve the classic 8.60 experience.
+Optional systems are listed in `config.lua.dist` and controlled individually in `config.lua`. Set a system to `true` to enable it or `false` to disable it, choosing only the features that fit your server.
+
+- For a classic 8.60 experience, keep most optional systems set to `false`.
+- For a modern or 15.x-inspired experience, set the systems you want to `true`.
+- You can freely mix `true` and `false` to create your own feature set. The server protocol remains 8.60.
+
+Most optional systems are disabled by default so new installations start with behavior closer to classic 8.60.
 
 <details>
 <summary><strong>View optional systems and config keys</strong></summary>
@@ -82,7 +88,7 @@ Optional systems are listed in `config.lua.dist` and enabled in `config.lua`. Mo
 | Soulpit | `soulpitSystemEnabled` |
 | Soulseals | `soulsealsSystemEnabled` |
 
-Set the desired key to `true` in `config.lua`. Bounty and Weekly Tasks require Task Hunting; Soulseals require Weekly Tasks or another configured source.
+Choose `true` or `false` for each key in `config.lua`. Bounty and Weekly Tasks require Task Hunting; Soulseals require Weekly Tasks or another configured source.
 
 </details>
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,8 @@ set -Eeuo pipefail
 REPO_URL="https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60.git"
 
 LUA_VERSION="5.5.0"
-LUA_TARBALL="lua-${LUA_VERSION}.tar.gz"
+LUA_SOURCE_DIR="lua-${LUA_VERSION}"
+LUA_TARBALL="${LUA_SOURCE_DIR}.tar.gz"
 LUA_URL="https://www.lua.org/ftp/${LUA_TARBALL}"
 LUA_SHA256="57ccc32bbbd005cab75bcc52444052535af691789dba2b9016d5c50640d68b3d"
 LUA_PREFIX="/usr/local"
@@ -27,6 +28,7 @@ SKIP_BUILD=0
 NONINTERACTIVE=0
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+LUA_PATCH_FILE="${SCRIPT_DIR}/tools/patches/lua-5.5.0-write-barrier.patch"
 APT_UPDATED=0
 SUDO=()
 
@@ -621,6 +623,7 @@ install_common_deps() {
     xz-utils
     cmake
     build-essential
+    patch
     pkg-config
     make
     gcc
@@ -682,13 +685,29 @@ lua_binary_is_55() {
   [[ "${version}" =~ ^Lua[[:space:]]5\.5(\.|[[:space:]]|$) ]]
 }
 
+lua_runtime_has_required_fixes() {
+  local lua_bin="${LUA_PREFIX}/bin/lua"
+
+  [[ -x "${lua_bin}" ]] || return 1
+  "${lua_bin}" -e '
+local parent = {}
+parent.__newindex = parent
+collectgarbage()
+local child = setmetatable({}, parent)
+child.__newindex = {x = "hello"}
+collectgarbage("step")
+assert(parent.__newindex.x == "hello")
+' >/dev/null 2>&1
+}
+
 lua_local_is_55() {
   local header="${LUA_PREFIX}/include/lua.h"
   local library="${LUA_PREFIX}/lib/liblua.a"
 
   [[ -f "${header}" && -f "${library}" ]] || return 1
   lua_header_declares_55 "${header}" || return 1
-  lua_binary_is_55
+  lua_binary_is_55 || return 1
+  lua_runtime_has_required_fixes
 }
 
 lua_pkgconfig_dirs() {
@@ -848,14 +867,15 @@ install_lua_55() {
   sayf lua_install "${LUA_VERSION}"
 
   cd /tmp
-  rm -rf "lua-${LUA_VERSION}" "${LUA_TARBALL}"
+  rm -rf "${LUA_SOURCE_DIR}" "${LUA_TARBALL}"
 
   wget -O "${LUA_TARBALL}" "${LUA_URL}"
   printf '%s  %s\n' "${LUA_SHA256}" "${LUA_TARBALL}" | sha256sum -c -
 
   tar -xzf "${LUA_TARBALL}"
-  cd "lua-${LUA_VERSION}"
+  cd "${LUA_SOURCE_DIR}"
 
+  patch -d src -p1 < "${LUA_PATCH_FILE}"
   make linux MYCFLAGS="-fPIC"
   "${SUDO[@]}" make install
   "${SUDO[@]}" ldconfig

--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -23,8 +23,8 @@ function Creature:onChangeZone(fromZone, toZone)
 	if hasEvent.onChangeZone then Event.onChangeZone(self, fromZone, toZone) end
 end
 
-function Creature:onUpdateStorage(key, value, oldValue, isSpawn)
+function Creature:onUpdateStorage(key, value, oldValue)
 	if hasEvent.onUpdateStorage then
-		Event.onUpdateStorage(self, key, value, oldValue, isSpawn)
+		Event.onUpdateStorage(self, key, value, oldValue)
 	end
 end

--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -25,6 +25,6 @@ end
 
 function Creature:onUpdateStorage(key, value, oldValue, isSpawn)
 	if hasEvent.onUpdateStorage then
-		Event.onUpdateStorage(self, key, oldValue, value, isSpawn)
+		Event.onUpdateStorage(self, key, value, oldValue, isSpawn)
 	end
 end

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -137,8 +137,8 @@ function Player:onNetworkMessage(recvByte, msg)
 	handler(self, msg)
 end
 
-function Player:onUpdateStorage(key, value, oldValue, isLogin)
-	if hasEvent.onUpdateStorage then Event.onUpdateStorage(self, key, value, oldValue, isLogin) end
+function Player:onUpdateStorage(key, value, oldValue)
+	if hasEvent.onUpdateStorage then Event.onUpdateStorage(self, key, value, oldValue) end
 end
 
 function Player:onUpdateInventory(item, slot, equip)

--- a/data/lib/functions/exercise_training.lua
+++ b/data/lib/functions/exercise_training.lua
@@ -63,52 +63,24 @@ local function isItemOwnedByPlayer(item, player)
 end
 
 function LeaveTraining(playerId)
-	if onExerciseTraining[playerId] then
-		stopEvent(onExerciseTraining[playerId].event)
-		onExerciseTraining[playerId] = nil
-	end
-end
-
-local function findContainerItemById(container, weaponId, weaponUid)
-	if not container or not container:isContainer() then
-		return nil
+	local training = onExerciseTraining[playerId]
+	if not training then
+		return
 	end
 
-	for i = 0, container:getSize() - 1 do
-		local item = container:getItem(i)
-		if item then
-			if item:getId() == weaponId and item:getUniqueId() == weaponUid then
-				return item
-			end
-
-			if item:isContainer() then
-				local found = findContainerItemById(item, weaponId, weaponUid)
-				if found then
-					return found
-				end
-			end
-		end
+	if training.event then
+		stopEvent(training.event)
 	end
 
-	return nil
-end
-
-local function findPlayerWeaponById(player, weaponId, weaponUid)
-	for slot = CONST_SLOT_HEAD, CONST_SLOT_AMMO do
-		local item = player:getSlotItem(slot)
-		if item and item:getId() == weaponId and item:getUniqueId() == weaponUid then
-			return item
-		end
-	end
-
-	local backpack = player:getSlotItem(CONST_SLOT_BACKPACK)
-	return findContainerItemById(backpack, weaponId, weaponUid)
+	training.weapon = nil
+	onExerciseTraining[playerId] = nil
 end
 
 function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
 	local player = Player(playerId)
 	if not player then
-		return LeaveTraining(playerId)
+		LeaveTraining(playerId)
+		return false
 	end
 
 	local training = onExerciseTraining[playerId]
@@ -116,41 +88,60 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
 		return false
 	end
 
-	if training.ownerGuid and training.ownerGuid ~= player:getGuid() then
+	if training.ownerGuid ~= player:getGuid() then
 		LeaveTraining(playerId)
 		return false
 	end
 
-	if not Tile(tilePosition):getItemById(dummyId) then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Someone has moved the dummy, the training has stopped.")
+	local dummyTile = Tile(tilePosition)
+	if not dummyTile or not dummyTile:getItemById(dummyId) then
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"Someone has moved the dummy, the training has stopped."
+		)
 		LeaveTraining(playerId)
 		return false
 	end
 
-	local playerPosition = player:getPosition()
-	if not player:getTile():hasFlag(TILESTATE_PROTECTIONZONE) and not staminaEvents[playerId] then
-        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You are no longer in a protection zone, the training has stopped.")
-		LeaveTraining(playerId)
-        return true
-    end
-
-	local weapon = findPlayerWeaponById(player, weaponId, training.weaponUid)
-	if not weapon then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The training weapon is no longer available, the training has stopped.")
+	local playerTile = player:getTile()
+	if not playerTile then
 		LeaveTraining(playerId)
 		return false
 	end
 
-	onExerciseTraining[playerId].weaponUid = weapon:getUniqueId()
+	if not playerTile:hasFlag(TILESTATE_PROTECTIONZONE) and not staminaEvents[playerId] then
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"You are no longer in a protection zone, the training has stopped."
+		)
+		LeaveTraining(playerId)
+		return false
+	end
+
+	local weapon = training.weapon
+	if not weapon or not weapon:isItem() or weapon:getId() ~= weaponId then
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"The training weapon is no longer available, the training has stopped."
+		)
+		LeaveTraining(playerId)
+		return false
+	end
 
 	if not isItemOwnedByPlayer(weapon, player) then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The training weapon is no longer yours, the training has stopped.")
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"The training weapon is no longer yours, the training has stopped."
+		)
 		LeaveTraining(playerId)
 		return false
 	end
 
 	if not weapon:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The selected item is not a training weapon, the training has stopped.")
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"The selected item is not a training weapon, the training has stopped."
+		)
 		LeaveTraining(playerId)
 		return false
 	end
@@ -158,43 +149,65 @@ function ExerciseEvent(playerId, tilePosition, weaponId, dummyId)
 	local weaponCharges = weapon:getAttribute(ITEM_ATTRIBUTE_CHARGES)
 	if not weaponCharges or weaponCharges <= 0 then
 		weapon:remove(1)
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon has disappeared.")
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"Your training weapon has disappeared."
+		)
 		LeaveTraining(playerId)
 		return false
 	end
 
-	local isMagic = ExerciseWeaponsTable[weaponId].skill == SKILL_MAGLEVEL
+	local weaponConfig = ExerciseWeaponsTable[weaponId]
+	if not weaponConfig then
+		LeaveTraining(playerId)
+		return false
+	end
+
 	local bonusDummy = 1
 
 	if table.contains(HouseDummies, dummyId) then
-		bonusDummy = 1.5 -- 50%
-	elseif table.contains(FreeDummies, dummyId) then
-		bonusDummy = 1
+		bonusDummy = 1.5
 	end
 
-	if isMagic then
+	if weaponConfig.skill == SKILL_MAGLEVEL then
 		player:addManaSpent(500 * bonusDummy)
 	else
-		player:addSkillTries(ExerciseWeaponsTable[weaponId].skill, 7 * bonusDummy)
+		player:addSkillTries(weaponConfig.skill, 7 * bonusDummy)
 	end
 
-	weapon:setAttribute(ITEM_ATTRIBUTE_CHARGES, (weaponCharges - 1))
+	weapon:setAttribute(ITEM_ATTRIBUTE_CHARGES, weaponCharges - 1)
 	tilePosition:sendMagicEffect(CONST_ME_HITAREA)
 
-	if ExerciseWeaponsTable[weaponId].effect then
-		playerPosition:sendDistanceEffect(tilePosition, ExerciseWeaponsTable[weaponId].effect)
+	if weaponConfig.effect then
+		player:getPosition():sendDistanceEffect(tilePosition, weaponConfig.effect)
 	end
 
 	if weapon:getAttribute(ITEM_ATTRIBUTE_CHARGES) <= 0 then
 		weapon:remove(1)
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon has disappeared.")
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"Your training weapon has disappeared."
+		)
 		LeaveTraining(playerId)
 		return false
 	end
 
+	local currentTraining = onExerciseTraining[playerId]
+	if not currentTraining or currentTraining ~= training then
+		return false
+	end
+
 	local vocation = player:getVocation()
-	onExerciseTraining[playerId].event = addEvent(ExerciseEvent, vocation:getAttackSpeed() / configManager.getNumber(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
-	onExerciseTraining[playerId].ownerGuid = player:getGuid()
+	currentTraining.event = addEvent(
+		ExerciseEvent,
+		vocation:getAttackSpeed() /
+			configManager.getNumber(configKeys.RATE_EXERCISE_TRAINING_SPEED),
+		playerId,
+		tilePosition,
+		weaponId,
+		dummyId
+	)
+
 	return true
 end
 

--- a/data/scripts/actions/items/exercise_training.lua
+++ b/data/scripts/actions/items/exercise_training.lua
@@ -61,17 +61,33 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 		end
 
 		local playerGuid = player:getGuid()
-		local weaponUid = item:getUniqueId()
-		onExerciseTraining[playerId] = {}
-		if not onExerciseTraining[playerId].event then
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You started training with an exercise weapon.")
-			onExerciseTraining[playerId].event = addEvent(ExerciseEvent, 0, playerId, targetPos,
-			                                              item.itemid, targetId)
-			onExerciseTraining[playerId].dummyPos = targetPos
-			onExerciseTraining[playerId].ownerGuid = playerGuid
-			onExerciseTraining[playerId].weaponUid = weaponUid
-			player:setStorageValue(PlayerStorageKeys.ExerciseDummyExhaust, os.time() + 30)
-		end
+		local training = {
+			weapon = item,
+			ownerGuid = playerGuid,
+			dummyPos = targetPos,
+		}
+
+		onExerciseTraining[playerId] = training
+
+		player:sendTextMessage(
+			MESSAGE_EVENT_ADVANCE,
+			"You started training with an exercise weapon."
+		)
+
+		training.event = addEvent(
+			ExerciseEvent,
+			0,
+			playerId,
+			targetPos,
+			item:getId(),
+			targetId
+		)
+
+		player:setStorageValue(
+			PlayerStorageKeys.ExerciseDummyExhaust,
+			os.time() + 30
+		)
+
 		return true
 	end
 	
@@ -87,26 +103,18 @@ end
 exerciseTraining:register()
 
 local exerciseTraining_Logout = CreatureEvent("ExerciseTraining_Logout")
-function exerciseTraining_Logout.onLogout(player)
-	local playerId = player:getId()
-	if onExerciseTraining[playerId] then
-		stopEvent(onExerciseTraining[playerId].event)
-		onExerciseTraining[playerId] = nil
-	end
 
+function exerciseTraining_Logout.onLogout(player)
+	LeaveTraining(player:getId())
 	return true
 end
 
 exerciseTraining_Logout:register()
 
 local exerciseTraining_Login = CreatureEvent("ExerciseTraining_Login")
+
 function exerciseTraining_Login.onLogin(player)
-
-	if onExerciseTraining[player:getId()] then -- onLogin & onLogout
-		stopEvent(onExerciseTraining[player:getId()].event)
-		onExerciseTraining[player:getId()] = nil
-	end
-
+	LeaveTraining(player:getId())
 	return true
 end
 

--- a/data/scripts/eventcallbacks/player/default_onUpdateStorage.lua
+++ b/data/scripts/eventcallbacks/player/default_onUpdateStorage.lua
@@ -2,9 +2,7 @@ local lastQuestUpdate = {}
 
 local event = Event()
 
-event.onUpdateStorage = function(creature, key, value, oldValue, isSpawn)
-	if isSpawn then return end
-
+event.onUpdateStorage = function(creature, key, value, oldValue)
 	local player = creature:getPlayer()
 	if not player then
 		player = Player(creature:getId())

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -2012,6 +2012,9 @@ function acceptHandler.onReceive(player, msg)
 		else
 			sendMarketMessage(owner, "Your market sell offer has been fulfilled. The payment was credited to your bank balance.")
 		end
+		if marketOpenSessions[owner:getId()] then
+			sendMarketBrowse(owner, MARKET_REQUEST_MY_OFFERS)
+		end
 	end
 end
 acceptHandler:register()

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -2007,8 +2007,11 @@ function acceptHandler.onReceive(player, msg)
 
 	local owner = Player(offer.playerName)
 	if owner then
-		sendMarketMessage(owner, "One of your market offers was accepted.")
-		refreshMarket(owner, MARKET_REQUEST_MY_OFFERS)
+		if offer.sale == MARKET_ACTION_BUY then
+			sendMarketMessage(owner, "Your market buy offer has been fulfilled. The purchased item was delivered to your Market Inbox.")
+		else
+			sendMarketMessage(owner, "Your market sell offer has been fulfilled. The payment was credited to your bank balance.")
+		end
 	end
 end
 acceptHandler:register()

--- a/data/scripts/talkactions/stress/stress_login_storage.lua
+++ b/data/scripts/talkactions/stress/stress_login_storage.lua
@@ -132,7 +132,7 @@ local function finishJob(job, message, isError)
     if activeJob ~= job then
         return
     end
-    notify(job, message .. string.format(" | tempo=%ds", elapsedSeconds(job)), isError)
+    notify(job, message .. string.format(" | elapsed=%ds", elapsedSeconds(job)), isError)
     activeJob = nil
 end
 
@@ -174,13 +174,13 @@ local function resolveOfflinePlayers(names)
     local targets = {}
     for _, name in ipairs(names) do
         if Player(name) then
-            return nil, "O personagem '" .. name .. "' precisa estar offline."
+            return nil, "The character '" .. name .. "' must be offline."
         end
 
         local query = "SELECT `id`, `name` FROM `players` WHERE `name` = " .. sqlString(name) .. " LIMIT 1"
         local resultId = db.storeQuery(query)
         if not resultId then
-            return nil, "Personagem nao encontrado: " .. name
+            return nil, "Character not found: " .. name
         end
 
         targets[#targets + 1] = {
@@ -196,14 +196,14 @@ local runPrepareStep
 
 runPrepareStep = function(job)
     if job.stopRequested then
-        finishJob(job, string.format("PREPARE interrompido em %d/%d rows", job.completed, job.total), true)
+        finishJob(job, string.format("PREPARE stopped at %d/%d rows", job.completed, job.total), true)
         return
     end
 
     local target = job.targets[job.targetIndex]
     if not target then
         finishJob(job, string.format(
-            "PREPARE concluido: %d storages em %d personagem(ns). Agora deixe-os offline e faca login simultaneo com 1, 2 e 3 clientes",
+            "PREPARE completed: %d storages for %d character(s). Keep them offline, then log in simultaneously with 1, 2, and 3 clients",
             job.completed,
             #job.targets
         ))
@@ -211,7 +211,7 @@ runPrepareStep = function(job)
     end
 
     if Player(target.name) then
-        finishJob(job, "PREPARE cancelado: '" .. target.name .. "' entrou durante a gravacao", true)
+        finishJob(job, "PREPARE cancelled: '" .. target.name .. "' logged in during setup", true)
         return
     end
 
@@ -236,14 +236,14 @@ runPrepareStep = function(job)
         .. " ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)"
 
     if not db.query(query) then
-        finishJob(job, string.format("Falha SQL preparando '%s' no offset %d", target.name, job.offset), true)
+        finishJob(job, string.format("SQL failure while preparing '%s' at offset %d", target.name, job.offset), true)
         return
     end
 
     job.offset = job.offset + amount
     job.completed = job.completed + amount
     maybeReport(job, string.format(
-        "PREPARE %d/%d rows (%.1f%%) | atual=%s",
+        "PREPARE %d/%d rows (%.1f%%) | current=%s",
         job.completed,
         job.total,
         (job.completed * 100) / math.max(1, job.total),
@@ -255,7 +255,7 @@ end
 local function startPrepare(player, namesValue, rowsValue)
     local names = splitNames(namesValue)
     if #names == 0 then
-        notifyPlayer(player, "Uso: /stress_login prepare,Nome 1|Nome 2|Nome 3,25000", true)
+        notifyPlayer(player, "Usage: /stress_login prepare,Name 1|Name 2|Name 3,25000", true)
         return
     end
 
@@ -275,7 +275,7 @@ local function startPrepare(player, namesValue, rowsValue)
     job.total = rows * #targets
 
     notify(job, string.format(
-        "PREPARE iniciado: %d personagem(ns) x %d storages = %d rows",
+        "PREPARE started: %d character(s) x %d storages = %d rows",
         #targets,
         rows,
         job.total
@@ -287,18 +287,18 @@ local runCleanStep
 
 runCleanStep = function(job)
     if job.stopRequested then
-        finishJob(job, string.format("CLEAN interrompido em %d/%d personagens", job.targetIndex - 1, #job.targets), true)
+        finishJob(job, string.format("CLEAN stopped at %d/%d characters", job.targetIndex - 1, #job.targets), true)
         return
     end
 
     local target = job.targets[job.targetIndex]
     if not target then
-        finishJob(job, string.format("CLEAN concluido para %d personagem(ns)", #job.targets))
+        finishJob(job, string.format("CLEAN completed for %d character(s)", #job.targets))
         return
     end
 
     if Player(target.name) then
-        finishJob(job, "CLEAN cancelado: '" .. target.name .. "' precisa estar offline", true)
+        finishJob(job, "CLEAN cancelled: '" .. target.name .. "' must be offline", true)
         return
     end
 
@@ -314,11 +314,11 @@ runCleanStep = function(job)
     )
 
     if not db.query(query) then
-        finishJob(job, "Falha SQL limpando '" .. target.name .. "'", true)
+        finishJob(job, "SQL failure while cleaning '" .. target.name .. "'", true)
         return
     end
 
-    notify(job, "CLEAN removido de " .. target.name)
+    notify(job, "CLEAN removed reserved storages for " .. target.name)
     job.targetIndex = job.targetIndex + 1
     schedule(job, runCleanStep, CONFIG.sqlBatchDelayMs)
 end
@@ -326,7 +326,7 @@ end
 local function startClean(player, namesValue)
     local names = splitNames(namesValue)
     if #names == 0 then
-        notifyPlayer(player, "Uso: /stress_login clean,Nome 1|Nome 2|Nome 3", true)
+        notifyPlayer(player, "Usage: /stress_login clean,Name 1|Name 2|Name 3", true)
         return
     end
 
@@ -339,7 +339,7 @@ local function startClean(player, namesValue)
     local job = newJob(player, "clean")
     job.targets = targets
     job.targetIndex = 1
-    notify(job, "CLEAN iniciado. Somente a faixa reservada pelo teste sera removida")
+    notify(job, "CLEAN started. Only the storage ranges reserved by this test will be removed")
     schedule(job, runCleanStep, 0)
 end
 
@@ -358,20 +358,20 @@ local function beginHammerCleanup(job, reason)
     job.cleanupPlayerIndex = 1
     job.cleanupSlot = 0
     job.cleanupReason = reason
-    notify(job, "HAMMER finalizando; restaurando storages temporarias...")
+    notify(job, "HAMMER finishing; restoring temporary storages...")
     schedule(job, runHammerCleanup, 0)
 end
 
 runHammerCleanup = function(job)
     local entry = job.players[job.cleanupPlayerIndex]
     if not entry then
-        local suffix = job.cleanupReason or "concluido"
+        local suffix = job.cleanupReason or "completed"
         local disconnectedCount = 0
         for _ in pairs(job.disconnected) do
             disconnectedCount = disconnectedCount + 1
         end
         finishJob(job, string.format(
-            "HAMMER %s: %d operacoes, %d saves solicitados, %d jogador(es), %d desconectado(s)",
+            "HAMMER %s: %d operations, %d saves requested, %d player(s), %d disconnected",
             suffix,
             job.completed,
             job.saveRequests,
@@ -384,7 +384,7 @@ runHammerCleanup = function(job)
     local player = getHammerPlayer(entry)
     if not player then
         job.disconnected[entry.guid] = true
-        notify(job, "AVISO: " .. entry.name .. " desconectou; use CLEAN com ele offline", true)
+        notify(job, "WARNING: " .. entry.name .. " disconnected; run CLEAN after the character is offline", true)
         job.cleanupPlayerIndex = job.cleanupPlayerIndex + 1
         job.cleanupSlot = 0
         schedule(job, runHammerCleanup, 0)
@@ -413,11 +413,11 @@ local runHammerSnapshot
 
 runHammerStep = function(job)
     if job.stopRequested then
-        beginHammerCleanup(job, "interrompido")
+        beginHammerCleanup(job, "stopped")
         return
     end
     if job.completed >= job.total then
-        beginHammerCleanup(job, "concluido")
+        beginHammerCleanup(job, "completed")
         return
     end
 
@@ -461,7 +461,7 @@ end
 runHammerSnapshot = function(job)
     if job.stopRequested then
         finishJob(job, string.format(
-            "HAMMER interrompido durante snapshot em %d/%d storages; nenhuma storage foi alterada",
+            "HAMMER stopped during snapshot at %d/%d storages; no storage was changed",
             job.snapshotCompleted,
             job.snapshotTotal
         ), true)
@@ -473,7 +473,7 @@ runHammerSnapshot = function(job)
         job.snapshotTargets = nil
         job.phase = "hammer"
         notify(job, string.format(
-            "HAMMER iniciado: %d ops, chunk=%d, jogadores=%d. Use /stress_login stop para abortar com limpeza",
+            "HAMMER started: %d ops, chunk=%d, players=%d. Use /stress_login stop to abort and clean up",
             job.total,
             job.chunkSize,
             #job.players
@@ -491,7 +491,7 @@ runHammerSnapshot = function(job)
 
     local player = getHammerPlayer(entry)
     if not player then
-        finishJob(job, "HAMMER cancelado: " .. entry.name .. " desconectou durante o snapshot; nenhuma storage foi alterada", true)
+        finishJob(job, "HAMMER cancelled: " .. entry.name .. " disconnected during the snapshot; no storage was changed", true)
         return
     end
 
@@ -507,7 +507,7 @@ runHammerSnapshot = function(job)
     job.snapshotSlot = job.snapshotSlot + amount
     job.snapshotCompleted = job.snapshotCompleted + amount
     maybeReport(job, string.format(
-        "HAMMER SNAPSHOT %d/%d storages (%.1f%%) | atual=%s",
+        "HAMMER SNAPSHOT %d/%d storages (%.1f%%) | current=%s",
         job.snapshotCompleted,
         job.snapshotTotal,
         (job.snapshotCompleted * 100) / math.max(1, job.snapshotTotal),
@@ -524,7 +524,7 @@ end
 local function startHammer(player, operationsValue, chunkValue)
     local onlinePlayers = Game.getPlayers()
     if #onlinePlayers == 0 then
-        notifyPlayer(player, "Nenhum jogador online para o HAMMER", true)
+        notifyPlayer(player, "No players are online for HAMMER", true)
         return
     end
 
@@ -559,7 +559,7 @@ local function startHammer(player, operationsValue, chunkValue)
     end
 
     notify(job, string.format(
-        "HAMMER snapshot iniciado: %d jogador(es) x %d storages",
+        "HAMMER snapshot started: %d player(s) x %d storages",
         #job.snapshotTargets,
         CONFIG.hammerStorageSlots
     ))
@@ -568,14 +568,14 @@ end
 
 local function showStatus(player)
     if not activeJob then
-        notifyPlayer(player, "Nenhum teste ativo")
+        notifyPlayer(player, "No active test")
         return
     end
 
     local job = activeJob
     if job.mode == "prepare" then
         notifyPlayer(player, string.format(
-            "Ativo: PREPARE %d/%d rows | alvo %d/%d | tempo=%ds",
+            "Active: PREPARE %d/%d rows | target %d/%d | elapsed=%ds",
             job.completed,
             job.total,
             job.targetIndex,
@@ -585,14 +585,14 @@ local function showStatus(player)
     elseif job.mode == "hammer" then
         if job.phase == "hammer_snapshot" then
             notifyPlayer(player, string.format(
-                "Ativo: HAMMER SNAPSHOT %d/%d storages | tempo=%ds",
+                "Active: HAMMER SNAPSHOT %d/%d storages | elapsed=%ds",
                 job.snapshotCompleted,
                 job.snapshotTotal,
                 elapsedSeconds(job)
             ))
         else
             notifyPlayer(player, string.format(
-                "Ativo: %s %d/%d ops | saves=%d | tempo=%ds",
+                "Active: %s %d/%d ops | saves=%d | elapsed=%ds",
                 job.phase:upper(),
                 job.completed,
                 job.total,
@@ -602,7 +602,7 @@ local function showStatus(player)
         end
     else
         notifyPlayer(player, string.format(
-            "Ativo: %s alvo %d/%d | tempo=%ds",
+            "Active: %s target %d/%d | elapsed=%ds",
             job.mode:upper(),
             job.targetIndex,
             #job.targets,
@@ -612,11 +612,11 @@ local function showStatus(player)
 end
 
 local function showHelp(player)
-    notifyPlayer(player, "PREPARE: /stress_login prepare,Nome 1|Nome 2|Nome 3,25000")
-    notifyPlayer(player, "Depois faca login simultaneo nos personagens preparados (1, 2 e 3 clientes)")
+    notifyPlayer(player, "PREPARE: /stress_login prepare,Name 1|Name 2|Name 3,25000")
+    notifyPlayer(player, "Then log in to the prepared characters simultaneously with 1, 2, and 3 clients")
     notifyPlayer(player, "HAMMER online: /stress_login hammer,200000,500")
-    notifyPlayer(player, "Controle: /stress_login status  |  /stress_login stop")
-    notifyPlayer(player, "Limpeza offline: /stress_login clean,Nome 1|Nome 2|Nome 3")
+    notifyPlayer(player, "Controls: /stress_login status  |  /stress_login stop")
+    notifyPlayer(player, "Offline cleanup: /stress_login clean,Name 1|Name 2|Name 3")
 end
 
 function stressLogin.onSay(player, words, param)
@@ -634,12 +634,12 @@ function stressLogin.onSay(player, words, param)
 
     if command == "stop" then
         if not activeJob then
-            notifyPlayer(player, "Nenhum teste ativo")
+            notifyPlayer(player, "No active test")
         elseif activeJob.phase == "hammer_cleanup" then
-            notifyPlayer(player, "HAMMER ja esta limpando; aguarde")
+            notifyPlayer(player, "HAMMER is already cleaning up; please wait")
         else
             activeJob.stopRequested = true
-            notifyPlayer(player, "Parada solicitada; o chunk atual sera concluido")
+            notifyPlayer(player, "Stop requested; the current chunk will finish")
         end
         return false
     end
@@ -650,7 +650,7 @@ function stressLogin.onSay(player, words, param)
     end
 
     if activeJob then
-        notifyPlayer(player, "Ja existe um teste ativo. Use /stress_login status ou stop", true)
+        notifyPlayer(player, "A test is already active. Use /stress_login status or stop", true)
         return false
     end
 

--- a/data/scripts/talkactions/stress/stress_login_storage.lua
+++ b/data/scripts/talkactions/stress/stress_login_storage.lua
@@ -17,6 +17,13 @@
     dispatcher remains able to process logins while the test is running.
 --]]
 
+-- Disabled by default. Enable manually only in a controlled test environment.
+local ENABLE_STRESS_LOGIN_COMMAND = false
+
+if not ENABLE_STRESS_LOGIN_COMMAND then
+    return
+end
+
 local stressLogin = TalkAction("/stress_login")
 
 local CONFIG = {

--- a/data/scripts/talkactions/stress/stress_login_storage.lua
+++ b/data/scripts/talkactions/stress/stress_login_storage.lua
@@ -32,6 +32,7 @@ local CONFIG = {
     defaultHammerChunk = 500,
     maxHammerOperations = 5000000,
     maxHammerChunk = 5000,
+    hammerSnapshotSlotsPerChunk = 256,
     hammerDelayMs = 1,
     saveEveryChunks = 4,
 
@@ -358,18 +359,24 @@ runHammerCleanup = function(job)
     local entry = job.players[job.cleanupPlayerIndex]
     if not entry then
         local suffix = job.cleanupReason or "concluido"
+        local disconnectedCount = 0
+        for _ in pairs(job.disconnected) do
+            disconnectedCount = disconnectedCount + 1
+        end
         finishJob(job, string.format(
-            "HAMMER %s: %d operacoes, %d saves solicitados, %d jogador(es)",
+            "HAMMER %s: %d operacoes, %d saves solicitados, %d jogador(es), %d desconectado(s)",
             suffix,
             job.completed,
             job.saveRequests,
-            #job.players
+            #job.players,
+            disconnectedCount
         ))
         return
     end
 
     local player = getHammerPlayer(entry)
     if not player then
+        job.disconnected[entry.guid] = true
         notify(job, "AVISO: " .. entry.name .. " desconectou; use CLEAN com ele offline", true)
         job.cleanupPlayerIndex = job.cleanupPlayerIndex + 1
         job.cleanupSlot = 0
@@ -395,6 +402,7 @@ runHammerCleanup = function(job)
 end
 
 local runHammerStep
+local runHammerSnapshot
 
 runHammerStep = function(job)
     if job.stopRequested then
@@ -443,6 +451,69 @@ runHammerStep = function(job)
     schedule(job, runHammerStep, CONFIG.hammerDelayMs)
 end
 
+runHammerSnapshot = function(job)
+    if job.stopRequested then
+        finishJob(job, string.format(
+            "HAMMER interrompido durante snapshot em %d/%d storages; nenhuma storage foi alterada",
+            job.snapshotCompleted,
+            job.snapshotTotal
+        ), true)
+        return
+    end
+
+    local target = job.snapshotTargets[job.snapshotPlayerIndex]
+    if not target then
+        job.snapshotTargets = nil
+        job.phase = "hammer"
+        notify(job, string.format(
+            "HAMMER iniciado: %d ops, chunk=%d, jogadores=%d. Use /stress_login stop para abortar com limpeza",
+            job.total,
+            job.chunkSize,
+            #job.players
+        ))
+        schedule(job, runHammerStep, 0)
+        return
+    end
+
+    local entry = job.players[job.snapshotPlayerIndex]
+    if not entry then
+        entry = target
+        entry.originalValues = {}
+        job.players[job.snapshotPlayerIndex] = entry
+    end
+
+    local player = getHammerPlayer(entry)
+    if not player then
+        finishJob(job, "HAMMER cancelado: " .. entry.name .. " desconectou durante o snapshot; nenhuma storage foi alterada", true)
+        return
+    end
+
+    local amount = math.min(
+        CONFIG.hammerSnapshotSlotsPerChunk,
+        CONFIG.hammerStorageSlots - job.snapshotSlot
+    )
+    for index = 0, amount - 1 do
+        local slot = job.snapshotSlot + index
+        entry.originalValues[slot + 1] = player:getStorageValue(CONFIG.hammerStorageBase + slot)
+    end
+
+    job.snapshotSlot = job.snapshotSlot + amount
+    job.snapshotCompleted = job.snapshotCompleted + amount
+    maybeReport(job, string.format(
+        "HAMMER SNAPSHOT %d/%d storages (%.1f%%) | atual=%s",
+        job.snapshotCompleted,
+        job.snapshotTotal,
+        (job.snapshotCompleted * 100) / math.max(1, job.snapshotTotal),
+        entry.name
+    ))
+
+    if job.snapshotSlot >= CONFIG.hammerStorageSlots then
+        job.snapshotPlayerIndex = job.snapshotPlayerIndex + 1
+        job.snapshotSlot = 0
+    end
+    schedule(job, runHammerSnapshot, CONFIG.hammerDelayMs)
+end
+
 local function startHammer(player, operationsValue, chunkValue)
     local onlinePlayers = Game.getPlayers()
     if #onlinePlayers == 0 then
@@ -458,34 +529,34 @@ local function startHammer(player, operationsValue, chunkValue)
     )
     local chunkSize = clampInteger(chunkValue, CONFIG.defaultHammerChunk, 1, CONFIG.maxHammerChunk)
     local job = newJob(player, "hammer")
+    job.phase = "hammer_snapshot"
     job.players = {}
+    job.snapshotTargets = {}
     job.disconnected = {}
     job.total = operations
     job.completed = 0
     job.chunkSize = chunkSize
     job.chunkNumber = 0
     job.saveRequests = 0
+    job.snapshotPlayerIndex = 1
+    job.snapshotSlot = 0
+    job.snapshotCompleted = 0
+    job.snapshotTotal = #onlinePlayers * CONFIG.hammerStorageSlots
 
     for _, onlinePlayer in ipairs(onlinePlayers) do
-        local entry = {
+        job.snapshotTargets[#job.snapshotTargets + 1] = {
             id = onlinePlayer:getId(),
             guid = onlinePlayer:getGuid(),
             name = onlinePlayer:getName(),
-            originalValues = {},
         }
-        for slot = 0, CONFIG.hammerStorageSlots - 1 do
-            entry.originalValues[slot + 1] = onlinePlayer:getStorageValue(CONFIG.hammerStorageBase + slot)
-        end
-        job.players[#job.players + 1] = entry
     end
 
     notify(job, string.format(
-        "HAMMER iniciado: %d ops, chunk=%d, jogadores=%d. Use /stress_login stop para abortar com limpeza",
-        operations,
-        chunkSize,
-        #job.players
+        "HAMMER snapshot iniciado: %d jogador(es) x %d storages",
+        #job.snapshotTargets,
+        CONFIG.hammerStorageSlots
     ))
-    schedule(job, runHammerStep, 0)
+    schedule(job, runHammerSnapshot, 0)
 end
 
 local function showStatus(player)
@@ -505,14 +576,23 @@ local function showStatus(player)
             elapsedSeconds(job)
         ))
     elseif job.mode == "hammer" then
-        notifyPlayer(player, string.format(
-            "Ativo: %s %d/%d ops | saves=%d | tempo=%ds",
-            job.phase:upper(),
-            job.completed,
-            job.total,
-            job.saveRequests,
-            elapsedSeconds(job)
-        ))
+        if job.phase == "hammer_snapshot" then
+            notifyPlayer(player, string.format(
+                "Ativo: HAMMER SNAPSHOT %d/%d storages | tempo=%ds",
+                job.snapshotCompleted,
+                job.snapshotTotal,
+                elapsedSeconds(job)
+            ))
+        else
+            notifyPlayer(player, string.format(
+                "Ativo: %s %d/%d ops | saves=%d | tempo=%ds",
+                job.phase:upper(),
+                job.completed,
+                job.total,
+                job.saveRequests,
+                elapsedSeconds(job)
+            ))
+        end
     else
         notifyPlayer(player, string.format(
             "Ativo: %s alvo %d/%d | tempo=%ds",

--- a/data/scripts/talkactions/stress/stress_login_storage.lua
+++ b/data/scripts/talkactions/stress/stress_login_storage.lua
@@ -1,0 +1,584 @@
+--[[
+    Server-side login/storage stress test for TFS 1.8.
+
+    Commands (account type 6 / access group only):
+      /stress_login prepare,Player One|Player Two|Player Three,25000
+      /stress_login hammer,200000,500
+      /stress_login status
+      /stress_login stop
+      /stress_login clean,Player One|Player Two|Player Three
+
+    "prepare" inserts isolated player_storage rows while the target characters
+    are offline. Log in those characters simultaneously afterwards to exercise
+    the real IOLoginData::loadPlayer storage path.
+
+    "hammer" repeatedly changes isolated storage keys on every online player
+    and periodically calls Player:saveAsync(). Work is chunked with addEvent so the
+    dispatcher remains able to process logins while the test is running.
+--]]
+
+local stressLogin = TalkAction("/stress_login")
+
+local CONFIG = {
+    storageBase = 2100000000,
+    maxPreparedStorages = 100000,
+    defaultPreparedStorages = 25000,
+    sqlRowsPerBatch = 250,
+    sqlBatchDelayMs = 1,
+
+    hammerStorageBase = 2100200000,
+    hammerStorageSlots = 4096,
+    defaultHammerOperations = 200000,
+    defaultHammerChunk = 500,
+    maxHammerOperations = 5000000,
+    maxHammerChunk = 5000,
+    hammerDelayMs = 1,
+    saveEveryChunks = 4,
+
+    progressEveryMs = 2000,
+}
+
+local MSG_INFO = MESSAGE_STATUS_CONSOLE_BLUE or MESSAGE_EVENT_ADVANCE or 19
+local MSG_ERROR = MESSAGE_STATUS_CONSOLE_RED or MESSAGE_STATUS_WARNING or MSG_INFO
+
+local activeJob = nil
+local nextJobId = 0
+
+local function trim(value)
+    return tostring(value or ""):match("^%s*(.-)%s*$")
+end
+
+local function clampInteger(value, defaultValue, minimum, maximum)
+    local number = tonumber(value) or defaultValue
+    number = math.floor(number)
+    if number < minimum then
+        return minimum
+    end
+    if number > maximum then
+        return maximum
+    end
+    return number
+end
+
+local function splitParameters(param)
+    local parts = {}
+    for value in tostring(param or ""):gmatch("([^,]+)") do
+        parts[#parts + 1] = trim(value)
+    end
+    return parts
+end
+
+local function splitNames(value)
+    local names = {}
+    local seen = {}
+    for rawName in tostring(value or ""):gmatch("([^|]+)") do
+        local name = trim(rawName)
+        local normalized = name:lower()
+        if name ~= "" and not seen[normalized] then
+            names[#names + 1] = name
+            seen[normalized] = true
+        end
+    end
+    return names
+end
+
+local function sqlString(value)
+    local escaped = db.escapeString(tostring(value or ""))
+    if not escaped or escaped == "" then
+        return "''"
+    end
+    if escaped:sub(1, 1) == "'" and escaped:sub(-1) == "'" then
+        return escaped
+    end
+    return "'" .. escaped .. "'"
+end
+
+local function getOwnerPlayer(job)
+    local player = Player(job.ownerId)
+    if not player or player:getGuid() ~= job.ownerGuid then
+        return nil
+    end
+    return player
+end
+
+local function notify(job, message, isError)
+    local prefix = "[STRESS LOGIN] "
+    print(prefix .. message)
+    local player = getOwnerPlayer(job)
+    if player then
+        player:sendTextMessage(isError and MSG_ERROR or MSG_INFO, prefix .. message)
+    end
+end
+
+local function notifyPlayer(player, message, isError)
+    local prefix = "[STRESS LOGIN] "
+    print(prefix .. message)
+    player:sendTextMessage(isError and MSG_ERROR or MSG_INFO, prefix .. message)
+end
+
+local function elapsedSeconds(job)
+    return math.max(0, os.time() - job.startedAt)
+end
+
+local function finishJob(job, message, isError)
+    if activeJob ~= job then
+        return
+    end
+    notify(job, message .. string.format(" | tempo=%ds", elapsedSeconds(job)), isError)
+    activeJob = nil
+end
+
+local function schedule(job, callback, delay)
+    addEvent(function(jobId)
+        if not activeJob or activeJob.id ~= jobId then
+            return
+        end
+        callback(activeJob)
+    end, delay or 0, job.id)
+end
+
+local function maybeReport(job, message)
+    local now = os.mtime and os.mtime() or (os.time() * 1000)
+    if now - job.lastProgressAt >= CONFIG.progressEveryMs then
+        job.lastProgressAt = now
+        notify(job, message)
+    end
+end
+
+local function newJob(player, mode)
+    nextJobId = nextJobId + 1
+    local now = os.mtime and os.mtime() or (os.time() * 1000)
+    local job = {
+        id = nextJobId,
+        mode = mode,
+        phase = mode,
+        ownerId = player:getId(),
+        ownerGuid = player:getGuid(),
+        startedAt = os.time(),
+        lastProgressAt = now,
+        stopRequested = false,
+    }
+    activeJob = job
+    return job
+end
+
+local function resolveOfflinePlayers(names)
+    local targets = {}
+    for _, name in ipairs(names) do
+        if Player(name) then
+            return nil, "O personagem '" .. name .. "' precisa estar offline."
+        end
+
+        local query = "SELECT `id`, `name` FROM `players` WHERE `name` = " .. sqlString(name) .. " LIMIT 1"
+        local resultId = db.storeQuery(query)
+        if not resultId then
+            return nil, "Personagem nao encontrado: " .. name
+        end
+
+        targets[#targets + 1] = {
+            guid = result.getNumber(resultId, "id"),
+            name = result.getString(resultId, "name"),
+        }
+        result.free(resultId)
+    end
+    return targets
+end
+
+local runPrepareStep
+
+runPrepareStep = function(job)
+    if job.stopRequested then
+        finishJob(job, string.format("PREPARE interrompido em %d/%d rows", job.completed, job.total), true)
+        return
+    end
+
+    local target = job.targets[job.targetIndex]
+    if not target then
+        finishJob(job, string.format(
+            "PREPARE concluido: %d storages em %d personagem(ns). Agora deixe-os offline e faca login simultaneo com 1, 2 e 3 clientes",
+            job.completed,
+            #job.targets
+        ))
+        return
+    end
+
+    if Player(target.name) then
+        finishJob(job, "PREPARE cancelado: '" .. target.name .. "' entrou durante a gravacao", true)
+        return
+    end
+
+    if job.offset >= job.rowsPerPlayer then
+        job.targetIndex = job.targetIndex + 1
+        job.offset = 0
+        schedule(job, runPrepareStep, CONFIG.sqlBatchDelayMs)
+        return
+    end
+
+    local amount = math.min(CONFIG.sqlRowsPerBatch, job.rowsPerPlayer - job.offset)
+    local values = {}
+    for index = 0, amount - 1 do
+        local offset = job.offset + index
+        local key = CONFIG.storageBase + offset
+        local value = 1000000 + offset
+        values[#values + 1] = string.format("(%d,%d,%d)", target.guid, key, value)
+    end
+
+    local query = "INSERT INTO `player_storage` (`player_id`, `key`, `value`) VALUES "
+        .. table.concat(values, ",")
+        .. " ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)"
+
+    if not db.query(query) then
+        finishJob(job, string.format("Falha SQL preparando '%s' no offset %d", target.name, job.offset), true)
+        return
+    end
+
+    job.offset = job.offset + amount
+    job.completed = job.completed + amount
+    maybeReport(job, string.format(
+        "PREPARE %d/%d rows (%.1f%%) | atual=%s",
+        job.completed,
+        job.total,
+        (job.completed * 100) / math.max(1, job.total),
+        target.name
+    ))
+    schedule(job, runPrepareStep, CONFIG.sqlBatchDelayMs)
+end
+
+local function startPrepare(player, namesValue, rowsValue)
+    local names = splitNames(namesValue)
+    if #names == 0 then
+        notifyPlayer(player, "Uso: /stress_login prepare,Nome 1|Nome 2|Nome 3,25000", true)
+        return
+    end
+
+    local rows = clampInteger(rowsValue, CONFIG.defaultPreparedStorages, 1, CONFIG.maxPreparedStorages)
+    local targets, errorMessage = resolveOfflinePlayers(names)
+    if not targets then
+        notifyPlayer(player, errorMessage, true)
+        return
+    end
+
+    local job = newJob(player, "prepare")
+    job.targets = targets
+    job.targetIndex = 1
+    job.offset = 0
+    job.rowsPerPlayer = rows
+    job.completed = 0
+    job.total = rows * #targets
+
+    notify(job, string.format(
+        "PREPARE iniciado: %d personagem(ns) x %d storages = %d rows",
+        #targets,
+        rows,
+        job.total
+    ))
+    schedule(job, runPrepareStep, 0)
+end
+
+local runCleanStep
+
+runCleanStep = function(job)
+    if job.stopRequested then
+        finishJob(job, string.format("CLEAN interrompido em %d/%d personagens", job.targetIndex - 1, #job.targets), true)
+        return
+    end
+
+    local target = job.targets[job.targetIndex]
+    if not target then
+        finishJob(job, string.format("CLEAN concluido para %d personagem(ns)", #job.targets))
+        return
+    end
+
+    if Player(target.name) then
+        finishJob(job, "CLEAN cancelado: '" .. target.name .. "' precisa estar offline", true)
+        return
+    end
+
+    local preparedEnd = CONFIG.storageBase + CONFIG.maxPreparedStorages - 1
+    local hammerEnd = CONFIG.hammerStorageBase + CONFIG.hammerStorageSlots - 1
+    local query = string.format(
+        "DELETE FROM `player_storage` WHERE `player_id` = %d AND ((`key` BETWEEN %d AND %d) OR (`key` BETWEEN %d AND %d))",
+        target.guid,
+        CONFIG.storageBase,
+        preparedEnd,
+        CONFIG.hammerStorageBase,
+        hammerEnd
+    )
+
+    if not db.query(query) then
+        finishJob(job, "Falha SQL limpando '" .. target.name .. "'", true)
+        return
+    end
+
+    notify(job, "CLEAN removido de " .. target.name)
+    job.targetIndex = job.targetIndex + 1
+    schedule(job, runCleanStep, CONFIG.sqlBatchDelayMs)
+end
+
+local function startClean(player, namesValue)
+    local names = splitNames(namesValue)
+    if #names == 0 then
+        notifyPlayer(player, "Uso: /stress_login clean,Nome 1|Nome 2|Nome 3", true)
+        return
+    end
+
+    local targets, errorMessage = resolveOfflinePlayers(names)
+    if not targets then
+        notifyPlayer(player, errorMessage, true)
+        return
+    end
+
+    local job = newJob(player, "clean")
+    job.targets = targets
+    job.targetIndex = 1
+    notify(job, "CLEAN iniciado. Somente a faixa reservada pelo teste sera removida")
+    schedule(job, runCleanStep, 0)
+end
+
+local function getHammerPlayer(entry)
+    local player = Player(entry.id)
+    if not player or player:getGuid() ~= entry.guid then
+        return nil
+    end
+    return player
+end
+
+local runHammerCleanup
+
+local function beginHammerCleanup(job, reason)
+    job.phase = "hammer_cleanup"
+    job.cleanupPlayerIndex = 1
+    job.cleanupSlot = 0
+    job.cleanupReason = reason
+    notify(job, "HAMMER finalizando; restaurando storages temporarias...")
+    schedule(job, runHammerCleanup, 0)
+end
+
+runHammerCleanup = function(job)
+    local entry = job.players[job.cleanupPlayerIndex]
+    if not entry then
+        local suffix = job.cleanupReason or "concluido"
+        finishJob(job, string.format(
+            "HAMMER %s: %d operacoes, %d saves solicitados, %d jogador(es)",
+            suffix,
+            job.completed,
+            job.saveRequests,
+            #job.players
+        ))
+        return
+    end
+
+    local player = getHammerPlayer(entry)
+    if not player then
+        notify(job, "AVISO: " .. entry.name .. " desconectou; use CLEAN com ele offline", true)
+        job.cleanupPlayerIndex = job.cleanupPlayerIndex + 1
+        job.cleanupSlot = 0
+        schedule(job, runHammerCleanup, 0)
+        return
+    end
+
+    local amount = math.min(job.chunkSize, CONFIG.hammerStorageSlots - job.cleanupSlot)
+    for index = 0, amount - 1 do
+        local slot = job.cleanupSlot + index
+        local oldValue = entry.originalValues[slot + 1]
+        player:setStorageValue(CONFIG.hammerStorageBase + slot, oldValue)
+    end
+    job.cleanupSlot = job.cleanupSlot + amount
+
+    if job.cleanupSlot >= CONFIG.hammerStorageSlots then
+        player:saveAsync()
+        job.saveRequests = job.saveRequests + 1
+        job.cleanupPlayerIndex = job.cleanupPlayerIndex + 1
+        job.cleanupSlot = 0
+    end
+    schedule(job, runHammerCleanup, CONFIG.hammerDelayMs)
+end
+
+local runHammerStep
+
+runHammerStep = function(job)
+    if job.stopRequested then
+        beginHammerCleanup(job, "interrompido")
+        return
+    end
+    if job.completed >= job.total then
+        beginHammerCleanup(job, "concluido")
+        return
+    end
+
+    local amount = math.min(job.chunkSize, job.total - job.completed)
+    for index = 1, amount do
+        local operation = job.completed + index - 1
+        local entry = job.players[(operation % #job.players) + 1]
+        local player = getHammerPlayer(entry)
+        if player then
+            local slot = math.floor(operation / #job.players) % CONFIG.hammerStorageSlots
+            local key = CONFIG.hammerStorageBase + slot
+            player:setStorageValue(key, job.id * 10000000 + operation + 1)
+        else
+            job.disconnected[entry.guid] = true
+        end
+    end
+
+    job.completed = job.completed + amount
+    job.chunkNumber = job.chunkNumber + 1
+
+    if job.chunkNumber % CONFIG.saveEveryChunks == 0 then
+        for _, entry in ipairs(job.players) do
+            local player = getHammerPlayer(entry)
+            if player then
+                player:saveAsync()
+                job.saveRequests = job.saveRequests + 1
+            end
+        end
+    end
+
+    maybeReport(job, string.format(
+        "HAMMER %d/%d ops (%.1f%%) | saves=%d",
+        job.completed,
+        job.total,
+        (job.completed * 100) / math.max(1, job.total),
+        job.saveRequests
+    ))
+    schedule(job, runHammerStep, CONFIG.hammerDelayMs)
+end
+
+local function startHammer(player, operationsValue, chunkValue)
+    local onlinePlayers = Game.getPlayers()
+    if #onlinePlayers == 0 then
+        notifyPlayer(player, "Nenhum jogador online para o HAMMER", true)
+        return
+    end
+
+    local operations = clampInteger(
+        operationsValue,
+        CONFIG.defaultHammerOperations,
+        1,
+        CONFIG.maxHammerOperations
+    )
+    local chunkSize = clampInteger(chunkValue, CONFIG.defaultHammerChunk, 1, CONFIG.maxHammerChunk)
+    local job = newJob(player, "hammer")
+    job.players = {}
+    job.disconnected = {}
+    job.total = operations
+    job.completed = 0
+    job.chunkSize = chunkSize
+    job.chunkNumber = 0
+    job.saveRequests = 0
+
+    for _, onlinePlayer in ipairs(onlinePlayers) do
+        local entry = {
+            id = onlinePlayer:getId(),
+            guid = onlinePlayer:getGuid(),
+            name = onlinePlayer:getName(),
+            originalValues = {},
+        }
+        for slot = 0, CONFIG.hammerStorageSlots - 1 do
+            entry.originalValues[slot + 1] = onlinePlayer:getStorageValue(CONFIG.hammerStorageBase + slot)
+        end
+        job.players[#job.players + 1] = entry
+    end
+
+    notify(job, string.format(
+        "HAMMER iniciado: %d ops, chunk=%d, jogadores=%d. Use /stress_login stop para abortar com limpeza",
+        operations,
+        chunkSize,
+        #job.players
+    ))
+    schedule(job, runHammerStep, 0)
+end
+
+local function showStatus(player)
+    if not activeJob then
+        notifyPlayer(player, "Nenhum teste ativo")
+        return
+    end
+
+    local job = activeJob
+    if job.mode == "prepare" then
+        notifyPlayer(player, string.format(
+            "Ativo: PREPARE %d/%d rows | alvo %d/%d | tempo=%ds",
+            job.completed,
+            job.total,
+            job.targetIndex,
+            #job.targets,
+            elapsedSeconds(job)
+        ))
+    elseif job.mode == "hammer" then
+        notifyPlayer(player, string.format(
+            "Ativo: %s %d/%d ops | saves=%d | tempo=%ds",
+            job.phase:upper(),
+            job.completed,
+            job.total,
+            job.saveRequests,
+            elapsedSeconds(job)
+        ))
+    else
+        notifyPlayer(player, string.format(
+            "Ativo: %s alvo %d/%d | tempo=%ds",
+            job.mode:upper(),
+            job.targetIndex,
+            #job.targets,
+            elapsedSeconds(job)
+        ))
+    end
+end
+
+local function showHelp(player)
+    notifyPlayer(player, "PREPARE: /stress_login prepare,Nome 1|Nome 2|Nome 3,25000")
+    notifyPlayer(player, "Depois faca login simultaneo nos personagens preparados (1, 2 e 3 clientes)")
+    notifyPlayer(player, "HAMMER online: /stress_login hammer,200000,500")
+    notifyPlayer(player, "Controle: /stress_login status  |  /stress_login stop")
+    notifyPlayer(player, "Limpeza offline: /stress_login clean,Nome 1|Nome 2|Nome 3")
+end
+
+function stressLogin.onSay(player, words, param)
+    if not player:getGroup():getAccess() then
+        return false
+    end
+
+    local parts = splitParameters(param)
+    local command = (parts[1] or "help"):lower()
+
+    if command == "status" then
+        showStatus(player)
+        return false
+    end
+
+    if command == "stop" then
+        if not activeJob then
+            notifyPlayer(player, "Nenhum teste ativo")
+        elseif activeJob.phase == "hammer_cleanup" then
+            notifyPlayer(player, "HAMMER ja esta limpando; aguarde")
+        else
+            activeJob.stopRequested = true
+            notifyPlayer(player, "Parada solicitada; o chunk atual sera concluido")
+        end
+        return false
+    end
+
+    if command == "help" or command == "" then
+        showHelp(player)
+        return false
+    end
+
+    if activeJob then
+        notifyPlayer(player, "Ja existe um teste ativo. Use /stress_login status ou stop", true)
+        return false
+    end
+
+    if command == "prepare" then
+        startPrepare(player, parts[2], parts[3])
+    elseif command == "clean" then
+        startClean(player, parts[2])
+    elseif command == "hammer" then
+        startHammer(player, parts[2], parts[3])
+    else
+        showHelp(player)
+    end
+    return false
+end
+
+stressLogin:separator(" ")
+stressLogin:accountType(6)
+stressLogin:register()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,6 +211,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/otserv.h
 	${CMAKE_CURRENT_LIST_DIR}/outfit.h
 	${CMAKE_CURRENT_LIST_DIR}/outputmessage.h
+	${CMAKE_CURRENT_LIST_DIR}/packet_backlog.h
 	${CMAKE_CURRENT_LIST_DIR}/party.h
 	${CMAKE_CURRENT_LIST_DIR}/performance_metrics.h
 	${CMAKE_CURRENT_LIST_DIR}/player.h

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1184,10 +1184,10 @@ void Creature::addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_
 
 	uint32_t attackerId = attacker->id;
 
-	// Do not keep a reference to the map element, as it may be invalidated
-	// during reentrant access (e.g., callbacks modifying the map).
-	damageMap[attackerId].total += damagePoints;
-	damageMap[attackerId].ticks = OTSYS_TIME();
+	auto [it, inserted] = damageMap.try_emplace(attackerId, CountBlock_t{0, 0});
+	(void)inserted;
+	it->second.total += damagePoints;
+	it->second.ticks = OTSYS_TIME();
 
 	lastAttacker = attacker;
 }
@@ -1889,11 +1889,29 @@ void Creature::setStorageValue(uint32_t key, std::optional<int64_t> value, bool 
 		storageMap.erase(key);
 	}
 
-	// Call event after map is in a consistent state
-	auto selfRef = getSharedCreature(this);
-	if (selfRef && !selfRef->isRemoved()) {
-		g_events->eventCreatureOnUpdateStorage(this, key, oldValue, value, isSpawn);
+	// Database loading may run in a worker thread. It must never enter the
+	// global Lua state or invoke gameplay callbacks.
+	if (isSpawn) {
+		return;
 	}
+
+	// Keep the creature alive for the whole callback after the map reaches a
+	// consistent state. The callback receives (new value, old value).
+	auto selfRef = getSharedCreature(this);
+	if (!selfRef || selfRef->isRemoved()) {
+		return;
+	}
+	g_events->eventCreatureOnUpdateStorage(this, key, normalizedNewValue, normalizedOldValue, false);
+}
+
+void Creature::loadStorageValue(uint32_t key, int64_t value)
+{
+	if (value == -1) {
+		storageMap.erase(key);
+		return;
+	}
+
+	storageMap.insert_or_assign(key, value);
 }
 
 void Creature::iconChanged()

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -29,16 +29,23 @@ std::shared_ptr<Creature> getSharedCreature(Creature* creature)
 } // namespace
 
 std::unordered_set<const Creature*> Creature::liveCreatures;
+std::shared_mutex Creature::liveCreaturesMutex;
 
 Creature::Creature()
 {
-	liveCreatures.insert(this);
+	{
+		std::unique_lock lock(liveCreaturesMutex);
+		liveCreatures.insert(this);
+	}
 	onIdleStatus();
 }
 
 Creature::~Creature()
 {
-	liveCreatures.erase(this);
+	{
+		std::unique_lock lock(liveCreaturesMutex);
+		liveCreatures.erase(this);
+	}
 
 	attackedCreature.reset();
 	followCreature.reset();
@@ -589,7 +596,11 @@ void Creature::onDeath()
 	const int64_t inFightTicks = getInteger(ConfigManager::PZ_LOCKED);
 	int32_t mostDamage = 0;
 	std::unordered_map<std::shared_ptr<Creature>, uint64_t> experienceMap;
-	for (const auto& it : damageMap) {
+	
+	// Use snapshot to prevent crashes if damageMap is cleared by Game::removeCreature
+	auto damageMapSnapshot = getDamageMapSnapshot();
+	
+	for (const auto& it : damageMapSnapshot) {
 		auto attacker = g_game.getCreatureByIDShared(it.first);
 		if (attacker) {
 			CountBlock_t cb = it.second;
@@ -654,7 +665,7 @@ void Creature::onDeath()
 
 				addPlayerOwner(lastHitCreature);
 				addPlayerOwner(mostDamageCreature);
-				for (const auto& [attackerId, _] : damageMap) {
+				for (const auto& [attackerId, _] : damageMapSnapshot) {
 					auto attacker = g_game.getCreatureByIDShared(attackerId);
 					if (attacker && attacker->getPlayer()) {
 						addPlayerOwner(attacker);
@@ -1173,9 +1184,10 @@ void Creature::addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_
 
 	uint32_t attackerId = attacker->id;
 
-	auto& cb = damageMap[attackerId];
-	cb.ticks = OTSYS_TIME();
-	cb.total += damagePoints;
+	// Do not keep a reference to the map element, as it may be invalidated
+	// during reentrant access (e.g., callbacks modifying the map).
+	damageMap[attackerId].total += damagePoints;
+	damageMap[attackerId].ticks = OTSYS_TIME();
 
 	lastAttacker = attacker;
 }
@@ -1858,12 +1870,30 @@ const std::vector<ZoneId>& Creature::getZoneIds() const
 void Creature::setStorageValue(uint32_t key, std::optional<int64_t> value, bool isSpawn)
 {
 	auto oldValue = getStorageValue(key);
-	if (value && value.value() != -1) {
-		storageMap.insert_or_assign(key, value.value());
+
+	auto normalize = [](int64_t v) -> std::optional<int64_t> {
+		return v == -1 ? std::nullopt : std::optional<int64_t>{v};
+	};
+	std::optional<int64_t> normalizedNewValue = value ? normalize(value.value()) : std::nullopt;
+	std::optional<int64_t> normalizedOldValue = oldValue ? normalize(oldValue.value()) : std::nullopt;
+
+	if (normalizedOldValue == normalizedNewValue) {
+		return;
+	}
+
+	// Complete the map modification BEFORE calling Lua callbacks to prevent
+	// reentrant access to the same flat_hash_map during element construction.
+	if (normalizedNewValue) {
+		storageMap.insert_or_assign(key, normalizedNewValue.value());
 	} else {
 		storageMap.erase(key);
 	}
-	g_events->eventCreatureOnUpdateStorage(this, key, oldValue, value, isSpawn);
+
+	// Call event after map is in a consistent state
+	auto selfRef = getSharedCreature(this);
+	if (selfRef && !selfRef->isRemoved()) {
+		g_events->eventCreatureOnUpdateStorage(this, key, oldValue, value, isSpawn);
+	}
 }
 
 void Creature::iconChanged()

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -583,6 +583,11 @@ void Creature::onDeath()
 	if (!self) {
 		return;
 	}
+
+	// onKilledCreature may execute Lua that removes this creature and clears
+	// damageMap. Capture all attribution data before the first callback.
+	const auto damageMapSnapshot = getDamageMapSnapshot();
+
 	auto lastHitCreature = lastAttacker.lock();
 	std::shared_ptr<Creature> lastHitCreatureMaster;
 	if (lastHitCreature) {
@@ -596,21 +601,19 @@ void Creature::onDeath()
 	const int64_t inFightTicks = getInteger(ConfigManager::PZ_LOCKED);
 	int32_t mostDamage = 0;
 	std::unordered_map<std::shared_ptr<Creature>, uint64_t> experienceMap;
-	
-	// Use snapshot to prevent crashes if damageMap is cleared by Game::removeCreature
-	auto damageMapSnapshot = getDamageMapSnapshot();
-	
+
 	for (const auto& it : damageMapSnapshot) {
 		auto attacker = g_game.getCreatureByIDShared(it.first);
 		if (attacker) {
-			CountBlock_t cb = it.second;
+			const CountBlock_t& cb = it.second;
 			if ((cb.total > mostDamage && (timeNow - cb.ticks <= inFightTicks))) {
 				mostDamage = cb.total;
 				mostDamageCreature = attacker;
 			}
 
 			if (attacker.get() != this) {
-				uint64_t gainExp = getGainedExperience(attacker);
+				const uint64_t gainExp =
+				    getGainedExperience(attacker, getDamageRatio(attacker, damageMapSnapshot));
 				if (Player* attackerPlayer = attacker->getPlayer()) {
 					attackerPlayer->removeAttacked(getPlayer());
 
@@ -1153,14 +1156,23 @@ size_t Creature::getSummonCount() const
 
 double Creature::getDamageRatio(const std::shared_ptr<Creature>& attacker) const
 {
-	uint32_t totalDamage = 0;
-	uint32_t attackerDamage = 0;
+	return getDamageRatio(attacker, damageMap);
+}
 
-	for (const auto& it : damageMap) {
+double Creature::getDamageRatio(const std::shared_ptr<Creature>& attacker, const CountMap& damageCounts) const
+{
+	uint64_t totalDamage = 0;
+	uint64_t attackerDamage = 0;
+
+	for (const auto& it : damageCounts) {
 		const CountBlock_t& cb = it.second;
-		totalDamage += cb.total;
+		if (cb.total <= 0) {
+			continue;
+		}
+
+		totalDamage += static_cast<uint64_t>(cb.total);
 		if (attacker && it.first == attacker->getID()) {
-			attackerDamage += cb.total;
+			attackerDamage += static_cast<uint64_t>(cb.total);
 		}
 	}
 
@@ -1173,7 +1185,12 @@ double Creature::getDamageRatio(const std::shared_ptr<Creature>& attacker) const
 
 uint64_t Creature::getGainedExperience(const std::shared_ptr<Creature>& attacker) const
 {
-	return std::floor(getDamageRatio(attacker) * getLostExperience());
+	return getGainedExperience(attacker, getDamageRatio(attacker));
+}
+
+uint64_t Creature::getGainedExperience(const std::shared_ptr<Creature>&, double damageRatio) const
+{
+	return std::floor(damageRatio * getLostExperience());
 }
 
 void Creature::addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_t damagePoints)
@@ -1184,8 +1201,7 @@ void Creature::addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_
 
 	uint32_t attackerId = attacker->id;
 
-	auto [it, inserted] = damageMap.try_emplace(attackerId, CountBlock_t{0, 0});
-	(void)inserted;
+	auto it = damageMap.try_emplace(attackerId, CountBlock_t{0, 0}).first;
 	it->second.total += damagePoints;
 	it->second.ticks = OTSYS_TIME();
 
@@ -1867,7 +1883,7 @@ const std::vector<ZoneId>& Creature::getZoneIds() const
 	return emptyZoneIds;
 }
 
-void Creature::setStorageValue(uint32_t key, std::optional<int64_t> value, bool isSpawn)
+void Creature::setStorageValue(uint32_t key, std::optional<int64_t> value)
 {
 	auto oldValue = getStorageValue(key);
 
@@ -1877,10 +1893,6 @@ void Creature::setStorageValue(uint32_t key, std::optional<int64_t> value, bool 
 	std::optional<int64_t> normalizedNewValue = value ? normalize(value.value()) : std::nullopt;
 	std::optional<int64_t> normalizedOldValue = oldValue ? normalize(oldValue.value()) : std::nullopt;
 
-	if (normalizedOldValue == normalizedNewValue) {
-		return;
-	}
-
 	// Complete the map modification BEFORE calling Lua callbacks to prevent
 	// reentrant access to the same flat_hash_map during element construction.
 	if (normalizedNewValue) {
@@ -1889,23 +1901,19 @@ void Creature::setStorageValue(uint32_t key, std::optional<int64_t> value, bool 
 		storageMap.erase(key);
 	}
 
-	// Database loading may run in a worker thread. It must never enter the
-	// global Lua state or invoke gameplay callbacks.
-	if (isSpawn) {
-		return;
-	}
-
 	// Keep the creature alive for the whole callback after the map reaches a
 	// consistent state. The callback receives (new value, old value).
 	auto selfRef = getSharedCreature(this);
 	if (!selfRef || selfRef->isRemoved()) {
 		return;
 	}
-	g_events->eventCreatureOnUpdateStorage(this, key, normalizedNewValue, normalizedOldValue, false);
+	g_events->eventCreatureOnUpdateStorage(this, key, normalizedNewValue, normalizedOldValue);
 }
 
 void Creature::loadStorageValue(uint32_t key, int64_t value)
 {
+	// Database loading can run on a worker thread. This path updates only the
+	// map; it deliberately never enters Lua or marks Player storage as dirty.
 	if (value == -1) {
 		storageMap.erase(key);
 		return;

--- a/src/creature.h
+++ b/src/creature.h
@@ -302,6 +302,7 @@ public:
 	CreatureVector getKillers() const;
 	void onDeath();
 	virtual uint64_t getGainedExperience(const std::shared_ptr<Creature>& attacker) const;
+	virtual uint64_t getGainedExperience(const std::shared_ptr<Creature>& attacker, double damageRatio) const;
 	void addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_t damagePoints);
 	bool hasBeenAttacked(uint32_t attackerId);
 
@@ -391,7 +392,6 @@ public:
 	Tile* getTile() override final { return tile.lock().get(); }
 	const Tile* getTile() const override final { return tile.lock().get(); }
 	std::shared_ptr<Tile> getTileShared() { return tile.lock(); }
-	std::shared_ptr<const Tile> getTileShared() const { return tile.lock(); }
 
 	const Position& getLastPosition() const { return lastPosition; }
 	void setLastPosition(Position newLastPos) { lastPosition = newLastPos; }
@@ -405,7 +405,7 @@ public:
 	               int32_t maxTargetDist, bool fullPathSearch = true, bool clearSight = true,
 	               int32_t maxSearchDist = 0) const;
 
-	virtual void setStorageValue(uint32_t key, std::optional<int64_t> value, bool isSpawn = false);
+	virtual void setStorageValue(uint32_t key, std::optional<int64_t> value);
 	void loadStorageValue(uint32_t key, int64_t value);
 	virtual std::optional<int64_t> getStorageValue(uint32_t key) const;
 	using StorageMap = absl::flat_hash_map<uint32_t, int64_t>;
@@ -430,6 +430,7 @@ protected:
 	};
 
 	using CountMap = absl::flat_hash_map<uint32_t, CountBlock_t>;
+	double getDamageRatio(const std::shared_ptr<Creature>& attacker, const CountMap& damageCounts) const;
 
 	Position position;
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <shared_mutex>
 
 class Creature;
 
@@ -114,7 +115,17 @@ public:
 	std::shared_ptr<Creature> asCreature() { return weak_from_this().lock(); }
 	std::shared_ptr<const Creature> asCreature() const { return weak_from_this().lock(); }
 
-	static bool isAlive(const Creature* c) { return liveCreatures.count(c) > 0; }
+	static bool isAlive(const Creature* c) {
+		if (!c) {
+			return false;
+		}
+		std::shared_lock lock(liveCreaturesMutex);
+		return liveCreatures.count(c) > 0;
+	}
+
+	static bool isAliveUnsafe(const Creature* c) {
+		return c && liveCreatures.count(c) > 0;
+	}
 	virtual Player* getPlayer() { return nullptr; }
 	virtual const Player* getPlayer() const { return nullptr; }
 	virtual Npc* getNpc() { return nullptr; }
@@ -409,6 +420,7 @@ public:
 	void setDefaultOutfit(Outfit_t outfit) { defaultOutfit = outfit; }
 
 	const auto& getDamageMap() const { return damageMap; }
+	auto getDamageMapSnapshot() const { return damageMap; }
 
 protected:
 	struct CountBlock_t
@@ -417,9 +429,10 @@ protected:
 		int64_t ticks;
 	};
 
+	using CountMap = absl::flat_hash_map<uint32_t, CountBlock_t>;
+
 	Position position;
 
-	using CountMap = absl::flat_hash_map<uint32_t, CountBlock_t>;
 	CountMap damageMap;
 
 	SummonList summons;
@@ -551,6 +564,7 @@ private:
 	std::map<std::string, CreatureIcon> creatureIcons;
 
 	static std::unordered_set<const Creature*> liveCreatures;
+	static std::shared_mutex liveCreaturesMutex;
 };
 
 template <typename T>

--- a/src/creature.h
+++ b/src/creature.h
@@ -123,9 +123,6 @@ public:
 		return liveCreatures.count(c) > 0;
 	}
 
-	static bool isAliveUnsafe(const Creature* c) {
-		return c && liveCreatures.count(c) > 0;
-	}
 	virtual Player* getPlayer() { return nullptr; }
 	virtual const Player* getPlayer() const { return nullptr; }
 	virtual Npc* getNpc() { return nullptr; }
@@ -393,6 +390,8 @@ public:
 
 	Tile* getTile() override final { return tile.lock().get(); }
 	const Tile* getTile() const override final { return tile.lock().get(); }
+	std::shared_ptr<Tile> getTileShared() { return tile.lock(); }
+	std::shared_ptr<const Tile> getTileShared() const { return tile.lock(); }
 
 	const Position& getLastPosition() const { return lastPosition; }
 	void setLastPosition(Position newLastPos) { lastPosition = newLastPos; }
@@ -407,6 +406,7 @@ public:
 	               int32_t maxSearchDist = 0) const;
 
 	virtual void setStorageValue(uint32_t key, std::optional<int64_t> value, bool isSpawn = false);
+	void loadStorageValue(uint32_t key, int64_t value);
 	virtual std::optional<int64_t> getStorageValue(uint32_t key) const;
 	using StorageMap = absl::flat_hash_map<uint32_t, int64_t>;
 	const StorageMap& getStorageMap() const { return storageMap; }

--- a/src/creatureevent.cpp
+++ b/src/creatureevent.cpp
@@ -434,24 +434,32 @@ void CreatureEvent::executeHealthChange(Creature* creature, Creature* attacker, 
 
 	ScriptEnvironment* env = scriptInterface->getScriptEnv();
 	env->setScriptId(scriptId, scriptInterface);
+	setLuaCrashCreatureEventDetails(eventName, creature ? creature->getID() : 0, attacker ? attacker->getID() : 0,
+	                                static_cast<int32_t>(damage.origin));
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(scriptId);
 
+	setLuaCrashPhase("CreatureEvent::executeHealthChange / push target userdata");
 	Lua::pushUserdata(L, creature);
 	Lua::setCreatureMetatable(L, -1, creature);
 	if (attacker) {
+		setLuaCrashPhase("CreatureEvent::executeHealthChange / push attacker userdata");
 		Lua::pushUserdata(L, attacker);
 		Lua::setCreatureMetatable(L, -1, attacker);
 	} else {
+		setLuaCrashPhase("CreatureEvent::executeHealthChange / push nil attacker");
 		lua_pushnil(L);
 	}
 
+	setLuaCrashPhase("CreatureEvent::executeHealthChange / push combat damage");
 	Lua::pushCombatDamage(L, damage);
 
 	if (scriptInterface->protectedCall(L, 7, 4) != 0) {
+		setLuaCrashPhase("CreatureEvent::executeHealthChange / report Lua error");
 		LuaScriptInterface::reportError(nullptr, Lua::popString(L));
 	} else {
+		setLuaCrashPhase("CreatureEvent::executeHealthChange / read Lua return values");
 		damage.primary.value = std::abs(Lua::getInteger<int32_t>(L, -4));
 		damage.primary.type = Lua::getInteger<CombatType_t>(L, -3);
 		damage.secondary.value = std::abs(Lua::getInteger<int32_t>(L, -2));

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -355,9 +355,9 @@ void Events::eventCreatureOnChangeZone(Creature* creature, ZoneType_t fromZone, 
 }
 
 void Events::eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key, const std::optional<int64_t> value,
-                                          const std::optional<int64_t> oldValue, bool isSpawn)
+                                          const std::optional<int64_t> oldValue)
 {
-	// Creature:onUpdateStorage(key, value, oldValue, isSpawn)
+	// Creature:onUpdateStorage(key, value, oldValue)
 	if (info.creatureOnUpdateStorage == -1) {
 		return;
 	}
@@ -393,9 +393,7 @@ void Events::eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key
 		lua_pushnil(L);
 	}
 
-	Lua::pushBoolean(L, isSpawn);
-
-	scriptInterface.callVoidFunction(5);
+	scriptInterface.callVoidFunction(4);
 }
 
 // Party

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -8,6 +8,7 @@
 #include "item.h"
 #include "monster.h"
 #include "player.h"
+#include "tasks.h"
 #include "imbuement.h"
 #include "logger.h"
 #include <fmt/format.h>
@@ -353,11 +354,15 @@ void Events::eventCreatureOnChangeZone(Creature* creature, ZoneType_t fromZone, 
 	scriptInterface.callVoidFunction(3);
 }
 
-void Events::eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key, const std::optional<int32_t> value,
-                                          const std::optional<int32_t> oldValue, bool isSpawn)
+void Events::eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key, const std::optional<int64_t> value,
+                                          const std::optional<int64_t> oldValue, bool isSpawn)
 {
 	// Creature:onUpdateStorage(key, value, oldValue, isSpawn)
 	if (info.creatureOnUpdateStorage == -1) {
+		return;
+	}
+	if (!g_dispatcher.isDispatcherThread()) {
+		LOG_ERROR("[Events::eventCreatureOnUpdateStorage] Refusing to execute Lua outside the dispatcher thread.");
 		return;
 	}
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -378,7 +378,7 @@ void Events::eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key
 	scriptInterface.pushFunction(info.creatureOnUpdateStorage);
 
 	Lua::pushUserdata<Creature>(L, creature);
-	Lua::setMetatable(L, -1, "Creature");
+	Lua::setCreatureMetatable(L, -1, creature);
 
 	lua_pushinteger(L, key);
 	if (value) {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1192,6 +1192,10 @@ void Events::eventPlayerOnUpdateInventory(Player* player, Item* item, const slot
 	if (info.playerOnUpdateInventory == -1) {
 		return;
 	}
+	if (!g_dispatcher.isDispatcherThread()) {
+		LOG_ERROR("[Events::eventPlayerOnUpdateInventory] Refusing to execute Lua outside the dispatcher thread.");
+		return;
+	}
 
 	if (!scriptInterface.reserveScriptEnv()) {
 		LOG_ERROR("[Error - Events::eventPlayerOnUpdateInventory] Call stack overflow");

--- a/src/events.h
+++ b/src/events.h
@@ -89,8 +89,8 @@ public:
 	ReturnValue eventCreatureOnTargetCombat(Creature* creature, Creature* target);
 	void eventCreatureOnHear(Creature* creature, Creature* speaker, std::string_view words, SpeakClasses type);
 	void eventCreatureOnChangeZone(Creature* creature, ZoneType_t fromZone, ZoneType_t toZone);
-	void eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key, const std::optional<int32_t> value,
-	                                  const std::optional<int32_t> oldValue, bool isSpawn);
+	void eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key, const std::optional<int64_t> value,
+	                                  const std::optional<int64_t> oldValue, bool isSpawn);
 
 	// Party
 	bool eventPartyOnJoin(Party* party, Player* player);

--- a/src/events.h
+++ b/src/events.h
@@ -90,7 +90,7 @@ public:
 	void eventCreatureOnHear(Creature* creature, Creature* speaker, std::string_view words, SpeakClasses type);
 	void eventCreatureOnChangeZone(Creature* creature, ZoneType_t fromZone, ZoneType_t toZone);
 	void eventCreatureOnUpdateStorage(Creature* creature, const uint32_t key, const std::optional<int64_t> value,
-	                                  const std::optional<int64_t> oldValue, bool isSpawn);
+	                                  const std::optional<int64_t> oldValue);
 
 	// Party
 	bool eventPartyOnJoin(Party* party, Player* player);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7827,6 +7827,7 @@ void Game::cleanup()
 {
 	// free memory
 	ToReleaseCreatures.clear();
+	ToReleaseCreatureSet.clear();
 
 	ToReleaseItems.clear(); // shared_ptrs destroyed, items freed
 }
@@ -7844,9 +7845,7 @@ void Game::ReleaseCreature(std::shared_ptr<Creature> creature)
 		return;
 	}
 
-	const auto alreadyQueued = std::ranges::any_of(
-	    ToReleaseCreatures, [&creature](const auto& queuedCreature) { return queuedCreature.get() == creature.get(); });
-	if (!alreadyQueued) {
+	if (ToReleaseCreatureSet.insert(creature.get()).second) {
 		ToReleaseCreatures.push_back(std::move(creature));
 	}
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1034,11 +1034,6 @@ std::shared_ptr<Creature> Game::getCreatureByNameShared(std::string_view s)
 	return nullptr;
 }
 
-Creature* Game::getCreatureByName(std::string_view s)
-{
-	return getCreatureByNameShared(s).get();
-}
-
 Npc* Game::getNpcByName(std::string_view npcName)
 {
 	if (npcName.empty()) {
@@ -1239,62 +1234,65 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 	}
 
 	auto tileRef = creature->getTileShared();
-	if (!tileRef) {
-		LOG_ERROR("[Game::removeCreature] Creature '{}' id={} has no valid tile.", creature->getName(), creature->getID());
-		return false;
-	}
+	if (tileRef) {
+		Tile* tile = tileRef.get();
+		const Position tilePosition = tile->getPosition();
 
-	Tile* tile = tileRef.get();
-	const Position tilePosition = tile->getPosition();
+		SpectatorVec spectators;
+		map.getSpectators(spectators, tilePosition, true);
 
-	SpectatorVec spectators;
-	map.getSpectators(spectators, tilePosition, true);
-
-	std::vector<int32_t> oldStackPosVector;
-	oldStackPosVector.reserve(spectators.size());
-	for (const auto& spectator : spectators.players()) {
-		Player* player = static_cast<Player*>(spectator.get());
-		oldStackPosVector.push_back(
-		    player->canSeeCreature(creature) ? tile->getClientIndexOfCreature(player, creature) : -1);
-	}
-
-	tile->removeCreature(creature);
-
-	// send to client
-	size_t i = 0;
-	for (const auto& spectator : spectators.players()) {
-		Player* player = static_cast<Player*>(spectator.get());
-		if (player->canSeeCreature(creature)) {
-			player->sendRemoveTileThing(tilePosition, oldStackPosVector[i]);
-		}
-		++i;
-	}
-
-	// event method
-	for (const auto& spectator : spectators) {
-		if (!spectator || !spectator->compareInstance(creature->getInstanceID())) {
-			continue;
+		std::vector<int32_t> oldStackPosVector;
+		oldStackPosVector.reserve(spectators.size());
+		for (const auto& spectator : spectators.players()) {
+			Player* player = static_cast<Player*>(spectator.get());
+			oldStackPosVector.push_back(
+			    player->canSeeCreature(creature) ? tile->getClientIndexOfCreature(player, creature) : -1);
 		}
 
-		spectator->onRemoveCreature(creature, isLogout);
+		tile->removeCreature(creature);
+
+		// send to client
+		size_t i = 0;
+		for (const auto& spectator : spectators.players()) {
+			Player* player = static_cast<Player*>(spectator.get());
+			if (player->canSeeCreature(creature)) {
+				player->sendRemoveTileThing(tilePosition, oldStackPosVector[i]);
+			}
+			++i;
+		}
+
+		// event method
+		for (const auto& spectator : spectators) {
+			if (!spectator || !spectator->compareInstance(creature->getInstanceID())) {
+				continue;
+			}
+
+			spectator->onRemoveCreature(creature, isLogout);
+		}
+
+		if (Cylinder* parent = creature->getParent()) {
+			parent->postRemoveNotification(creature, nullptr, 0);
+		} else {
+			LOG_ERROR("[Game::removeCreature] Creature '{}' id={} lost its parent during tile removal.",
+			          creature->getName(), creature->getID());
+		}
+	} else {
+		LOG_ERROR("[Game::removeCreature] Creature '{}' id={} has no valid tile; continuing global cleanup.",
+		          creature->getName(), creature->getID());
 	}
 
 	auto master = creature->getMaster();
-	if (master && !master->isRemoved()) {
+	if (master) {
 		creature->setMaster(nullptr);
 	}
-
-	creature->getParent()->postRemoveNotification(creature, nullptr, 0);
 
 	creature->removeList();
 	creature->setRemoved();
 
 	removeCreatureCheck(creature);
 
-	// Explicitly clear master ref on each summon BEFORE recursive removal.
-	// removeCreature(summon) would skip setMaster(nullptr) because 'creature'
-	// is already marked removed. Clearing here avoids relying on destructor
-	// ordering for the master ref decrement.
+	// Explicitly clear each summon master before recursive removal so the
+	// relationship is detached while both shared references are still held.
 	std::vector<std::shared_ptr<Creature>> summonRefs;
 	summonRefs.reserve(creature->summons.size());
 	for (const auto& summonRef : creature->summons) {
@@ -1324,6 +1322,7 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 		creatureSharedRefs.erase(creature->getID());
 	}
 
+	ReleaseCreature(std::move(creatureRef));
 	return true;
 }
 
@@ -7835,11 +7834,22 @@ void Game::cleanup()
 void Game::ReleaseCreature(Creature* creature)
 {
 	if (auto creatureRef = getCreatureSharedRef(creature)) {
-		ToReleaseCreatures.push_back(std::move(creatureRef));
+		ReleaseCreature(std::move(creatureRef));
 	}
 }
 
-void Game::ReleaseCreature(std::shared_ptr<Creature> creature) { ToReleaseCreatures.push_back(std::move(creature)); }
+void Game::ReleaseCreature(std::shared_ptr<Creature> creature)
+{
+	if (!creature) {
+		return;
+	}
+
+	const auto alreadyQueued = std::ranges::any_of(
+	    ToReleaseCreatures, [&creature](const auto& queuedCreature) { return queuedCreature.get() == creature.get(); });
+	if (!alreadyQueued) {
+		ToReleaseCreatures.push_back(std::move(creature));
+	}
+}
 
 void Game::ReleaseItem(Item* item)
 {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8278,7 +8278,7 @@ void Game::playerReportBug(uint32_t playerId, std::string_view message)
 	g_events->eventPlayerOnReportBug(player, message);
 }
 
-void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr msg)
+void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr& msg)
 {
 	auto playerRef = getPlayerByID(playerId);
 	Player* player = playerRef.get();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -992,7 +992,7 @@ std::shared_ptr<Player> Game::getPlayerByID(uint32_t id)
 	return it->second.lock();
 }
 
-Creature* Game::getCreatureByName(std::string_view s)
+std::shared_ptr<Creature> Game::getCreatureByNameShared(std::string_view s)
 {
 	if (s.empty()) {
 		return nullptr;
@@ -1004,7 +1004,7 @@ Creature* Game::getCreatureByName(std::string_view s)
 		std::shared_lock<std::shared_mutex> lock(playersMutex);
 		auto it = mappedPlayerNames.find(lowerCaseName);
 		if (it != mappedPlayerNames.end()) {
-			return it->second.lock().get();
+			return it->second.lock();
 		}
 	}
 
@@ -1014,27 +1014,29 @@ Creature* Game::getCreatureByName(std::string_view s)
 			return false;
 		}
 
-		auto& name = creature->getName();
-		return caseInsensitiveEqual(lowerCaseName, name);
+		return caseInsensitiveEqual(lowerCaseName, creature->getName());
 	};
 
 	{
 		auto it = std::find_if(npcs.begin(), npcs.end(), equalCreatureName);
 		if (it != npcs.end()) {
-			auto npc = it->second.lock();
-			return npc.get();
+			return it->second.lock();
 		}
 	}
 
 	{
 		auto it = std::find_if(monsters.begin(), monsters.end(), equalCreatureName);
 		if (it != monsters.end()) {
-			auto monster = it->second.lock();
-			return monster.get();
+			return it->second.lock();
 		}
 	}
 
 	return nullptr;
+}
+
+Creature* Game::getCreatureByName(std::string_view s)
+{
+	return getCreatureByNameShared(s).get();
 }
 
 Npc* Game::getNpcByName(std::string_view npcName)
@@ -1227,7 +1229,7 @@ bool Game::placeCreature(Creature* creature, const Position& pos, bool extendedP
 
 bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 {
-	if (creature->isRemoved()) {
+	if (!creature || creature->isRemoved()) {
 		return false;
 	}
 
@@ -1236,10 +1238,17 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 		return false;
 	}
 
-	Tile* tile = creature->getTile();
+	auto tileRef = getTileSharedRef(creature->getTile());
+	if (!tileRef) {
+		LOG_ERROR("[Game::removeCreature] Creature '{}' id={} has no valid tile.", creature->getName(), creature->getID());
+		return false;
+	}
+
+	Tile* tile = tileRef.get();
+	const Position tilePosition = tile->getPosition();
 
 	SpectatorVec spectators;
-	map.getSpectators(spectators, tile->getPosition(), true);
+	map.getSpectators(spectators, tilePosition, true);
 
 	std::vector<int32_t> oldStackPosVector;
 	oldStackPosVector.reserve(spectators.size());
@@ -1250,8 +1259,6 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 	}
 
 	tile->removeCreature(creature);
-
-	const Position& tilePosition = tile->getPosition();
 
 	// send to client
 	size_t i = 0;
@@ -1282,14 +1289,6 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 	creature->removeList();
 	creature->setRemoved();
 
-	// Eagerly release internal structures while the creature still exists.
-	// These would be cleaned by the destructor eventually, but releasing now
-	// prevents the allocations from being reported as leaked if the
-	// destructor runs late due to refcount chain dependencies.
-	creature->damageMap.clear();
-
-	ReleaseCreature(creatureRef);
-
 	removeCreatureCheck(creature);
 
 	// Explicitly clear master ref on each summon BEFORE recursive removal.
@@ -1312,6 +1311,12 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 		}
 		removeCreature(summon.get());
 	}
+
+	// Eagerly release internal structures AFTER all callbacks and removal logic.
+	// These would be cleaned by the destructor eventually, but releasing now
+	// prevents the allocations from being reported as leaked if the
+	// destructor runs late due to refcount chain dependencies.
+	creature->damageMap.clear();
 
 	// Drop the shared_ptr anchor from the global creature registry.
 	{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1238,7 +1238,7 @@ bool Game::removeCreature(Creature* creature, bool isLogout /* = true*/)
 		return false;
 	}
 
-	auto tileRef = getTileSharedRef(creature->getTile());
+	auto tileRef = creature->getTileShared();
 	if (!tileRef) {
 		LOG_ERROR("[Game::removeCreature] Creature '{}' id={} has no valid tile.", creature->getName(), creature->getID());
 		return false;

--- a/src/game.h
+++ b/src/game.h
@@ -470,7 +470,7 @@ public:
 	void playerEnableSharedPartyExperience(uint32_t playerId, bool sharedExpActive);
 
 	void parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, std::string_view buffer);
-	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr msg);
+	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr& msg);
 
 	// Spy system
 	bool playerStartSpy(uint32_t godPlayerId, const std::string& targetName);

--- a/src/game.h
+++ b/src/game.h
@@ -183,13 +183,6 @@ public:
 	[[nodiscard]] std::shared_ptr<Player> getPlayerByID(uint32_t id);
 
 	/**
-	 * Returns a creature based on a string name identifier
-	 * \param s is the name identifier
-	 * \returns A Pointer to the creature
-	 */
-	[[nodiscard]] Creature* getCreatureByName(std::string_view s);
-
-	/**
 	 * Returns a npc based on a string name identifier
 	 * \param s is the name identifier
 	 * \returns A Pointer to the npc

--- a/src/game.h
+++ b/src/game.h
@@ -733,6 +733,7 @@ private:
 	std::vector<std::shared_ptr<Creature>> checkCreatureLists[EVENT_CREATURECOUNT];
 
 	std::vector<std::shared_ptr<Creature>> ToReleaseCreatures;
+	std::unordered_set<const Creature*> ToReleaseCreatureSet;
 	std::vector<std::shared_ptr<Item>> ToReleaseItems;
 
 	size_t lastBucket = 0;

--- a/src/game.h
+++ b/src/game.h
@@ -153,6 +153,13 @@ public:
 	[[nodiscard]] std::shared_ptr<Creature> getCreatureByIDShared(uint32_t id) const;
 
 	/**
+	 * Returns a creature based on a string name identifier
+	 * \param s is the name identifier
+	 * \returns A shared pointer to the creature
+	 */
+	[[nodiscard]] std::shared_ptr<Creature> getCreatureByNameShared(std::string_view s);
+
+	/**
 	 * Returns a monster based on the unique creature identifier
 	 * \param id is the unique monster id to get a monster pointer to
 	 * \returns A Monster pointer to the monster

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -871,7 +871,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result, bool deferWorl
 	if ((result = db.storeQuery(
 	         fmt::format("SELECT `key`, `value` FROM `player_storage` WHERE `player_id` = {:d}", player->getGUID())))) {
 		do {
-			player->setStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int64_t>("value"), true);
+			player->loadStorageValue(result->getNumber<uint32_t>("key"), result->getNumber<int64_t>("value"));
 		} while (result->next());
 	}
 

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -384,7 +384,20 @@ void IOLoginData::loadPlayerGuild(Player* player)
 
 void IOLoginData::loadPlayerWorldData(Player* player)
 {
+	if (!player) {
+		return;
+	}
+
 	loadPlayerGuild(player);
+
+	// Inventory ownership is established by the login worker, but notification
+	// side effects can execute Lua and therefore belong to the dispatcher.
+	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+		Item* item = player->getInventoryItem(static_cast<slots_t>(slot));
+		if (item) {
+			player->postAddNotification(item, nullptr, slot);
+		}
+	}
 }
 
 bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result, bool deferWorldData)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -553,6 +553,8 @@ void clearLuaCrashContext() noexcept
 }
 
 #ifndef _WIN32
+// GDB/LLDB hook: `call dumpLuaCrashContext()` prints the last signal-safe
+// snapshot without asking the debugger to inspect the possibly damaged Lua VM.
 extern "C" __attribute__((used)) void dumpLuaCrashContext() { writeLuaCrashContext(); }
 #endif
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -13,6 +13,7 @@
 #define STDERR_FILENO 2
 using ssize_t = ptrdiff_t;
 #else
+#include <signal.h>
 #include <unistd.h>
 #endif
 
@@ -21,6 +22,148 @@ namespace {
 std::mutex loggerMutex;
 std::atomic<bool> loggerInitialized{false};
 std::atomic<bool> shutdownInProgress{false};
+
+constexpr size_t CRASH_CONTEXT_CAPACITY = 1024;
+
+struct CrashContextLine
+{
+	std::array<char, CRASH_CONTEXT_CAPACITY> text{};
+	size_t length = 0;
+};
+
+struct CrashContextState
+{
+	std::array<CrashContextLine, 2> lines{};
+	std::atomic<unsigned int> active{0};
+};
+
+static_assert(std::atomic<unsigned int>::is_always_lock_free, "fatal-signal crash context requires lock-free atomics");
+
+CrashContextState luaCrashOrigin;
+CrashContextState luaCrashDetails;
+CrashContextState luaCrashPhase;
+
+template <typename... Args>
+void publishCrashLine(CrashContextState& state, fmt::format_string<Args...> format, Args&&... args) noexcept
+{
+	try {
+		const unsigned int next = state.active.load(std::memory_order_relaxed) ^ 1U;
+		auto& line = state.lines[next];
+		const auto result =
+		    fmt::format_to_n(line.text.data(), line.text.size() - 2, format, std::forward<Args>(args)...);
+		line.length = std::min(result.size, line.text.size() - 2);
+		line.text[line.length++] = '\n';
+		line.text[line.length] = '\0';
+		state.active.store(next, std::memory_order_release);
+	} catch (...) {
+		// Crash diagnostics must never affect normal server execution.
+	}
+}
+
+void publishCrashText(CrashContextState& state, std::string_view prefix, std::string_view value) noexcept
+{
+	const unsigned int next = state.active.load(std::memory_order_relaxed) ^ 1U;
+	auto& line = state.lines[next];
+	const size_t prefixLength = std::min(prefix.size(), line.text.size() - 2);
+	std::memcpy(line.text.data(), prefix.data(), prefixLength);
+	const size_t valueLength = std::min(value.size(), line.text.size() - prefixLength - 2);
+	std::memcpy(line.text.data() + prefixLength, value.data(), valueLength);
+	line.length = prefixLength + valueLength;
+	line.text[line.length++] = '\n';
+	line.text[line.length] = '\0';
+	state.active.store(next, std::memory_order_release);
+}
+
+void clearCrashLine(CrashContextState& state) noexcept
+{
+	const unsigned int next = state.active.load(std::memory_order_relaxed) ^ 1U;
+	state.lines[next].length = 0;
+	state.lines[next].text[0] = '\0';
+	state.active.store(next, std::memory_order_release);
+}
+
+bool writeCrashLine(const CrashContextState& state) noexcept
+{
+	const unsigned int active = state.active.load(std::memory_order_acquire);
+	const auto& line = state.lines[active];
+	if (line.length != 0) {
+		[[maybe_unused]] const ssize_t result = write(STDERR_FILENO, line.text.data(), line.length);
+		return true;
+	}
+	return false;
+}
+
+void writeLuaCrashContext() noexcept
+{
+	const bool hasContext = writeCrashLine(luaCrashOrigin);
+	writeCrashLine(luaCrashDetails);
+	writeCrashLine(luaCrashPhase);
+
+	if (hasContext) {
+		const char note[] =
+		    "[CRASH CONTEXT] phase is the last operation started; it can reveal an earlier memory corruption\n";
+		[[maybe_unused]] const ssize_t result = write(STDERR_FILENO, note, sizeof(note) - 1);
+	}
+}
+
+#ifndef _WIN32
+struct SignalSafeText
+{
+	const char* data;
+	size_t size;
+};
+
+SignalSafeText getSegvReason(int code) noexcept
+{
+	switch (code) {
+		case SEGV_MAPERR:
+			return {"address not mapped", sizeof("address not mapped") - 1};
+		case SEGV_ACCERR:
+			return {"invalid permissions", sizeof("invalid permissions") - 1};
+		default:
+			return {"unknown memory fault", sizeof("unknown memory fault") - 1};
+	}
+}
+
+void writeFaultAddress(const void* address) noexcept
+{
+	constexpr char digits[] = "0123456789abcdef";
+	char buffer[2 + sizeof(uintptr_t) * 2];
+	buffer[0] = '0';
+	buffer[1] = 'x';
+	uintptr_t value = reinterpret_cast<uintptr_t>(address);
+	for (size_t i = 0; i < sizeof(uintptr_t) * 2; ++i) {
+		const size_t shift = (sizeof(uintptr_t) * 2 - i - 1) * 4;
+		buffer[2 + i] = digits[(value >> shift) & 0x0F];
+	}
+	[[maybe_unused]] const ssize_t result = write(STDERR_FILENO, buffer, sizeof(buffer));
+}
+
+void loggerSignalHandlerWithInfo(int signal, siginfo_t* info, void*)
+{
+	const SignalSafeText signalName = signal == SIGSEGV ? SignalSafeText{"SIGSEGV", sizeof("SIGSEGV") - 1}
+	                                                    : SignalSafeText{"SIGABRT", sizeof("SIGABRT") - 1};
+	const char prefix[] = "[CRITICAL] Signal received: ";
+	[[maybe_unused]] const ssize_t r1 = write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
+	[[maybe_unused]] const ssize_t r2 = write(STDERR_FILENO, signalName.data, signalName.size);
+
+	if (signal == SIGSEGV && info) {
+		const char separator[] = ", reason=";
+		const SignalSafeText reason = getSegvReason(info->si_code);
+		[[maybe_unused]] const ssize_t r3 = write(STDERR_FILENO, separator, sizeof(separator) - 1);
+		[[maybe_unused]] const ssize_t r4 = write(STDERR_FILENO, reason.data, reason.size);
+		const char addressPrefix[] = ", faultAddress=";
+		[[maybe_unused]] const ssize_t r5 = write(STDERR_FILENO, addressPrefix, sizeof(addressPrefix) - 1);
+		writeFaultAddress(info->si_addr);
+	}
+
+	const char suffix[] = "\n";
+	[[maybe_unused]] const ssize_t r6 = write(STDERR_FILENO, suffix, sizeof(suffix) - 1);
+	writeLuaCrashContext();
+
+	::raise(signal);
+}
+#endif
 
 spdlog::level::level_enum toSpd(LogLevel level)
 {
@@ -375,6 +518,44 @@ static std::unique_ptr<Logger> loggerInstance;
 
 } // namespace
 
+void setLuaCrashContext(std::string_view interfaceName, std::string_view scriptName, int32_t scriptId) noexcept
+{
+	publishCrashLine(luaCrashOrigin, "[CRASH CONTEXT] Lua interface=\"{}\" script=\"{}\" scriptId={}", interfaceName,
+	                 scriptName, scriptId);
+	clearCrashLine(luaCrashDetails);
+	publishCrashLine(luaCrashPhase, "[CRASH CONTEXT] phase=preparing Lua callback arguments");
+}
+
+void setLuaCrashDetails(std::string_view details) noexcept
+{
+	publishCrashText(luaCrashDetails, "[CRASH CONTEXT] C++ ", details);
+}
+
+void setLuaCrashCreatureEventDetails(std::string_view eventName, uint32_t creatureId, uint32_t attackerId,
+                                     int32_t damageOrigin) noexcept
+{
+	publishCrashLine(luaCrashDetails,
+	                 "[CRASH CONTEXT] C++ CreatureEvent::executeHealthChange event=\"{}\" creatureId={} "
+	                 "attackerId={} damageOrigin={}",
+	                 eventName, creatureId, attackerId, damageOrigin);
+}
+
+void setLuaCrashPhase(std::string_view phase) noexcept
+{
+	publishCrashText(luaCrashPhase, "[CRASH CONTEXT] phase=", phase);
+}
+
+void clearLuaCrashContext() noexcept
+{
+	clearCrashLine(luaCrashOrigin);
+	clearCrashLine(luaCrashDetails);
+	clearCrashLine(luaCrashPhase);
+}
+
+#ifndef _WIN32
+extern "C" __attribute__((used)) void dumpLuaCrashContext() { writeLuaCrashContext(); }
+#endif
+
 Logger& g_logger()
 {
 	if (loggerInitialized.load(std::memory_order_acquire) && loggerInstance) {
@@ -472,6 +653,7 @@ void loggerSignalHandler(int signal)
 	[[maybe_unused]] ssize_t r1 = write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
 	[[maybe_unused]] ssize_t r2 = write(STDERR_FILENO, signalName, strlen(signalName));
 	[[maybe_unused]] ssize_t r3 = write(STDERR_FILENO, suffix, sizeof(suffix) - 1);
+	writeLuaCrashContext();
 
 	std::signal(signal, SIG_DFL);
 	std::raise(signal);
@@ -479,6 +661,15 @@ void loggerSignalHandler(int signal)
 
 void setupLoggerSignalHandlers()
 {
+#ifdef _WIN32
 	std::signal(SIGSEGV, loggerSignalHandler);
 	std::signal(SIGABRT, loggerSignalHandler);
+#else
+	struct sigaction action{};
+	action.sa_sigaction = loggerSignalHandlerWithInfo;
+	sigemptyset(&action.sa_mask);
+	action.sa_flags = SA_SIGINFO | SA_RESETHAND;
+	sigaction(SIGSEGV, &action, nullptr);
+	sigaction(SIGABRT, &action, nullptr);
+#endif
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -297,6 +297,15 @@ LogLevel parseLogLevel(std::string_view level);
 void setupLoggerSignalHandlers();
 void loggerSignalHandler(int signal);
 
+// The strings are copied into fixed buffers so the fatal-signal handler can
+// report the last active Lua callback without touching the damaged Lua state.
+void setLuaCrashContext(std::string_view interfaceName, std::string_view scriptName, int32_t scriptId) noexcept;
+void setLuaCrashDetails(std::string_view details) noexcept;
+void setLuaCrashCreatureEventDetails(std::string_view eventName, uint32_t creatureId, uint32_t attackerId,
+                                     int32_t damageOrigin) noexcept;
+void setLuaCrashPhase(std::string_view phase) noexcept;
+void clearLuaCrashContext() noexcept;
+
 #define LOG_TRACE(...) \
 	do { \
 		if (isLoggerInitialized()) g_logger().trace(__VA_ARGS__); \

--- a/src/luacreature.cpp
+++ b/src/luacreature.cpp
@@ -80,13 +80,14 @@ void updateCreatureInstance(const std::shared_ptr<Creature>& creature, uint32_t 
 int luaCreatureCreate(lua_State* L)
 {
 	// Creature(id or name or userdata)
-	Creature* creature;
+	Creature* creature = nullptr;
 	std::shared_ptr<Creature> creatureRef;
 	if (isInteger(L, 2)) {
 		creatureRef = g_game.getCreatureByIDShared(getInteger<uint32_t>(L, 2));
 		creature = creatureRef.get();
 	} else if (isString(L, 2)) {
-		creature = g_game.getCreatureByName(getString(L, 2));
+		creatureRef = g_game.getCreatureByNameShared(getString(L, 2));
+		creature = creatureRef.get();
 	} else if (isUserdata(L, 2)) {
 		LuaDataType type = getUserdataType(L, 2);
 		if (type != LuaData_Player && type != LuaData_Monster && type != LuaData_Npc) {
@@ -94,11 +95,9 @@ int luaCreatureCreate(lua_State* L)
 			return 1;
 		}
 		creature = getUserdata<Creature>(L, 2);
-	} else {
-		creature = nullptr;
 	}
 
-	if (creature) {
+	if (creature && !creature->isRemoved()) {
 		pushUserdata<Creature>(L, creature);
 		setCreatureMetatable(L, -1, creature);
 	} else {
@@ -1039,7 +1038,7 @@ int luaCreatureGetDamageMap(lua_State* L)
 		return 1;
 	}
 
-	const auto& damageMap = creature->getDamageMap();
+	const auto& damageMap = creature->getDamageMapSnapshot();
 	lua_createtable(L, damageMap.size(), 0);
 	for (const auto& damageEntry : damageMap) {
 		lua_createtable(L, 0, 2);
@@ -1322,10 +1321,12 @@ int LuaScriptInterface::luaCreatureGC(lua_State* L)
 	if (creaturePtr) {
 		*creaturePtr = nullptr;
 	}
+
 	if (getAssociatedValue(L, 1, 1)) {
 		auto* weakPtr = static_cast<std::weak_ptr<Creature>*>(lua_touserdata(L, -1));
 		if (weakPtr) {
 			std::destroy_at(weakPtr);
+			std::construct_at(weakPtr);
 		}
 		lua_pop(L, 1);
 	}

--- a/src/luacreature.cpp
+++ b/src/luacreature.cpp
@@ -1326,9 +1326,14 @@ int LuaScriptInterface::luaCreatureGC(lua_State* L)
 		auto* weakPtr = static_cast<std::weak_ptr<Creature>*>(lua_touserdata(L, -1));
 		if (weakPtr) {
 			std::destroy_at(weakPtr);
-			std::construct_at(weakPtr);
 		}
 		lua_pop(L, 1);
+
+		// Remove the ownership userdata after destroying its C++ object. This
+		// makes a repeated/finalizer re-entry a no-op without starting a second
+		// weak_ptr lifetime in memory owned by Lua.
+		lua_pushnil(L);
+		lua_setiuservalue(L, 1, 1);
 	}
 	return 0;
 }

--- a/src/luagame.cpp
+++ b/src/luagame.cpp
@@ -66,14 +66,20 @@ int luaGameGetSpectators(lua_State* L)
 int luaGameGetPlayers(lua_State* L)
 {
 	// Game.getPlayers()
+	setLuaCrashDetails("Game.getPlayers / building Player userdata snapshot");
+	setLuaCrashPhase("Game.getPlayers / create result table");
 	lua_createtable(L, g_game.getPlayersOnline(), 0);
 
 	int index = 0;
 	for (const auto& player : g_game.getPlayers()) {
+		setLuaCrashPhase("Game.getPlayers / allocate Player userdata");
 		pushUserdata<Player>(L, player.get());
+		setLuaCrashPhase("Game.getPlayers / assign Player metatable");
 		setMetatable(L, -1, "Player");
+		setLuaCrashPhase("Game.getPlayers / append Player userdata to result");
 		lua_rawseti(L, -2, ++index);
 	}
+	setLuaCrashPhase("Lua callback execution / Game.getPlayers complete");
 	return 1;
 }
 

--- a/src/luanetworkmessage.cpp
+++ b/src/luanetworkmessage.cpp
@@ -116,11 +116,14 @@ int luaNetworkMessageCreate(lua_State* L)
 {
 	// NetworkMessage([player])
 	pushSharedPtr(L, tfs::net::make_network_message());
+	const int32_t messageIndex = lua_gettop(L);
 	setMetatable(L, -1, "NetworkMessage");
 
-	if (const auto player = getPlayer(L, 1)) {
+	// __call receives the NetworkMessage class table at index 1 and the
+	// optional constructor argument at index 2.
+	if (const auto player = getPlayer(L, 2)) {
 		lua_pushinteger(L, player->getID());
-		lua_setiuservalue(L, 2, 1);
+		lua_setiuservalue(L, messageIndex, 1);
 	}
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -324,6 +324,12 @@ bool ScriptEnvironment::setCallbackId(int32_t callbackId, LuaScriptInterface* sc
 
 	this->callbackId = callbackId;
 	interface = scriptInterface;
+	if (scriptInterface) {
+		setLuaCrashContext(scriptInterface->getInterfaceName(), scriptInterface->getFileById(callbackId), callbackId);
+		setLuaCrashPhase("registered Lua callback");
+	} else {
+		clearLuaCrashContext();
+	}
 	return true;
 }
 
@@ -549,10 +555,12 @@ void LuaScriptInterface::resetScriptEnv()
 		return;
 	}
 
+	const int32_t activeScriptId =
+	    outerEnv->getCallbackId() != 0 ? outerEnv->getCallbackId() : outerEnv->getScriptId();
 	const std::string_view origin = outerEnv->getTimerEventOrigin().empty()
-	                                    ? outerInterface->getFileById(outerEnv->getScriptId())
+	                                    ? outerInterface->getFileById(activeScriptId)
 	                                    : std::string_view(outerEnv->getTimerEventOrigin());
-	setLuaCrashContext(outerInterface->getInterfaceName(), origin, outerEnv->getScriptId());
+	setLuaCrashContext(outerInterface->getInterfaceName(), origin, activeScriptId);
 	setLuaCrashPhase("resumed outer Lua callback");
 }
 
@@ -4490,6 +4498,26 @@ bool LuaEnvironment::initState()
 	}
 
 	luaL_openlibs(luaState);
+
+#if LUA_VERSION_NUM == 505
+	// Lua 5.5.0 shipped with a missing write barrier in luaV_finishset. Fail
+	// fast for an unpatched system library instead of accepting latent heap
+	// corruption. Patched 5.5 builds and later 5.5 maintenance releases pass.
+	constexpr const char* writeBarrierProbe =
+	    "local p={}; p.__newindex=p; collectgarbage(); "
+	    "local c=setmetatable({},p); c.__newindex={x='ok'}; "
+	    "collectgarbage('step'); assert(p.__newindex.x=='ok')";
+	if (luaL_dostring(luaState, writeBarrierProbe) != LUA_OK) {
+		const char* error = lua_tostring(luaState, -1);
+		LOG_ERROR("[LuaEnvironment::initState] Lua 5.5 write-barrier self-test failed: {}",
+		          error ? error : "unknown error");
+		ownedLuaState_.reset();
+		luaState = nullptr;
+		return false;
+	}
+	lua_settop(luaState, 0);
+#endif
+
 	registerFunctions();
 
 	runningEventId = EVENT_ID_USER;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -256,6 +256,21 @@ ScriptEnvironment::ScriptEnvironment() { resetEnv(); }
 
 ScriptEnvironment::~ScriptEnvironment() { resetEnv(); }
 
+void ScriptEnvironment::setScriptId(int32_t newScriptId, LuaScriptInterface* scriptInterface)
+{
+	scriptId = newScriptId;
+	interface = scriptInterface;
+
+	if (!scriptInterface) {
+		clearLuaCrashContext();
+		return;
+	}
+
+	const std::string_view origin = timerEvent && !timerEventOrigin.empty() ? std::string_view(timerEventOrigin)
+	                                                                        : scriptInterface->getFileById(newScriptId);
+	setLuaCrashContext(scriptInterface->getInterfaceName(), origin, newScriptId);
+}
+
 void ScriptEnvironment::resetEnv()
 {
 	scriptId = 0;
@@ -512,6 +527,35 @@ LuaScriptInterface::~LuaScriptInterface()
 	cacheFiles.clear();
 }
 
+void LuaScriptInterface::resetScriptEnv()
+{
+	assert(scriptEnvIndex >= 0);
+	// Rollback any open transaction leaked by the script that just ended
+	if (Database::getInstance().isInTransaction()) {
+		Database::getInstance().rollback();
+		scriptEnv[scriptEnvIndex].hasOpenTransaction = false;
+	}
+	scriptEnv[scriptEnvIndex--].resetEnv();
+
+	if (!hasScriptEnv()) {
+		clearLuaCrashContext();
+		return;
+	}
+
+	ScriptEnvironment* outerEnv = getScriptEnv();
+	LuaScriptInterface* outerInterface = outerEnv->getScriptInterface();
+	if (!outerInterface) {
+		clearLuaCrashContext();
+		return;
+	}
+
+	const std::string_view origin = outerEnv->getTimerEventOrigin().empty()
+	                                    ? outerInterface->getFileById(outerEnv->getScriptId())
+	                                    : std::string_view(outerEnv->getTimerEventOrigin());
+	setLuaCrashContext(outerInterface->getInterfaceName(), origin, outerEnv->getScriptId());
+	setLuaCrashPhase("resumed outer Lua callback");
+}
+
 bool LuaScriptInterface::reInitState()
 {
 	g_luaEnvironment.clearCombatObjects(this);
@@ -539,11 +583,14 @@ void LuaEnvironment::shutdown()
 /// Same as lua_pcall, but adds stack trace to error strings in called function.
 int LuaScriptInterface::protectedCall(lua_State* L, int nargs, int nresults)
 {
+	setLuaCrashPhase("LuaScriptInterface::protectedCall / install error handler");
 	int error_index = lua_gettop(L) - nargs;
 	lua_pushcfunction(L, luaErrorHandler);
 	lua_insert(L, error_index);
 
+	setLuaCrashPhase("LuaScriptInterface::protectedCall / executing lua_pcall");
 	int ret = lua_pcall(L, nargs, nresults, error_index);
+	setLuaCrashPhase("LuaScriptInterface::protectedCall / remove error handler");
 	lua_remove(L, error_index);
 	return ret;
 }
@@ -763,6 +810,7 @@ void LuaScriptInterface::reportError(const char* function, std::string_view erro
 
 bool LuaScriptInterface::pushFunction(int32_t functionId)
 {
+	setLuaCrashPhase("LuaScriptInterface::pushFunction / registry lookup");
 	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
 	if (!Lua::isTable(luaState, -1)) {
 		return false;
@@ -1095,6 +1143,7 @@ void Lua::setItemMetatable(lua_State* L, int32_t index, const Item* item)
 
 void Lua::setCreatureMetatable(lua_State* L, int32_t index, const Creature* creature)
 {
+	setLuaCrashPhase("Lua::setCreatureMetatable / select creature metatable");
 	if (creature->isPlayer()) {
 		luaL_getmetatable(L, "Player");
 	} else if (creature->isMonster()) {
@@ -1106,10 +1155,13 @@ void Lua::setCreatureMetatable(lua_State* L, int32_t index, const Creature* crea
 		LOG_ERROR("[Lua::setCreatureMetatable] Unknown creature type: {}", static_cast<int32_t>(creature->getType()));
 		luaL_getmetatable(L, "Creature");
 	}
+	setLuaCrashPhase("Lua::setCreatureMetatable / lua_setmetatable");
 	lua_setmetatable(L, index - 1);
 
-	new (lua_newuserdatauv(L, sizeof(std::weak_ptr<Creature>), 0)) std::weak_ptr<Creature>(
-	    g_game.getCreatureWeakRef(creature));
+	setLuaCrashPhase("Lua::setCreatureMetatable / allocate weak ownership userdata");
+	new (lua_newuserdatauv(L, sizeof(std::weak_ptr<Creature>), 0))
+	    std::weak_ptr<Creature>(g_game.getCreatureWeakRef(creature));
+	setLuaCrashPhase("Lua::setCreatureMetatable / lua_setiuservalue weak ownership");
 	lua_setiuservalue(L, index - 1, 1);
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -226,6 +226,7 @@ public:
 	bool setCallbackId(int32_t callbackId, LuaScriptInterface* scriptInterface);
 
 	int32_t getScriptId() const { return scriptId; }
+	int32_t getCallbackId() const { return callbackId; }
 	LuaScriptInterface* getScriptInterface() { return interface; }
 	void setScriptInterface(LuaScriptInterface* scriptInterface) { interface = scriptInterface; }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -222,11 +222,7 @@ public:
 
 	void resetEnv();
 
-	void setScriptId(int32_t scriptId, LuaScriptInterface* scriptInterface)
-	{
-		this->scriptId = scriptId;
-		interface = scriptInterface;
-	}
+	void setScriptId(int32_t scriptId, LuaScriptInterface* scriptInterface);
 	bool setCallbackId(int32_t callbackId, LuaScriptInterface* scriptInterface);
 
 	int32_t getScriptId() const { return scriptId; }
@@ -352,16 +348,7 @@ public:
 
 	static bool reserveScriptEnv() { return ++scriptEnvIndex < 16; }
 
-	static void resetScriptEnv()
-	{
-		assert(scriptEnvIndex >= 0);
-		// Rollback any open transaction leaked by the script that just ended
-		if (Database::getInstance().isInTransaction()) {
-			Database::getInstance().rollback();
-			scriptEnv[scriptEnvIndex].hasOpenTransaction = false;
-		}
-		scriptEnv[scriptEnvIndex--].resetEnv();
-	}
+	static void resetScriptEnv();
 
 	static void reportError(const char* function, std::string_view error_desc, lua_State* L = nullptr,
 	                        bool stack_trace = false);
@@ -1003,7 +990,12 @@ std::optional<uint8_t> getBlessingId(lua_State* L, int32_t arg);
 
 inline bool getAssociatedValue(lua_State* L, int32_t arg, int32_t index)
 {
-	return lua_getiuservalue(L, arg, index) != LUA_TNONE;
+	const int32_t valueType = lua_getiuservalue(L, arg, index);
+	if (valueType == LUA_TNONE || valueType == LUA_TNIL) {
+		lua_pop(L, 1);
+		return false;
+	}
+	return true;
 }
 
 // Is

--- a/src/packet_backlog.h
+++ b/src/packet_backlog.h
@@ -12,6 +12,36 @@
 
 namespace tfs::net {
 
+// Preserve the legacy dispatcher deadline only for gameplay actions that
+// become unsafe or confusing when replayed after a long dispatcher stall.
+constexpr bool shouldExpireQueuedGamePacket(uint8_t opcode) noexcept
+{
+	switch (opcode) {
+		case 0x6F: // turn north
+		case 0x70: // turn east
+		case 0x71: // turn south
+		case 0x72: // turn west
+		case 0x77: // hotkey equip
+		case 0x78: // move item
+		case 0x79: // look in shop
+		case 0x7A: // buy
+		case 0x7B: // sell
+		case 0x7E: // look in trade
+		case 0x82: // use item
+		case 0x83: // use item on position
+		case 0x84: // use item on creature
+		case 0x85: // rotate item
+		case 0x8B: // wrap item
+		case 0x8C: // look at
+		case 0x8D: // look in battle list
+		case 0xCB: // browse field
+		case 0xCC: // seek in container
+			return true;
+		default:
+			return false;
+	}
+}
+
 class PacketBacklog
 {
 private:

--- a/src/packet_backlog.h
+++ b/src/packet_backlog.h
@@ -1,0 +1,144 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_PACKET_BACKLOG_H
+#define FS_PACKET_BACKLOG_H
+
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace tfs::net {
+
+class PacketBacklog
+{
+private:
+	struct State
+	{
+		explicit State(uint32_t packetLimit) : limit(packetLimit) {}
+
+		const uint32_t limit;
+		std::atomic<uint32_t> pending{0};
+		std::atomic<bool> floodTriggered{false};
+#ifdef PROTOCOLGAME_BACKLOG_DIAGNOSTICS
+		std::atomic<uint32_t> peak{0};
+		std::atomic<uint64_t> rejected{0};
+#endif
+	};
+
+public:
+	static constexpr uint32_t DEFAULT_LIMIT = 128;
+
+	class Ticket
+	{
+	public:
+		Ticket() = default;
+		Ticket(const Ticket&) = delete;
+		Ticket& operator=(const Ticket&) = delete;
+		Ticket(Ticket&& other) noexcept : state(std::exchange(other.state, {})) {}
+		Ticket& operator=(Ticket&& other) noexcept
+		{
+			if (this != &other) {
+				release();
+				state = std::exchange(other.state, {});
+			}
+			return *this;
+		}
+
+		~Ticket() { release(); }
+
+		explicit operator bool() const noexcept { return static_cast<bool>(state); }
+
+	private:
+		friend class PacketBacklog;
+		explicit Ticket(std::shared_ptr<State> state) : state(std::move(state)) {}
+
+		void release() noexcept
+		{
+			if (!state) {
+				return;
+			}
+
+			const uint32_t previous = state->pending.fetch_sub(1, std::memory_order_acq_rel);
+			assert(previous > 0 && "Packet backlog counter underflow");
+			(void)previous;
+			state.reset();
+		}
+
+		std::shared_ptr<State> state;
+	};
+
+	struct Admission
+	{
+		Ticket ticket;
+		uint32_t observedPending = 0;
+		uint32_t newPeak = 0;
+		bool requestDisconnect = false;
+
+		explicit operator bool() const noexcept { return static_cast<bool>(ticket); }
+	};
+
+	explicit PacketBacklog(uint32_t limit = DEFAULT_LIMIT) : state(std::make_shared<State>(limit))
+	{
+		assert(limit > 0 && "Packet backlog limit must be positive");
+	}
+
+	Admission tryAcquire() noexcept
+	{
+		Admission admission;
+		if (state->floodTriggered.load(std::memory_order_acquire)) {
+			recordRejected();
+			return admission;
+		}
+
+		const uint32_t pending = state->pending.fetch_add(1, std::memory_order_acq_rel) + 1;
+		admission.observedPending = pending;
+		if (pending > state->limit || state->floodTriggered.load(std::memory_order_acquire)) {
+			state->pending.fetch_sub(1, std::memory_order_acq_rel);
+			recordRejected();
+
+			bool expected = false;
+			admission.requestDisconnect = pending > state->limit && state->floodTriggered.compare_exchange_strong(
+			    expected, true, std::memory_order_acq_rel, std::memory_order_acquire);
+			return admission;
+		}
+
+#ifdef PROTOCOLGAME_BACKLOG_DIAGNOSTICS
+		uint32_t peak = state->peak.load(std::memory_order_relaxed);
+		while (pending > peak && !state->peak.compare_exchange_weak(
+		                             peak, pending, std::memory_order_relaxed, std::memory_order_relaxed)) {
+		}
+		if (pending > peak) {
+			admission.newPeak = pending;
+		}
+#endif
+
+		admission.ticket = Ticket(state);
+		return admission;
+	}
+
+	uint32_t current() const noexcept { return state->pending.load(std::memory_order_acquire); }
+	uint32_t limit() const noexcept { return state->limit; }
+	bool floodTriggered() const noexcept { return state->floodTriggered.load(std::memory_order_acquire); }
+
+#ifdef PROTOCOLGAME_BACKLOG_DIAGNOSTICS
+	uint32_t peak() const noexcept { return state->peak.load(std::memory_order_relaxed); }
+	uint64_t rejected() const noexcept { return state->rejected.load(std::memory_order_relaxed); }
+#endif
+
+private:
+	void recordRejected() noexcept
+	{
+#ifdef PROTOCOLGAME_BACKLOG_DIAGNOSTICS
+		state->rejected.fetch_add(1, std::memory_order_relaxed);
+#endif
+	}
+
+	std::shared_ptr<State> state;
+};
+
+} // namespace tfs::net
+
+#endif // FS_PACKET_BACKLOG_H

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1728,11 +1728,16 @@ void Player::setStorageValue(const uint32_t key, const std::optional<int64_t> va
 	const auto oldValue = getStorageValue(key);
 	Creature::setStorageValue(key, value, isSpawn);
 
-	if (isSpawn || oldValue == getStorageValue(key)) {
+	if (isSpawn) {
 		return;
 	}
 
-	if (value && value.value() != -1) {
+	const auto currentValue = getStorageValue(key);
+	if (oldValue == currentValue) {
+		return;
+	}
+
+	if (currentValue) {
 		removedStorageKeys.erase(key);
 		modifiedStorageKeys.insert(key);
 	} else {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1747,6 +1747,14 @@ void Player::setStorageValue(const uint32_t key, const std::optional<int64_t> va
 	storageDirtyKeyRevisions[key] = ++storageDirtyRevision;
 }
 
+void Player::loadStorageValue(uint32_t key, int64_t value)
+{
+	Creature::loadStorageValue(key, value);
+	modifiedStorageKeys.erase(key);
+	removedStorageKeys.erase(key);
+	storageDirtyKeyRevisions.erase(key);
+}
+
 Player::StorageDirtySnapshot Player::getStorageDirtySnapshot() const
 {
 	return StorageDirtySnapshot{storageDirtyRevision, modifiedStorageKeys, removedStorageKeys};

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -491,13 +491,6 @@ std::string Player::getDescription(int32_t lookDistance) const
 			s << " You have no vocation (Level " << level << ").";
 		}
 
-		if (ConfigManager::getBoolean(ConfigManager::RESET_SYSTEM_ENABLED) && reset > 0) {
-			if (lookDistance == -1) {
-				s << " You have " << reset << " reset" << (reset == 1 ? "" : "s") << ".";
-			} else {
-				s << " " << subjectPronoun << " has " << reset << " reset" << (reset == 1 ? "" : "s") << ".";
-			}
-		}
 	} else {
 		s << name;
 		if (!group->access) {
@@ -518,12 +511,13 @@ std::string Player::getDescription(int32_t lookDistance) const
 		} else {
 			s << " has no vocation.";
 		}
-		if (ConfigManager::getBoolean(ConfigManager::RESET_SYSTEM_ENABLED) && reset > 0) {
-			if (lookDistance == -1) {
-				s << " You have " << reset << " reset" << (reset == 1 ? "" : "s") << ".";
-			} else {
-				s << " " << subjectPronoun << " has " << reset << " reset" << (reset == 1 ? "" : "s") << ".";
-			}
+	}
+
+	if (ConfigManager::getBoolean(ConfigManager::RESET_SYSTEM_ENABLED) && reset > 0) {
+		if (lookDistance == -1) {
+			s << " You have " << reset << " reset" << (reset == 1 ? "" : "s") << ".";
+		} else {
+			s << " " << subjectPronoun << " has " << reset << " reset" << (reset == 1 ? "" : "s") << ".";
 		}
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4714,6 +4714,13 @@ Thing* Player::getThing(size_t index) const
 void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index,
                                  cylinderlink_t link /*= LINK_OWNER*/)
 {
+	// IOLoginData builds the inventory in a worker thread. The item is already
+	// attached by internalAddThing(), but every notification side effect below
+	// must wait until the player is placed on the dispatcher thread.
+	if (isLoading()) {
+		return;
+	}
+
 	if (link == LINK_OWNER) {
 		// calling movement scripts
 		g_moveEvents->onPlayerEquip(this, thing->getItem(), static_cast<slots_t>(index), false);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1717,14 +1717,10 @@ std::optional<Player::BestiaryKillResult> Player::takePendingBestiaryKill(uint32
 	return result;
 }
 
-void Player::setStorageValue(const uint32_t key, const std::optional<int64_t> value, const bool isSpawn /* = false*/)
+void Player::setStorageValue(const uint32_t key, const std::optional<int64_t> value)
 {
 	const auto oldValue = getStorageValue(key);
-	Creature::setStorageValue(key, value, isSpawn);
-
-	if (isSpawn) {
-		return;
-	}
+	Creature::setStorageValue(key, value);
 
 	const auto currentValue = getStorageValue(key);
 	if (oldValue == currentValue) {
@@ -5055,12 +5051,17 @@ void Player::maintainAttackFlow()
 
 uint64_t Player::getGainedExperience(const std::shared_ptr<Creature>& attacker) const
 {
+	return getGainedExperience(attacker, getDamageRatio(attacker));
+}
+
+uint64_t Player::getGainedExperience(const std::shared_ptr<Creature>& attacker, double damageRatio) const
+{
 	if (getBoolean(ConfigManager::EXPERIENCE_FROM_PLAYERS)) {
 		Player* attackerPlayer = attacker ? attacker->getPlayer() : nullptr;
 		if (attackerPlayer && attacker.get() != this && skillLoss &&
 		    std::abs(static_cast<int64_t>(attackerPlayer->getLevel() - level)) <=
 		        getInteger(ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)) {
-			return std::max<uint64_t>(0, std::floor(getLostExperience() * getDamageRatio(attacker) * 0.75));
+			return std::max<uint64_t>(0, std::floor(getLostExperience() * damageRatio * 0.75));
 		}
 	}
 	return 0;

--- a/src/player.h
+++ b/src/player.h
@@ -487,7 +487,7 @@ public:
 
 	bool canOpenCorpse(uint32_t ownerId) const;
 
-	void setStorageValue(const uint32_t key, const std::optional<int64_t> value, const bool isSpawn = false) override;
+	void setStorageValue(const uint32_t key, const std::optional<int64_t> value) override;
 	void loadStorageValue(uint32_t key, int64_t value);
 	const std::unordered_set<uint32_t>& getModifiedStorageKeys() const { return modifiedStorageKeys; }
 	const std::unordered_set<uint32_t>& getRemovedStorageKeys() const { return removedStorageKeys; }
@@ -895,6 +895,7 @@ public:
 	void addInFightTicks(bool pzlock = false);
 
 	uint64_t getGainedExperience(const std::shared_ptr<Creature>& attacker) const override;
+	uint64_t getGainedExperience(const std::shared_ptr<Creature>& attacker, double damageRatio) const override;
 
 	// combat event functions
 	void onAddCondition(ConditionType_t type) override;

--- a/src/player.h
+++ b/src/player.h
@@ -494,6 +494,7 @@ public:
 	bool canOpenCorpse(uint32_t ownerId) const;
 
 	void setStorageValue(const uint32_t key, const std::optional<int64_t> value, const bool isSpawn = false) override;
+	void loadStorageValue(uint32_t key, int64_t value);
 	const std::unordered_set<uint32_t>& getModifiedStorageKeys() const { return modifiedStorageKeys; }
 	const std::unordered_set<uint32_t>& getRemovedStorageKeys() const { return removedStorageKeys; }
 	bool hasStorageDirty() const { return !modifiedStorageKeys.empty() || !removedStorageKeys.empty(); }

--- a/src/player.h
+++ b/src/player.h
@@ -183,12 +183,6 @@ public:
 	const std::string& getName() const override { return name; }
 	void setName(std::string_view name) { this->name = name; }
 	const std::string& getNameDescription() const override { return name; }
-	std::string getDisplayName() const {
-		if (reset > 0) {
-			return name + " [" + std::to_string(reset) + "]";
-		}
-		return name;
-	}
 	std::string getDescription(int32_t lookDistance) const override;
 
 	CreatureType_t getType() const override { return CREATURETYPE_PLAYER; }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -7,6 +7,7 @@
 
 #include "outputmessage.h"
 #include "rsa.h"
+#include "tasks.h"
 #include "xtea.h"
 
 namespace {
@@ -66,7 +67,7 @@ void Protocol::onRecvMessage(NetworkMessage& msg)
 
 OutputMessage_ptr Protocol::getOutputBuffer(int32_t size)
 {
-	// dispatcher thread
+	assert(g_dispatcher.isDispatcherThread() && "Protocol::getOutputBuffer must run on the dispatcher thread");
 	if (!outputBuffer) {
 		outputBuffer = OutputMessagePool::getOutputMessage();
 		OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1566,9 +1566,8 @@ void ProtocolGame::disconnectClient(std::string_view message) const
 
 void ProtocolGame::dispatchCancelMessage(ReturnValue message) const
 {
-	const uint32_t playerId = player ? player->getID() : 0;
-	if (auto playerRef = g_game.getPlayerByID(playerId)) {
-		playerRef->sendCancelMessage(message);
+	if (player) {
+		player->sendCancelMessage(message);
 	}
 }
 
@@ -1580,10 +1579,11 @@ void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg)
 
 void ProtocolGame::parsePacket(NetworkMessage& msg)
 {
-	if (msg.getLength() == 0) {
+	if (msg.getLength() == 0 || getReadableBytes(msg) == 0) {
 		return;
 	}
 
+	const uint8_t opcode = msg.getBuffer()[msg.getBufferPosition()];
 	auto admission = packetBacklog.tryAcquire();
 	if (!admission) {
 		if (admission.requestDisconnect) {
@@ -1605,14 +1605,20 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 	// The ASIO thread only owns the incoming bytes. Protocol and player state
 	// are read exclusively by the dispatcher task below.
 	auto packet = tfs::net::make_network_message(msg);
-	g_dispatcher.addTask([thisPtr = getThis(), packet = std::move(packet), ticket = std::move(admission.ticket)]() mutable {
+	auto task = [thisPtr = getThis(), packet = std::move(packet), ticket = std::move(admission.ticket)]() mutable {
 		(void)ticket;
 		if (thisPtr->isConnectionExpired()) {
 			return;
 		}
 
 		thisPtr->parsePacketOnDispatcher(packet);
-	});
+	};
+
+	if (tfs::net::shouldExpireQueuedGamePacket(opcode)) {
+		g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, std::move(task));
+	} else {
+		g_dispatcher.addTask(std::move(task));
+	}
 }
 
 void ProtocolGame::parsePacketOnDispatcher(NetworkMessage_ptr& packet)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1137,10 +1137,13 @@ void ProtocolGame::finishLogin(uint32_t reservedGuid, uint32_t accountId, bool l
 	player->client->isOTC = isOTC;
 	player->client->isAstraClient = isAstraClient;
 	player->client->isFonticakClient = isFonticakClient;
+	// Astra item-state features depend on the loaded player and on this
+	// protocol already owning player->client. Advertise the final feature set
+	// before serializing the initial map, otherwise the server appends Astra
+	// item metadata that the client does not know how to consume.
 	if (isAstraClient) {
 		sendFeatures();
 	}
-
 	if (!g_game.placeCreature(player.get(), player->getLoginPosition())) {
 		if (!g_game.placeCreature(player.get(), player->getTemplePosition(), false, true)) {
 			g_game.releaseLogin(reservedGuid);
@@ -1279,6 +1282,9 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	player->client->isOTC = isOTC;
 	player->client->isAstraClient = isAstraClient;
 	player->client->isFonticakClient = isFonticakClient;
+	// Reconnecting Astra clients also need the feature set recalculated after
+	// this protocol becomes the owner, and before sendAddCreature sends map and
+	// item data.
 	if (isAstraClient) {
 		sendFeatures();
 	}
@@ -1359,7 +1365,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	key[2] = msg.get<uint32_t>();
 	key[3] = msg.get<uint32_t>();
 	enableXTEAEncryption();
-	setXTEAKey(std::move(key));
+	setXTEAKey(key);
 
 	msg.skipBytes(1); // gamemaster flag
 
@@ -1471,17 +1477,6 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		LOG_NETWORK("Client connected: FonticakClient");
 	}
 
-	if (isOTC) {
-		NetworkMessage opcodeMessage;
-		opcodeMessage.addByte(0x32);
-		opcodeMessage.addByte(0x00);
-		opcodeMessage.add<uint16_t>(0x00);
-		writeToOutputBuffer(opcodeMessage);
-	}
-	if (isOTCv8) {
-		sendFeatures();
-	}
-
 	if (version < CLIENT_VERSION_MIN || version > CLIENT_VERSION_MAX) {
 		disconnectClient(fmt::format("Only clients with protocol {:s} allowed!", CLIENT_VERSION_STR));
 		return;
@@ -1571,6 +1566,16 @@ void ProtocolGame::disconnectClient(std::string_view message) const
 	disconnect();
 }
 
+void ProtocolGame::dispatchCancelMessage(ReturnValue message) const
+{
+	const uint32_t playerId = player ? player->getID() : 0;
+	g_dispatcher.addTask([playerId, message]() {
+		if (auto playerRef = g_game.getPlayerByID(playerId)) {
+			playerRef->sendCancelMessage(message);
+		}
+	});
+}
+
 void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg)
 {
 	auto out = getOutputBuffer(msg.getLength());
@@ -1614,7 +1619,7 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 			case 0x96: // say (allows /unspy)
 				break; // allowed — fall through to normal processing
 			default:
-				sendCancelWalk();
+				g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->sendCancelWalk(); });
 				return; // block all other actions
 		}
 	}
@@ -2374,7 +2379,7 @@ void ProtocolGame::parseAutoWalk(NetworkMessage& msg)
 void ProtocolGame::parseSetOutfit(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -2464,7 +2469,7 @@ void ProtocolGame::parseSetMonsterPodium(NetworkMessage& msg)
 void ProtocolGame::parseUseItem(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -2542,7 +2547,7 @@ void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
 void ProtocolGame::parseUseItemEx(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -2560,7 +2565,7 @@ void ProtocolGame::parseUseItemEx(NetworkMessage& msg)
 void ProtocolGame::parseUseWithCreature(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -2734,7 +2739,7 @@ void ProtocolGame::parseQuickLootBlackWhitelist(NetworkMessage& msg)
 void ProtocolGame::parseThrow(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -2807,7 +2812,11 @@ void ProtocolGame::parseSay(NetworkMessage& msg)
 	}
 
 	if (player->isAccountManager()) {
-		player->manageAccount(std::string{text});
+		g_dispatcher.addTask([playerID = player->getID(), text = std::string{text}]() {
+			if (auto playerRef = g_game.getPlayerByID(playerID)) {
+				playerRef->manageAccount(text);
+			}
+		});
 		return;
 	}
 
@@ -2819,7 +2828,7 @@ void ProtocolGame::parseSay(NetworkMessage& msg)
 void ProtocolGame::parseAttack(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -2892,7 +2901,7 @@ void ProtocolGame::parsePlayerSale(NetworkMessage& msg)
 void ProtocolGame::parseRequestTrade(NetworkMessage& msg)
 {
 	if (player->isAccountManager()) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		dispatchCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
@@ -5860,11 +5869,13 @@ void ProtocolGame::parseSwitchCast(uint8_t direction)
 
 void ProtocolGame::parseImbuementDurations(NetworkMessage& msg)
 {
-	bool open = msg.getByte() != 0;
-	imbuementTrackerOpen = open;
-	if (open) {
-		sendImbuementDurations();
-	}
+	const bool open = msg.getByte() != 0;
+	g_dispatcher.addTask([thisPtr = getThis(), open]() {
+		thisPtr->imbuementTrackerOpen = open;
+		if (open) {
+			thisPtr->sendImbuementDurations();
+		}
+	});
 }
 
 void ProtocolGame::sendImbuementDurations(slots_t updatedSlot, const Item* updatedItem)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -935,7 +935,10 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 
 	// OTCv8 and Mehah features and extended opcodes
 	if (isOTC) {
-		sendFeatures();
+		// Player loading can emit status packets before finishLogin(). Astra
+		// therefore needs its final wire-format features advertised up front.
+		sendFeatures(isAstraClient);
+
 		NetworkMessage opcodeMessage;
 		opcodeMessage.addByte(0x32);
 		opcodeMessage.addByte(0x00);
@@ -1137,13 +1140,6 @@ void ProtocolGame::finishLogin(uint32_t reservedGuid, uint32_t accountId, bool l
 	player->client->isOTC = isOTC;
 	player->client->isAstraClient = isAstraClient;
 	player->client->isFonticakClient = isFonticakClient;
-	// Astra item-state features depend on the loaded player and on this
-	// protocol already owning player->client. Advertise the final feature set
-	// before serializing the initial map, otherwise the server appends Astra
-	// item metadata that the client does not know how to consume.
-	if (isAstraClient) {
-		sendFeatures();
-	}
 	if (!g_game.placeCreature(player.get(), player->getLoginPosition())) {
 		if (!g_game.placeCreature(player.get(), player->getTemplePosition(), false, true)) {
 			g_game.releaseLogin(reservedGuid);
@@ -1282,12 +1278,6 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	player->client->isOTC = isOTC;
 	player->client->isAstraClient = isAstraClient;
 	player->client->isFonticakClient = isFonticakClient;
-	// Reconnecting Astra clients also need the feature set recalculated after
-	// this protocol becomes the owner, and before sendAddCreature sends map and
-	// item data.
-	if (isAstraClient) {
-		sendFeatures();
-	}
 	sendAddCreature(player.get(), player->getPosition(), 0);
 	resetDllCheckState();
 	sendLootContainers();
@@ -1584,6 +1574,26 @@ void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg)
 
 void ProtocolGame::parsePacket(NetworkMessage& msg)
 {
+	if (msg.getLength() == 0) {
+		return;
+	}
+
+	// The ASIO thread only owns the incoming bytes. Protocol and player state
+	// are read exclusively by the dispatcher task below.
+	auto packet = tfs::net::make_network_message(msg);
+	g_dispatcher.addTask([thisPtr = getThis(), packet = std::move(packet)]() {
+		if (thisPtr->isConnectionExpired()) {
+			return;
+		}
+
+		thisPtr->parsePacketOnDispatcher(*packet);
+	});
+}
+
+void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
+{
+	assert(g_dispatcher.isDispatcherThread() && "ProtocolGame packet state must be handled by the dispatcher");
+
 	if (!acceptPackets || g_game.getGameState() == GAME_STATE_SHUTDOWN || msg.getLength() == 0) {
 		return;
 	}
@@ -1619,7 +1629,13 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 			case 0x96: // say (allows /unspy)
 				break; // allowed — fall through to normal processing
 			default:
-				g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->sendCancelWalk(); });
+				g_dispatcher.addTask([thisPtr = getThis()]() {
+					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+						return;
+					}
+
+					thisPtr->sendCancelWalk();
+				});
 				return; // block all other actions
 		}
 	}
@@ -1646,24 +1662,56 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 				break; // GameClientExtendedPing
 			case 0x6F:
 			case 0x71:
-				g_dispatcher.addTask([thisPtr = getThis(), dir = recvbyte - 0x6F]() { thisPtr->spectatorTurn(dir); });
+				g_dispatcher.addTask([thisPtr = getThis(), dir = recvbyte - 0x6F]() {
+					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+						return;
+					}
+
+					thisPtr->spectatorTurn(dir);
+				});
 				break;
 			case 0x70: // Turn East - used for Next Cast (CTRL + RIGHT)
 				if (canProcessCastSwitch()) {
-					g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->parseSwitchCast(uint8_t(1)); });
+					g_dispatcher.addTask([thisPtr = getThis()]() {
+						if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+							return;
+						}
+
+						thisPtr->parseSwitchCast(uint8_t(1));
+					});
 				}
 				break;
 			case 0x72: // Turn West - used for Prev Cast (CTRL + LEFT)
 				if (canProcessCastSwitch()) {
-					g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->parseSwitchCast(uint8_t(0)); });
+					g_dispatcher.addTask([thisPtr = getThis()]() {
+						if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+							return;
+						}
+
+						thisPtr->parseSwitchCast(uint8_t(0));
+					});
 				}
 				break;
 			case 0x8C: parseLookAt(msg); break; // Look at tile/item
 				break;
 			case 0x96: parseSpectatorSay(msg); break;
-			case 0x97: g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->sendCastChannel(); }); break;
+			case 0x97:
+				g_dispatcher.addTask([thisPtr = getThis()]() {
+					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+						return;
+					}
+
+					thisPtr->sendCastChannel();
+				});
+				break;
 			default:
-				g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->sendCancelWalk(); });
+				g_dispatcher.addTask([thisPtr = getThis()]() {
+					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+						return;
+					}
+
+					thisPtr->sendCancelWalk();
+				});
 				break;
 		}
 		return;
@@ -1936,6 +1984,10 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 		case 0xCF:
 			if (isAstraClient) {
 				g_dispatcher.addTask([thisPtr = getThis()]() {
+					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+						return;
+					}
+
 					thisPtr->sendBlessingWindow();
 				});
 			}
@@ -4053,7 +4105,11 @@ void ProtocolGame::failDllCheck()
 void ProtocolGame::parseDllCheckResponse(NetworkMessage& msg)
 {
 	auto reject = [thisPtr = getThis()]() {
-		g_dispatcher.addTask([thisPtr]() { thisPtr->failDllCheck(); });
+		g_dispatcher.addTask([thisPtr]() {
+			if (!thisPtr->isConnectionExpired()) {
+				thisPtr->failDllCheck();
+			}
+		});
 	};
 
 	if (clientOperatingSystem != CLIENTOS_CUSTOM_DLL || getReadableBytes(msg) < sizeof(uint16_t)) {
@@ -4076,7 +4132,9 @@ void ProtocolGame::parseDllCheckResponse(NetworkMessage& msg)
 
 	const int64_t receivedAt = OTSYS_TIME();
 	g_dispatcher.addTask([thisPtr = getThis(), response = std::move(response), receivedAt]() mutable {
-		thisPtr->validateDllCheckResponse(std::move(response), receivedAt);
+		if (!thisPtr->isConnectionExpired()) {
+			thisPtr->validateDllCheckResponse(std::move(response), receivedAt);
+		}
 	});
 }
 
@@ -5545,7 +5603,13 @@ void ProtocolGame::parseNewPing(NetworkMessage& msg)
 {
 	uint32_t pingId = msg.get<uint32_t>();
 	if (g_game.getGameState() == GAME_STATE_NORMAL && player) {
-		g_dispatcher.addTask([thisPtr = getThis(), pingId]() { thisPtr->sendNewPing(pingId); });
+		g_dispatcher.addTask([thisPtr = getThis(), pingId]() {
+			if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+				return;
+			}
+
+			thisPtr->sendNewPing(pingId);
+		});
 	}
 }
 
@@ -5554,6 +5618,10 @@ void ProtocolGame::parseCustomClientPing(NetworkMessage& msg)
 	const uint32_t pingId = msg.get<uint32_t>();
 	if (g_game.getGameState() == GAME_STATE_NORMAL && player) {
 		g_dispatcher.addTask([thisPtr = getThis(), playerId = player->getID(), pingId]() {
+			if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+				return;
+			}
+
 			g_game.playerReceivePing(playerId);
 			thisPtr->sendCustomClientPing(pingId);
 		});
@@ -5561,7 +5629,7 @@ void ProtocolGame::parseCustomClientPing(NetworkMessage& msg)
 }
 
 // OTCv8 and Mehah
-void ProtocolGame::sendFeatures()
+void ProtocolGame::sendFeatures(bool advertiseAstraItemState)
 {
 	zoneWeatherFeatureEnabled = false;
 
@@ -5608,7 +5676,7 @@ void ProtocolGame::sendFeatures()
 		features[GameFeature::ZoneWeather] = true;
 		zoneWeatherFeatureEnabled = true;
 	}
-	if (canSendAstraItemState()) {
+	if (advertiseAstraItemState && isAstraClient && getBoolean(ConfigManager::ASTRA_ITEM_STATE_ENABLED)) {
 		features[GameFeature::DisplayItemDuration] = true;
 		features[GameFeature::DisplayItemCharges] = true;
 		features[GameFeature::PackedPlayerInventory] = true;
@@ -5725,12 +5793,18 @@ void ProtocolGame::parseSpectatorSay(NetworkMessage& msg)
 		return;
 	}
 
-	g_dispatcher.addTask([thisPtr = getThis(), text = std::string(text), channelId]() { thisPtr->spectatorSay(text, channelId); });
+	g_dispatcher.addTask([thisPtr = getThis(), text = std::string(text), channelId]() {
+		if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+			return;
+		}
+
+		thisPtr->spectatorSay(text, channelId);
+	});
 }
 
 void ProtocolGame::spectatorSay(const std::string text, uint16_t channelId)
 {
-	if (channelId != CHANNEL_CAST || !player->client) {
+	if (channelId != CHANNEL_CAST || !player || !player->client) {
 		return;
 	}
 
@@ -5865,6 +5939,10 @@ void ProtocolGame::parseImbuementDurations(NetworkMessage& msg)
 {
 	const bool open = msg.getByte() != 0;
 	g_dispatcher.addTask([thisPtr = getThis(), open]() {
+		if (thisPtr->isConnectionExpired() || !thisPtr->player) {
+			return;
+		}
+
 		thisPtr->imbuementTrackerOpen = open;
 		if (open) {
 			thisPtr->sendImbuementDurations();

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -763,7 +763,15 @@ std::size_t clientLogin(const Player& player)
 
 } // namespace
 
-ProtocolGame::~ProtocolGame() = default;
+ProtocolGame::~ProtocolGame()
+{
+#ifdef PROTOCOLGAME_BACKLOG_DIAGNOSTICS
+	if (packetBacklog.peak() != 0 || packetBacklog.rejected() != 0) {
+		LOG_NETWORK("[ProtocolGame] Packet backlog summary: peak={} rejected={}", packetBacklog.peak(),
+		            packetBacklog.rejected());
+	}
+#endif
+}
 
 void ProtocolGame::sendBlessingWindow()
 {
@@ -1559,11 +1567,9 @@ void ProtocolGame::disconnectClient(std::string_view message) const
 void ProtocolGame::dispatchCancelMessage(ReturnValue message) const
 {
 	const uint32_t playerId = player ? player->getID() : 0;
-	g_dispatcher.addTask([playerId, message]() {
-		if (auto playerRef = g_game.getPlayerByID(playerId)) {
-			playerRef->sendCancelMessage(message);
-		}
-	});
+	if (auto playerRef = g_game.getPlayerByID(playerId)) {
+		playerRef->sendCancelMessage(message);
+	}
 }
 
 void ProtocolGame::writeToOutputBuffer(const NetworkMessage& msg)
@@ -1578,21 +1584,41 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 		return;
 	}
 
+	auto admission = packetBacklog.tryAcquire();
+	if (!admission) {
+		if (admission.requestDisconnect) {
+			LOG_NETWORK("[ProtocolGame] Packet backlog limit exceeded. Closing connection. pending={} limit={}",
+			            admission.observedPending, packetBacklog.limit());
+			g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->disconnect(); });
+		}
+		return;
+	}
+
+#ifdef PROTOCOLGAME_BACKLOG_DIAGNOSTICS
+	if (admission.newPeak >= 16 &&
+	    (admission.newPeak == packetBacklog.limit() || (admission.newPeak & (admission.newPeak - 1)) == 0)) {
+		LOG_NETWORK("[ProtocolGame] New packet backlog peak: pending={} limit={}", admission.newPeak,
+		            packetBacklog.limit());
+	}
+#endif
+
 	// The ASIO thread only owns the incoming bytes. Protocol and player state
 	// are read exclusively by the dispatcher task below.
 	auto packet = tfs::net::make_network_message(msg);
-	g_dispatcher.addTask([thisPtr = getThis(), packet = std::move(packet)]() {
+	g_dispatcher.addTask([thisPtr = getThis(), packet = std::move(packet), ticket = std::move(admission.ticket)]() mutable {
+		(void)ticket;
 		if (thisPtr->isConnectionExpired()) {
 			return;
 		}
 
-		thisPtr->parsePacketOnDispatcher(*packet);
+		thisPtr->parsePacketOnDispatcher(packet);
 	});
 }
 
-void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
+void ProtocolGame::parsePacketOnDispatcher(NetworkMessage_ptr& packet)
 {
 	assert(g_dispatcher.isDispatcherThread() && "ProtocolGame packet state must be handled by the dispatcher");
+	NetworkMessage& msg = *packet;
 
 	if (!acceptPackets || g_game.getGameState() == GAME_STATE_SHUTDOWN || msg.getLength() == 0) {
 		return;
@@ -1629,25 +1655,19 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			case 0x96: // say (allows /unspy)
 				break; // allowed — fall through to normal processing
 			default:
-				g_dispatcher.addTask([thisPtr = getThis()]() {
-					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-						return;
-					}
-
-					thisPtr->sendCancelWalk();
-				});
+				sendCancelWalk();
 				return; // block all other actions
 		}
 	}
 
 	if (isSpectator) {
 		switch (recvbyte) {
-			case 0x14: g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->disconnect(); }); break;
+			case 0x14: disconnect(); break;
 			case 0x1E:
 				if (clientOperatingSystem == CLIENTOS_CUSTOM_DLL) {
 					parseCustomClientPing(msg);
 				} else {
-					g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerReceivePing(playerID); });
+					g_game.playerReceivePing(player->getID());
 				}
 				break;
 			case 0x32:
@@ -1662,76 +1682,44 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 				break; // GameClientExtendedPing
 			case 0x6F:
 			case 0x71:
-				g_dispatcher.addTask([thisPtr = getThis(), dir = recvbyte - 0x6F]() {
-					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-						return;
-					}
-
-					thisPtr->spectatorTurn(dir);
-				});
+				spectatorTurn(recvbyte - 0x6F);
 				break;
 			case 0x70: // Turn East - used for Next Cast (CTRL + RIGHT)
 				if (canProcessCastSwitch()) {
-					g_dispatcher.addTask([thisPtr = getThis()]() {
-						if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-							return;
-						}
-
-						thisPtr->parseSwitchCast(uint8_t(1));
-					});
+					parseSwitchCast(uint8_t(1));
 				}
 				break;
 			case 0x72: // Turn West - used for Prev Cast (CTRL + LEFT)
 				if (canProcessCastSwitch()) {
-					g_dispatcher.addTask([thisPtr = getThis()]() {
-						if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-							return;
-						}
-
-						thisPtr->parseSwitchCast(uint8_t(0));
-					});
+					parseSwitchCast(uint8_t(0));
 				}
 				break;
 			case 0x8C: parseLookAt(msg); break; // Look at tile/item
 				break;
 			case 0x96: parseSpectatorSay(msg); break;
 			case 0x97:
-				g_dispatcher.addTask([thisPtr = getThis()]() {
-					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-						return;
-					}
-
-					thisPtr->sendCastChannel();
-				});
+				sendCastChannel();
 				break;
 			default:
-				g_dispatcher.addTask([thisPtr = getThis()]() {
-					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-						return;
-					}
-
-					thisPtr->sendCancelWalk();
-				});
+				sendCancelWalk();
 				break;
 		}
 		return;
 	}
 
-	auto dispatchPlayerNetworkMessage = [&](uint8_t byte, NetworkMessage& message) {
-		g_dispatcher.addTask([=, playerID = player->getID(), message = tfs::net::make_network_message(message)]() {
-			g_game.parsePlayerNetworkMessage(playerID, byte, message);
-		});
+	auto handlePlayerNetworkMessage = [&](uint8_t byte) {
+		g_game.parsePlayerNetworkMessage(player->getID(), byte, packet);
 	};
 
 	switch (recvbyte) {
 		case 0x14:
-			g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->logout(true, false); });
+			logout(true, false);
 			break;
 		case 0x1E:
 			if (clientOperatingSystem == CLIENTOS_CUSTOM_DLL) {
 				parseCustomClientPing(msg);
 			} else {
-				g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerReceivePing(playerID); });
+				g_game.playerReceivePing(player->getID());
 			}
 			break;
 		case 0x32:
@@ -1765,47 +1753,43 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			parseAutoWalk(msg);
 			break;
 		case 0x65:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_NORTH); });
+			g_game.playerMove(player->getID(), DIRECTION_NORTH);
 			break;
 		case 0x66:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_EAST); });
+			g_game.playerMove(player->getID(), DIRECTION_EAST);
 			break;
 		case 0x67:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_SOUTH); });
+			g_game.playerMove(player->getID(), DIRECTION_SOUTH);
 			break;
 		case 0x68:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_WEST); });
+			g_game.playerMove(player->getID(), DIRECTION_WEST);
 			break;
 		case 0x69:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerStopAutoWalk(playerID); });
+			g_game.playerStopAutoWalk(player->getID());
 			break;
 		case 0x6A:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_NORTHEAST); });
+			g_game.playerMove(player->getID(), DIRECTION_NORTHEAST);
 			break;
 		case 0x6B:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_SOUTHEAST); });
+			g_game.playerMove(player->getID(), DIRECTION_SOUTHEAST);
 			break;
 		case 0x6C:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_SOUTHWEST); });
+			g_game.playerMove(player->getID(), DIRECTION_SOUTHWEST);
 			break;
 		case 0x6D:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerMove(playerID, DIRECTION_NORTHWEST); });
+			g_game.playerMove(player->getID(), DIRECTION_NORTHWEST);
 			break;
 		case 0x6F:
-			g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-			                     [playerID = player->getID()]() { g_game.playerTurn(playerID, DIRECTION_NORTH); });
+			g_game.playerTurn(player->getID(), DIRECTION_NORTH);
 			break;
 		case 0x70:
-			g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-			                     [playerID = player->getID()]() { g_game.playerTurn(playerID, DIRECTION_EAST); });
+			g_game.playerTurn(player->getID(), DIRECTION_EAST);
 			break;
 		case 0x71:
-			g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-			                     [playerID = player->getID()]() { g_game.playerTurn(playerID, DIRECTION_SOUTH); });
+			g_game.playerTurn(player->getID(), DIRECTION_SOUTH);
 			break;
 		case 0x72:
-			g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-			                     [playerID = player->getID()]() { g_game.playerTurn(playerID, DIRECTION_WEST); });
+			g_game.playerTurn(player->getID(), DIRECTION_WEST);
 			break;
 		case 0x77:
 			if (isAstraClient) {
@@ -1827,7 +1811,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			parsePlayerSale(msg);
 			break;
 		case 0x7C:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerCloseShop(playerID); });
+			g_game.playerCloseShop(player->getID());
 			break;
 		case 0x7D:
 			parseRequestTrade(msg);
@@ -1836,10 +1820,10 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			parseLookInTrade(msg);
 			break;
 		case 0x7F:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerAcceptTrade(playerID); });
+			g_game.playerAcceptTrade(player->getID());
 			break;
 		case 0x80:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerCloseTrade(playerID); });
+			g_game.playerCloseTrade(player->getID());
 			break;
 		case 0x82:
 			parseUseItem(msg);
@@ -1908,7 +1892,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		case 0x97:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerRequestChannels(playerID); });
+			g_game.playerRequestChannels(player->getID());
 			break;
 
 		case 0x98:
@@ -1924,7 +1908,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		case 0x9E:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerCloseNpcChannel(playerID); });
+			g_game.playerCloseNpcChannel(player->getID());
 			break;
 
 		case 0x9F:
@@ -1958,7 +1942,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		case 0xA7:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerLeaveParty(playerID); });
+			g_game.playerLeaveParty(player->getID());
 			break;
 
 		case 0xA8:
@@ -1966,7 +1950,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		case 0xAA:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerCreatePrivateChannel(playerID); });
+			g_game.playerCreatePrivateChannel(player->getID());
 			break;
 
 		case 0xAB:
@@ -1978,18 +1962,12 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		case 0xBE:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerCancelAttackAndFollow(playerID); });
+			g_game.playerCancelAttackAndFollow(player->getID());
 			break;
 
 		case 0xCF:
 			if (isAstraClient) {
-				g_dispatcher.addTask([thisPtr = getThis()]() {
-					if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-						return;
-					}
-
-					thisPtr->sendBlessingWindow();
-				});
+				sendBlessingWindow();
 			}
 			break;
 
@@ -2024,15 +2002,15 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 
 		case 0xD2:
 			if (isHirelingOutfitRequestPacket(msg, isAstraClient)) {
-				dispatchPlayerNetworkMessage(recvbyte, msg);
+				handlePlayerNetworkMessage(recvbyte);
 			} else {
-				g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerRequestOutfit(playerID); });
+				g_game.playerRequestOutfit(player->getID());
 			}
 			break;
 
 		case 0xD3:
 			if (isHirelingOutfitChangePacket(msg, isAstraClient)) {
-				dispatchPlayerNetworkMessage(recvbyte, msg);
+				handlePlayerNetworkMessage(recvbyte);
 			} else {
 				parseSetOutfit(msg);
 			}
@@ -2051,7 +2029,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		case 0xE7: /* thank you / custom wheel gem action */
-			dispatchPlayerNetworkMessage(recvbyte, msg);
+			handlePlayerNetworkMessage(recvbyte);
 			break;
 
 		case 0xF2:
@@ -2065,7 +2043,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 		case 0xFA: /* custom store history */
 		case 0xFB: /* custom store open */
 		case 0xFC: /* custom store buy */
-			dispatchPlayerNetworkMessage(recvbyte, msg);
+			handlePlayerNetworkMessage(recvbyte);
 			break;
 
 		case 0xF9:
@@ -2073,7 +2051,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage& msg)
 			break;
 
 		default:
-			dispatchPlayerNetworkMessage(recvbyte, msg);
+			handlePlayerNetworkMessage(recvbyte);
 			break;
 	}
 
@@ -2096,11 +2074,7 @@ void ProtocolGame::parseCharacterBazaar(NetworkMessage& msg)
 			skipUnreadBytes(msg);
 			return;
 		}
-		g_dispatcher.addTask([playerId = player->getID()]() {
-			if (auto playerRef = g_game.getPlayerByID(playerId)) {
-				CharacterBazaar::sendRequirements(playerRef.get());
-			}
-		});
+		CharacterBazaar::sendRequirements(player.get());
 		return;
 	}
 
@@ -2118,13 +2092,9 @@ void ProtocolGame::parseCharacterBazaar(NetworkMessage& msg)
 		return;
 	}
 
-	g_dispatcher.addTask([playerId = player->getID(), startPrice, duration, description]() {
-		if (auto playerRef = g_game.getPlayerByID(playerId)) {
-			std::string result;
-			const bool success = CharacterBazaar::createAuction(playerRef.get(), startPrice, duration, description, result);
-			CharacterBazaar::sendCreateResult(playerRef.get(), success, result);
-		}
-	});
+	std::string result;
+	const bool success = CharacterBazaar::createAuction(player.get(), startPrice, duration, description, result);
+	CharacterBazaar::sendCreateResult(player.get(), success, result);
 }
 
 void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
@@ -2345,35 +2315,31 @@ bool ProtocolGame::canSee(int32_t x, int32_t y, int32_t z) const
 void ProtocolGame::parseChannelInvite(NetworkMessage& msg)
 {
 	auto name = msg.getString();
-	g_dispatcher.addTask(
-	    [playerID = player->getID(), name = std::string{name}]() { g_game.playerChannelInvite(playerID, name); });
+	g_game.playerChannelInvite(player->getID(), name);
 }
 
 void ProtocolGame::parseChannelExclude(NetworkMessage& msg)
 {
 	auto name = msg.getString();
-	g_dispatcher.addTask(
-	    [=, playerID = player->getID(), name = std::string{name}]() { g_game.playerChannelExclude(playerID, name); });
+	g_game.playerChannelExclude(player->getID(), name);
 }
 
 void ProtocolGame::parseOpenChannel(NetworkMessage& msg)
 {
 	uint16_t channelId = msg.get<uint16_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerOpenChannel(playerID, channelId); });
+	g_game.playerOpenChannel(player->getID(), channelId);
 }
 
 void ProtocolGame::parseCloseChannel(NetworkMessage& msg)
 {
 	uint16_t channelId = msg.get<uint16_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerCloseChannel(playerID, channelId); });
+	g_game.playerCloseChannel(player->getID(), channelId);
 }
 
 void ProtocolGame::parseOpenPrivateChannel(NetworkMessage& msg)
 {
 	auto receiver = msg.getString();
-	g_dispatcher.addTask([playerID = player->getID(), receiver = std::string{receiver}]() {
-		g_game.playerOpenPrivateChannel(playerID, receiver);
-	});
+	g_game.playerOpenPrivateChannel(player->getID(), std::move(receiver));
 }
 
 void ProtocolGame::parseAutoWalk(NetworkMessage& msg)
@@ -2424,8 +2390,7 @@ void ProtocolGame::parseAutoWalk(NetworkMessage& msg)
 		return;
 	}
 
-	g_dispatcher.addTask(
-	    [playerID = player->getID(), path = std::move(path)]() { g_game.playerAutoWalk(playerID, path); });
+	g_game.playerAutoWalk(player->getID(), path);
 }
 
 void ProtocolGame::parseSetOutfit(NetworkMessage& msg)
@@ -2459,7 +2424,7 @@ void ProtocolGame::parseSetOutfit(NetworkMessage& msg)
 		newOutfit.lookFamiliar =
 		    familiar && requestedFamiliar == familiar->lookType ? requestedFamiliar : 0;
 	}
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerChangeOutfit(playerID, newOutfit); });
+	g_game.playerChangeOutfit(player->getID(), newOutfit);
 }
 
 void ProtocolGame::parseInspectionObject(NetworkMessage& msg)
@@ -2475,9 +2440,7 @@ void ProtocolGame::parseInspectionObject(NetworkMessage& msg)
 		}
 
 		const Position position = msg.getPosition();
-		g_dispatcher.addTask([playerID = player->getID(), position]() {
-			g_game.playerInspectItem(playerID, position);
-		});
+		g_game.playerInspectItem(player->getID(), position);
 		return;
 	}
 
@@ -2492,9 +2455,7 @@ void ProtocolGame::parseInspectionObject(NetworkMessage& msg)
 
 	const uint16_t itemId = msg.get<uint16_t>();
 	const uint8_t itemCount = msg.getByte();
-	g_dispatcher.addTask([playerID = player->getID(), itemId, itemCount, inspectionType]() {
-		g_game.playerInspectItem(playerID, itemId, itemCount, inspectionType);
-	});
+	g_game.playerInspectItem(player->getID(), itemId, itemCount, inspectionType);
 }
 
 void ProtocolGame::parseSetMonsterPodium(NetworkMessage& msg)
@@ -2511,11 +2472,8 @@ void ProtocolGame::parseSetMonsterPodium(NetworkMessage& msg)
 	const bool podiumVisible = msg.getByte() != 0;
 	const bool creatureVisible = msg.getByte() != 0;
 
-	g_dispatcher.addTask([playerID = player->getID(), raceId, position, stackPos, itemId, direction,
-	                      podiumVisible, creatureVisible]() {
-		g_game.playerSetMonsterPodium(playerID, raceId, position, stackPos, itemId, direction,
-		                              podiumVisible, creatureVisible);
-	});
+	g_game.playerSetMonsterPodium(player->getID(), raceId, position, stackPos, itemId, direction, podiumVisible,
+	                              creatureVisible);
 }
 
 void ProtocolGame::parseUseItem(NetworkMessage& msg)
@@ -2529,9 +2487,7 @@ void ProtocolGame::parseUseItem(NetworkMessage& msg)
 	uint16_t spriteId = msg.get<uint16_t>();
 	uint8_t stackpos = msg.getByte();
 	uint8_t index = msg.getByte();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerUseItem(playerID, pos, stackpos, index, spriteId);
-	});
+	g_game.playerUseItem(player->getID(), pos, stackpos, index, spriteId);
 }
 
 void ProtocolGame::parseBrowseField(NetworkMessage& msg)
@@ -2541,9 +2497,7 @@ void ProtocolGame::parseBrowseField(NetworkMessage& msg)
 	}
 
 	const Position pos = msg.getPosition();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [playerID = player->getID(), pos]() {
-		g_game.playerBrowseField(playerID, pos);
-	});
+	g_game.playerBrowseField(player->getID(), pos);
 }
 
 void ProtocolGame::parseSeekInContainer(NetworkMessage& msg)
@@ -2554,9 +2508,7 @@ void ProtocolGame::parseSeekInContainer(NetworkMessage& msg)
 
 	const uint8_t containerId = msg.getByte();
 	const uint16_t index = msg.get<uint16_t>();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [playerID = player->getID(), containerId, index]() {
-		g_game.playerSeekInContainer(playerID, containerId, index);
-	});
+	g_game.playerSeekInContainer(player->getID(), containerId, index);
 }
 
 void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
@@ -2591,9 +2543,7 @@ void ProtocolGame::parseHotkeyEquip(NetworkMessage& msg)
 		tier = msg.getByte();
 	}
 
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [playerID = player->getID(), itemId, hasTier, tier]() {
-		g_game.playerEquipItem(playerID, itemId, hasTier, tier);
-	});
+	g_game.playerEquipItem(player->getID(), itemId, hasTier, tier);
 }
 
 void ProtocolGame::parseUseItemEx(NetworkMessage& msg)
@@ -2609,9 +2559,7 @@ void ProtocolGame::parseUseItemEx(NetworkMessage& msg)
 	Position toPos = msg.getPosition();
 	uint16_t toSpriteId = msg.get<uint16_t>();
 	uint8_t toStackPos = msg.getByte();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerUseItemEx(playerID, fromPos, fromStackPos, fromSpriteId, toPos, toStackPos, toSpriteId);
-	});
+	g_game.playerUseItemEx(player->getID(), fromPos, fromStackPos, fromSpriteId, toPos, toStackPos, toSpriteId);
 }
 
 void ProtocolGame::parseUseWithCreature(NetworkMessage& msg)
@@ -2625,27 +2573,25 @@ void ProtocolGame::parseUseWithCreature(NetworkMessage& msg)
 	uint16_t spriteId = msg.get<uint16_t>();
 	uint8_t fromStackPos = msg.getByte();
 	uint32_t creatureId = msg.get<uint32_t>();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerUseWithCreature(playerID, fromPos, fromStackPos, creatureId, spriteId);
-	});
+	g_game.playerUseWithCreature(player->getID(), fromPos, fromStackPos, creatureId, spriteId);
 }
 
 void ProtocolGame::parseCloseContainer(NetworkMessage& msg)
 {
 	uint8_t cid = msg.getByte();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerCloseContainer(playerID, cid); });
+	g_game.playerCloseContainer(player->getID(), cid);
 }
 
 void ProtocolGame::parseUpArrowContainer(NetworkMessage& msg)
 {
 	uint8_t cid = msg.getByte();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerMoveUpContainer(playerID, cid); });
+	g_game.playerMoveUpContainer(player->getID(), cid);
 }
 
 void ProtocolGame::parseUpdateContainer(NetworkMessage& msg)
 {
 	uint8_t cid = msg.getByte();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerUpdateContainer(playerID, cid); });
+	g_game.playerUpdateContainer(player->getID(), cid);
 }
 
 void ProtocolGame::parseQuickLoot(NetworkMessage& msg)
@@ -2663,7 +2609,7 @@ void ProtocolGame::parseQuickLoot(NetworkMessage& msg)
 	Position pos = msg.getPosition();
 
 	if (variant == 2) {
-		g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerLootNearby(playerID); });
+		g_game.playerLootNearby(player->getID());
 		skipUnreadBytes(msg);
 		return;
 	}
@@ -2675,9 +2621,7 @@ void ProtocolGame::parseQuickLoot(NetworkMessage& msg)
 	uint16_t itemId = msg.get<uint16_t>();
 	uint8_t stackpos = msg.getByte();
 	const bool lootAllCorpses = variant == 1;
-	g_dispatcher.addTask([=, playerID = player->getID()]() {
-		g_game.playerQuickLoot(playerID, pos, itemId, stackpos, lootAllCorpses);
-	});
+	g_game.playerQuickLoot(player->getID(), pos, itemId, stackpos, lootAllCorpses);
 }
 
 void ProtocolGame::parseLootContainer(NetworkMessage& msg)
@@ -2704,9 +2648,7 @@ void ProtocolGame::parseLootContainer(NetworkMessage& msg)
 			uint16_t itemId = msg.get<uint16_t>();
 			uint8_t stackpos = msg.getByte();
 			const bool isLootContainer = action == 0;
-			g_dispatcher.addTask([=, playerID = player->getID()]() {
-				g_game.playerSetManagedLootContainer(playerID, category, pos, itemId, stackpos, isLootContainer);
-			});
+			g_game.playerSetManagedLootContainer(player->getID(), category, pos, itemId, stackpos, isLootContainer);
 			break;
 		}
 		case 1:
@@ -2717,9 +2659,7 @@ void ProtocolGame::parseLootContainer(NetworkMessage& msg)
 
 			auto category = static_cast<ObjectCategory_t>(msg.getByte());
 			const bool isLootContainer = action == 1;
-			g_dispatcher.addTask([=, playerID = player->getID()]() {
-				g_game.playerClearManagedLootContainer(playerID, category, isLootContainer);
-			});
+			g_game.playerClearManagedLootContainer(player->getID(), category, isLootContainer);
 			break;
 		}
 		case 2:
@@ -2730,9 +2670,7 @@ void ProtocolGame::parseLootContainer(NetworkMessage& msg)
 
 			auto category = static_cast<ObjectCategory_t>(msg.getByte());
 			const bool isLootContainer = action == 2;
-			g_dispatcher.addTask([=, playerID = player->getID()]() {
-				g_game.playerOpenManagedLootContainer(playerID, category, isLootContainer);
-			});
+			g_game.playerOpenManagedLootContainer(player->getID(), category, isLootContainer);
 			break;
 		}
 		case 3: {
@@ -2741,9 +2679,7 @@ void ProtocolGame::parseLootContainer(NetworkMessage& msg)
 			}
 
 			bool useMainAsFallback = msg.getByte() == 1;
-			g_dispatcher.addTask([=, playerID = player->getID()]() {
-				g_game.playerSetQuickLootFallback(playerID, useMainAsFallback);
-			});
+			g_game.playerSetQuickLootFallback(player->getID(), useMainAsFallback);
 			break;
 		}
 		default:
@@ -2783,9 +2719,7 @@ void ProtocolGame::parseQuickLootBlackWhitelist(NetworkMessage& msg)
 		listedItems.push_back(msg.get<uint16_t>());
 	}
 
-	g_dispatcher.addTask([=, playerID = player->getID(), listedItems = std::move(listedItems)]() mutable {
-		g_game.playerQuickLootBlackWhitelist(playerID, filter, std::move(listedItems));
-	});
+	g_game.playerQuickLootBlackWhitelist(player->getID(), filter, std::move(listedItems));
 }
 
 void ProtocolGame::parseThrow(NetworkMessage& msg)
@@ -2802,9 +2736,7 @@ void ProtocolGame::parseThrow(NetworkMessage& msg)
 	uint8_t count = msg.getByte();
 
 	if (toPos != fromPos) {
-		g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-			g_game.playerMoveThing(playerID, fromPos, spriteId, fromStackpos, toPos, count);
-		});
+		g_game.playerMoveThing(player->getID(), fromPos, spriteId, fromStackpos, toPos, count);
 	}
 }
 
@@ -2822,15 +2754,13 @@ void ProtocolGame::parseLookAt(NetworkMessage& msg)
 		return;
 	}
 
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-	                     [=, playerID = player->getID()]() { g_game.playerLookAt(playerID, pos, stackpos); });
+	g_game.playerLookAt(player->getID(), pos, stackpos);
 }
 
 void ProtocolGame::parseLookInBattleList(NetworkMessage& msg)
 {
 	uint32_t creatureId = msg.get<uint32_t>();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-	                     [=, playerID = player->getID()]() { g_game.playerLookInBattleList(playerID, creatureId); });
+	g_game.playerLookInBattleList(player->getID(), creatureId);
 }
 
 void ProtocolGame::parseSay(NetworkMessage& msg)
@@ -2864,17 +2794,11 @@ void ProtocolGame::parseSay(NetworkMessage& msg)
 	}
 
 	if (player->isAccountManager()) {
-		g_dispatcher.addTask([playerID = player->getID(), text = std::string{text}]() {
-			if (auto playerRef = g_game.getPlayerByID(playerID)) {
-				playerRef->manageAccount(text);
-			}
-		});
+		player->manageAccount(text);
 		return;
 	}
 
-	g_dispatcher.addTask([=, playerID = player->getID(), receiver = std::string{receiver}, text = std::string{text}]() {
-		g_game.playerSay(playerID, channelId, type, receiver, text, forceCastOnFoot);
-	});
+	g_game.playerSay(player->getID(), channelId, type, receiver, text, forceCastOnFoot);
 }
 
 void ProtocolGame::parseAttack(NetworkMessage& msg)
@@ -2888,7 +2812,7 @@ void ProtocolGame::parseAttack(NetworkMessage& msg)
 	if (isMehah) {
 		msg.get<uint32_t>(); // attack sequence
 	}
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerSetAttackedCreature(playerID, creatureId); });
+	g_game.playerSetAttackedCreature(player->getID(), creatureId);
 }
 
 void ProtocolGame::parseFollow(NetworkMessage& msg)
@@ -2897,16 +2821,14 @@ void ProtocolGame::parseFollow(NetworkMessage& msg)
 	if (isMehah) {
 		msg.get<uint32_t>(); // follow sequence
 	}
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerFollowCreature(playerID, creatureId); });
+	g_game.playerFollowCreature(player->getID(), creatureId);
 }
 
 void ProtocolGame::parseTextWindow(NetworkMessage& msg)
 {
 	uint32_t windowTextID = msg.get<uint32_t>();
 	auto newText = msg.getString();
-	g_dispatcher.addTask([playerID = player->getID(), windowTextID, newText = std::string{newText}]() {
-		g_game.playerWriteItem(playerID, windowTextID, newText);
-	});
+	g_game.playerWriteItem(player->getID(), windowTextID, newText);
 }
 
 void ProtocolGame::parseHouseWindow(NetworkMessage& msg)
@@ -2914,17 +2836,14 @@ void ProtocolGame::parseHouseWindow(NetworkMessage& msg)
 	uint8_t doorId = msg.getByte();
 	uint32_t id = msg.get<uint32_t>();
 	auto text = msg.getString();
-	g_dispatcher.addTask([=, playerID = player->getID(), text = std::string{text}]() {
-		g_game.playerUpdateHouseWindow(playerID, doorId, id, text);
-	});
+	g_game.playerUpdateHouseWindow(player->getID(), doorId, id, text);
 }
 
 void ProtocolGame::parseLookInShop(NetworkMessage& msg)
 {
 	uint16_t id = msg.get<uint16_t>();
 	uint8_t count = msg.getByte();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION,
-	                     [=, playerID = player->getID()]() { g_game.playerLookInShop(playerID, id, count); });
+	g_game.playerLookInShop(player->getID(), id, count);
 }
 
 void ProtocolGame::parsePlayerPurchase(NetworkMessage& msg)
@@ -2934,9 +2853,7 @@ void ProtocolGame::parsePlayerPurchase(NetworkMessage& msg)
 	uint8_t amount = msg.getByte();
 	bool ignoreCap = msg.getByte() != 0;
 	bool inBackpacks = msg.getByte() != 0;
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerPurchaseItem(playerID, id, count, amount, ignoreCap, inBackpacks);
-	});
+	g_game.playerPurchaseItem(player->getID(), id, count, amount, ignoreCap, inBackpacks);
 }
 
 void ProtocolGame::parsePlayerSale(NetworkMessage& msg)
@@ -2945,9 +2862,7 @@ void ProtocolGame::parsePlayerSale(NetworkMessage& msg)
 	uint8_t count = msg.getByte();
 	uint8_t amount = msg.getByte();
 	bool ignoreEquipped = msg.getByte() != 0;
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerSellItem(playerID, id, count, amount, ignoreEquipped);
-	});
+	g_game.playerSellItem(player->getID(), id, count, amount, ignoreEquipped);
 }
 
 void ProtocolGame::parseRequestTrade(NetworkMessage& msg)
@@ -2961,30 +2876,26 @@ void ProtocolGame::parseRequestTrade(NetworkMessage& msg)
 	uint16_t spriteId = msg.get<uint16_t>();
 	uint8_t stackpos = msg.getByte();
 	uint32_t playerId = msg.get<uint32_t>();
-	g_dispatcher.addTask(
-	    [=, playerID = player->getID()]() { g_game.playerRequestTrade(playerID, pos, stackpos, playerId, spriteId); });
+	g_game.playerRequestTrade(player->getID(), pos, stackpos, playerId, spriteId);
 }
 
 void ProtocolGame::parseLookInTrade(NetworkMessage& msg)
 {
 	bool counterOffer = (msg.getByte() == 0x01);
 	uint8_t index = msg.getByte();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerLookInTrade(playerID, counterOffer, index);
-	});
+	g_game.playerLookInTrade(player->getID(), counterOffer, index);
 }
 
 void ProtocolGame::parseAddVip(NetworkMessage& msg)
 {
 	auto name = msg.getString();
-	g_dispatcher.addTask(
-	    [playerID = player->getID(), name = std::string{name}]() { g_game.playerRequestAddVip(playerID, name); });
+	g_game.playerRequestAddVip(player->getID(), name);
 }
 
 void ProtocolGame::parseRemoveVip(NetworkMessage& msg)
 {
 	uint32_t guid = msg.get<uint32_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerRequestRemoveVip(playerID, guid); });
+	g_game.playerRequestRemoveVip(player->getID(), guid);
 }
 
 void ProtocolGame::parseRotateItem(NetworkMessage& msg)
@@ -2992,9 +2903,7 @@ void ProtocolGame::parseRotateItem(NetworkMessage& msg)
 	Position pos = msg.getPosition();
 	uint16_t spriteId = msg.get<uint16_t>();
 	uint8_t stackpos = msg.getByte();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerRotateItem(playerID, pos, stackpos, spriteId);
-	});
+	g_game.playerRotateItem(player->getID(), pos, stackpos, spriteId);
 }
 
 void ProtocolGame::parseWrapableItem(NetworkMessage& msg)
@@ -3007,9 +2916,7 @@ void ProtocolGame::parseWrapableItem(NetworkMessage& msg)
 	Position pos = msg.getPosition();
 	uint16_t spriteId = msg.get<uint16_t>();
 	uint8_t stackpos = msg.getByte();
-	g_dispatcher.addTask(DISPATCHER_TASK_EXPIRATION, [=, playerID = player->getID()]() {
-		g_game.playerWrapableItem(playerID, pos, stackpos, spriteId);
-	});
+	g_game.playerWrapableItem(player->getID(), pos, stackpos, spriteId);
 }
 
 void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
@@ -3045,49 +2952,43 @@ void ProtocolGame::parseRuleViolationReport(NetworkMessage& msg)
 		}
 	}
 
-	g_dispatcher.addTask([=, playerID = player->getID(), targetName = std::string{targetName},
-	                      comment = std::string{comment}, translation = std::string{translation}]() {
-		g_game.playerReportRuleViolation(playerID, targetName, reportType, reportReason, comment, translation);
-	});
+	g_game.playerReportRuleViolation(player->getID(), targetName, reportType, reportReason, comment, translation);
 }
 
 void ProtocolGame::parseBugReport(NetworkMessage& msg)
 {
 	auto message = msg.getString();
-	g_dispatcher.addTask([=, playerID = player->getID(), message = std::string{message}]() {
-		g_game.playerReportBug(playerID, message);
-	});
+	g_game.playerReportBug(player->getID(), message);
 }
 
 void ProtocolGame::parseInviteToParty(NetworkMessage& msg)
 {
 	uint32_t targetId = msg.get<uint32_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerInviteToParty(playerID, targetId); });
+	g_game.playerInviteToParty(player->getID(), targetId);
 }
 
 void ProtocolGame::parseJoinParty(NetworkMessage& msg)
 {
 	uint32_t targetId = msg.get<uint32_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerJoinParty(playerID, targetId); });
+	g_game.playerJoinParty(player->getID(), targetId);
 }
 
 void ProtocolGame::parseRevokePartyInvite(NetworkMessage& msg)
 {
 	uint32_t targetId = msg.get<uint32_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerRevokePartyInvitation(playerID, targetId); });
+	g_game.playerRevokePartyInvitation(player->getID(), targetId);
 }
 
 void ProtocolGame::parsePassPartyLeadership(NetworkMessage& msg)
 {
 	uint32_t targetId = msg.get<uint32_t>();
-	g_dispatcher.addTask([=, playerID = player->getID()]() { g_game.playerPassPartyLeadership(playerID, targetId); });
+	g_game.playerPassPartyLeadership(player->getID(), targetId);
 }
 
 void ProtocolGame::parseEnableSharedPartyExperience(NetworkMessage& msg)
 {
 	bool sharedExpActive = msg.getByte() == 1;
-	g_dispatcher.addTask(
-	    [=, playerID = player->getID()]() { g_game.playerEnableSharedPartyExperience(playerID, sharedExpActive); });
+	g_game.playerEnableSharedPartyExperience(player->getID(), sharedExpActive);
 }
 
 void ProtocolGame::parseModalWindowAnswer(NetworkMessage& msg)
@@ -3099,8 +3000,7 @@ void ProtocolGame::parseModalWindowAnswer(NetworkMessage& msg)
 	uint32_t id = msg.get<uint32_t>();
 	uint8_t button = msg.getByte();
 	uint8_t choice = msg.getByte();
-	g_dispatcher.addTask(
-	    [=, playerID = player->getID()]() { g_game.playerAnswerModalWindow(playerID, id, button, choice); });
+	g_game.playerAnswerModalWindow(player->getID(), id, button, choice);
 }
 
 // Send methods
@@ -4104,13 +4004,7 @@ void ProtocolGame::failDllCheck()
 
 void ProtocolGame::parseDllCheckResponse(NetworkMessage& msg)
 {
-	auto reject = [thisPtr = getThis()]() {
-		g_dispatcher.addTask([thisPtr]() {
-			if (!thisPtr->isConnectionExpired()) {
-				thisPtr->failDllCheck();
-			}
-		});
-	};
+	auto reject = [this]() { failDllCheck(); };
 
 	if (clientOperatingSystem != CLIENTOS_CUSTOM_DLL || getReadableBytes(msg) < sizeof(uint16_t)) {
 		reject();
@@ -4131,11 +4025,7 @@ void ProtocolGame::parseDllCheckResponse(NetworkMessage& msg)
 	}
 
 	const int64_t receivedAt = OTSYS_TIME();
-	g_dispatcher.addTask([thisPtr = getThis(), response = std::move(response), receivedAt]() mutable {
-		if (!thisPtr->isConnectionExpired()) {
-			thisPtr->validateDllCheckResponse(std::move(response), receivedAt);
-		}
-	});
+	validateDllCheckResponse(std::move(response), receivedAt);
 }
 
 void ProtocolGame::validateDllCheckResponse(std::string response, int64_t receivedAt)
@@ -5562,14 +5452,11 @@ void ProtocolGame::parseExtendedOpcode(NetworkMessage& msg)
 	const auto helperStateStorageKey = getHelperStateStorageKey(opcode);
 
 	// process additional opcodes via lua script event
-	g_dispatcher.addTask([=, playerID = player->getID(), buffer = std::string{buffer}]() {
-		if (helperStateStorageKey) {
-			if (auto playerRef = g_game.getPlayerByID(playerID)) {
-				playerRef->setStorageValue(*helperStateStorageKey, std::optional<int64_t>{isEnabledHelperBuffer(buffer) ? 1 : 0});
-			}
-		}
-		g_game.parsePlayerExtendedOpcode(playerID, opcode, buffer);
-	});
+	if (helperStateStorageKey) {
+		player->setStorageValue(*helperStateStorageKey,
+		                        std::optional<int64_t>{isEnabledHelperBuffer(buffer) ? 1 : 0});
+	}
+	g_game.parsePlayerExtendedOpcode(player->getID(), opcode, buffer);
 }
 
 void ProtocolGame::sendNewPing(uint32_t pingId)
@@ -5603,13 +5490,7 @@ void ProtocolGame::parseNewPing(NetworkMessage& msg)
 {
 	uint32_t pingId = msg.get<uint32_t>();
 	if (g_game.getGameState() == GAME_STATE_NORMAL && player) {
-		g_dispatcher.addTask([thisPtr = getThis(), pingId]() {
-			if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-				return;
-			}
-
-			thisPtr->sendNewPing(pingId);
-		});
+		sendNewPing(pingId);
 	}
 }
 
@@ -5617,14 +5498,8 @@ void ProtocolGame::parseCustomClientPing(NetworkMessage& msg)
 {
 	const uint32_t pingId = msg.get<uint32_t>();
 	if (g_game.getGameState() == GAME_STATE_NORMAL && player) {
-		g_dispatcher.addTask([thisPtr = getThis(), playerId = player->getID(), pingId]() {
-			if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-				return;
-			}
-
-			g_game.playerReceivePing(playerId);
-			thisPtr->sendCustomClientPing(pingId);
-		});
+		g_game.playerReceivePing(player->getID());
+		sendCustomClientPing(pingId);
 	}
 }
 
@@ -5793,13 +5668,7 @@ void ProtocolGame::parseSpectatorSay(NetworkMessage& msg)
 		return;
 	}
 
-	g_dispatcher.addTask([thisPtr = getThis(), text = std::string(text), channelId]() {
-		if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-			return;
-		}
-
-		thisPtr->spectatorSay(text, channelId);
-	});
+	spectatorSay(text, channelId);
 }
 
 void ProtocolGame::spectatorSay(const std::string text, uint16_t channelId)
@@ -5938,16 +5807,10 @@ void ProtocolGame::parseSwitchCast(uint8_t direction)
 void ProtocolGame::parseImbuementDurations(NetworkMessage& msg)
 {
 	const bool open = msg.getByte() != 0;
-	g_dispatcher.addTask([thisPtr = getThis(), open]() {
-		if (thisPtr->isConnectionExpired() || !thisPtr->player) {
-			return;
-		}
-
-		thisPtr->imbuementTrackerOpen = open;
-		if (open) {
-			thisPtr->sendImbuementDurations();
-		}
-	});
+	imbuementTrackerOpen = open;
+	if (open) {
+		sendImbuementDurations();
+	}
 }
 
 void ProtocolGame::sendImbuementDurations(slots_t updatedSlot, const Item* updatedItem)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3852,11 +3852,7 @@ void ProtocolGame::sendCreatureSay(const Creature* creature, SpeakClasses type, 
 	msg.addByte(0xAA);
 	msg.add<uint32_t>(0x00);
 
-	if (auto p = creature->getPlayer()) {
-		msg.addString(p->getDisplayName());
-	} else {
-		msg.addString(creature->getName());
-	}
+	msg.addString(creature->getName());
 
 	// Add level only for players
 	if (const Player* speaker = creature->getPlayer()) {
@@ -5126,9 +5122,7 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bo
 		msg.add<uint16_t>(0x61);
 		msg.add<uint32_t>(remove);
 		msg.add<uint32_t>(creature->getID());
-		if (auto p = creature->getPlayer()) {
-			msg.addString(p->getDisplayName());
-		} else if (creature->getMonster() && creature->getMonster()->getLevel() > 0) {
+		if (creature->getMonster() && creature->getMonster()->getLevel() > 0) {
 			msg.addString(creature->getName() + " [" + std::to_string(creature->getMonster()->getLevel()) + "]");
 		} else {
 			msg.addString(creature->getName());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1695,7 +1695,6 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage_ptr& packet)
 				}
 				break;
 			case 0x8C: parseLookAt(msg); break; // Look at tile/item
-				break;
 			case 0x96: parseSpectatorSay(msg); break;
 			case 0x97:
 				sendCastChannel();

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -97,6 +97,7 @@ private:
 
 	// we have all the parse methods
 	void parsePacket(NetworkMessage& msg) override;
+	void parsePacketOnDispatcher(NetworkMessage& msg);
 	void onRecvFirstMessage(NetworkMessage& msg) override;
 	void onConnect() override;
 
@@ -322,7 +323,7 @@ private:
 	}
 
 	// OTCv8
-	void sendFeatures();
+	void sendFeatures(bool advertiseAstraItemState = false);
 	bool shouldSendQuickLootFlags() const;
 	bool shouldSendContainerPagination() const;
 	bool shouldPaginateContainer(const Container* container) const;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -84,6 +84,7 @@ private:
 	void connect(uint32_t playerId, OperatingSystem_t operatingSystem);
 	void finishLogin(uint32_t reservedGuid, uint32_t accountId, bool loaded, OperatingSystem_t operatingSystem);
 	void disconnectClient(std::string_view message) const;
+	void dispatchCancelMessage(ReturnValue message) const;
 	void writeToOutputBuffer(const NetworkMessage& msg);
 
 	void release() override;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -6,6 +6,7 @@
 
 #include "chat.h"
 #include "creature.h"
+#include "packet_backlog.h"
 #include "protocol.h"
 #include "tasks.h"
 #include "zoneweather.h"
@@ -97,7 +98,7 @@ private:
 
 	// we have all the parse methods
 	void parsePacket(NetworkMessage& msg) override;
-	void parsePacketOnDispatcher(NetworkMessage& msg);
+	void parsePacketOnDispatcher(NetworkMessage_ptr& packet);
 	void onRecvFirstMessage(NetworkMessage& msg) override;
 	void onConnect() override;
 
@@ -368,6 +369,7 @@ private:
 
 	std::unordered_set<uint32_t> knownCreatureSet;
 	std::shared_ptr<Player> player;
+	tfs::net::PacketBacklog packetBacklog;
 
 	uint32_t eventConnect = 0;
 	uint32_t challengeTimestamp = 0;

--- a/src/tests/test_bestiary.cpp
+++ b/src/tests/test_bestiary.cpp
@@ -16,7 +16,7 @@ void ensureItemTypesLoaded()
 
 	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
 	                       "data/items/items.otb";
-	REQUIRE(Item::items.loadFromOtb(itemsPath.string()));
+	CHECK(Item::items.loadFromOtb(itemsPath.string()));
 }
 
 } // namespace
@@ -69,7 +69,7 @@ TEST_CASE(bestiary_registration_uses_race_id_as_legacy_identity)
 	system.registerMonster(replacement);
 
 	const auto registered = system.getMonster(2764);
-	REQUIRE(registered.has_value());
+	CHECK(registered.has_value());
 	CHECK(registered->get().name == "Night Harpy");
 }
 

--- a/src/tests/test_protocolgame_pipeline.cpp
+++ b/src/tests/test_protocolgame_pipeline.cpp
@@ -112,16 +112,16 @@ TEST_CASE(packet_pipeline_preserves_connection_order)
 	reactor.shutdown();
 }
 
-TEST_CASE(network_message_is_forwarded_without_a_second_copy)
+TEST_CASE(packet_expiration_policy_matches_legacy_gameplay_actions)
 {
-	NetworkMessage original;
-	original.addByte(0xFB);
-	auto packet = tfs::net::make_network_message(original);
-	NetworkMessage* const address = packet.get();
+	for (uint8_t opcode : {0x6F, 0x72, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7E, 0x82, 0x83,
+	                       0x84, 0x85, 0x8B, 0x8C, 0x8D, 0xCB, 0xCC}) {
+		CHECK(tfs::net::shouldExpireQueuedGamePacket(opcode));
+	}
 
-	auto forwardToHandler = [address](NetworkMessage_ptr& forwarded) { CHECK(forwarded.get() == address); };
-	forwardToHandler(packet);
-	CHECK(packet.get() == address);
+	for (uint8_t opcode : {0x14, 0x1E, 0x32, 0x40, 0x64, 0x65, 0x7D, 0x7F, 0x80, 0x96}) {
+		CHECK(!tfs::net::shouldExpireQueuedGamePacket(opcode));
+	}
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_protocolgame_pipeline.cpp
+++ b/src/tests/test_protocolgame_pipeline.cpp
@@ -1,0 +1,127 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../networkmessage.h"
+#include "../packet_backlog.h"
+#include "../position.h"
+#include "../reactor.h"
+
+#include "test_support.h"
+
+TEST_CASE(network_message_copy_preserves_parser_state)
+{
+	NetworkMessage original;
+	original.addByte(0xA1);
+	original.add<uint32_t>(0x12345678);
+	original.addString("packet payload");
+	CHECK(original.setBufferPosition(0));
+	CHECK(original.getByte() == 0xA1);
+
+	auto copy = tfs::net::make_network_message(original);
+	CHECK(copy->getLength() == original.getLength());
+	CHECK(copy->getBufferPosition() == original.getBufferPosition());
+	CHECK(copy->isOverrun() == original.isOverrun());
+	CHECK(std::memcmp(copy->getBuffer(), original.getBuffer(), NETWORKMESSAGE_MAXSIZE) == 0);
+
+	original.getBuffer()[NetworkMessage::INITIAL_BUFFER_POSITION] = 0xFF;
+	CHECK(copy->getBuffer()[NetworkMessage::INITIAL_BUFFER_POSITION] == 0xA1);
+
+	CHECK(original.setBufferPosition(original.getLength()));
+	(void)original.get<uint32_t>();
+	CHECK(original.isOverrun());
+	auto overrunCopy = tfs::net::make_network_message(original);
+	CHECK(overrunCopy->isOverrun());
+	CHECK(overrunCopy->getBufferPosition() == original.getBufferPosition());
+}
+
+TEST_CASE(packet_backlog_limits_copies_and_disconnects_once)
+{
+	tfs::net::PacketBacklog backlog(2);
+	uint32_t copies = 0;
+	uint32_t disconnectRequests = 0;
+
+	auto first = backlog.tryAcquire();
+	if (first) {
+		++copies;
+	}
+	auto second = backlog.tryAcquire();
+	if (second) {
+		++copies;
+	}
+	auto overflow = backlog.tryAcquire();
+	if (overflow) {
+		++copies;
+	}
+	disconnectRequests += overflow.requestDisconnect ? 1 : 0;
+	auto rejected = backlog.tryAcquire();
+	if (rejected) {
+		++copies;
+	}
+	disconnectRequests += rejected.requestDisconnect ? 1 : 0;
+
+	CHECK(first);
+	CHECK(second);
+	CHECK(!overflow);
+	CHECK(overflow.observedPending == 3);
+	CHECK(!rejected);
+	CHECK(copies == 2);
+	CHECK(disconnectRequests == 1);
+	CHECK(backlog.current() == 2);
+	CHECK(backlog.floodTriggered());
+
+	first.ticket = {};
+	second.ticket = {};
+	CHECK(backlog.current() == 0);
+	CHECK(!backlog.tryAcquire());
+}
+
+TEST_CASE(packet_backlog_ticket_releases_when_task_is_discarded)
+{
+	tfs::net::PacketBacklog backlog(4);
+	auto admission = backlog.tryAcquire();
+	CHECK(admission);
+	CHECK(backlog.current() == 1);
+
+	ReactorCallback discardedTask = [ticket = std::move(admission.ticket)]() mutable { (void)ticket; };
+	discardedTask = {};
+	CHECK(backlog.current() == 0);
+}
+
+TEST_CASE(packet_pipeline_preserves_connection_order)
+{
+	tfs::net::PacketBacklog backlog(3);
+	TaskReactor reactor;
+	reactor.start();
+	std::vector<int> processed;
+
+	for (int direction : {DIRECTION_NORTH, DIRECTION_EAST, DIRECTION_SOUTH}) {
+		auto admission = backlog.tryAcquire();
+		CHECK(admission);
+		CHECK(reactor.send([ticket = std::move(admission.ticket), direction, &processed]() mutable {
+			(void)ticket;
+			processed.push_back(direction);
+		}));
+	}
+
+	CHECK(backlog.current() == 3);
+	reactor.runOnce();
+	CHECK(processed == std::vector<int>({DIRECTION_NORTH, DIRECTION_EAST, DIRECTION_SOUTH}));
+	CHECK(backlog.current() == 0);
+	reactor.shutdown();
+}
+
+TEST_CASE(network_message_is_forwarded_without_a_second_copy)
+{
+	NetworkMessage original;
+	original.addByte(0xFB);
+	auto packet = tfs::net::make_network_message(original);
+	NetworkMessage* const address = packet.get();
+
+	auto forwardToHandler = [address](NetworkMessage_ptr& forwarded) { CHECK(forwarded.get() == address); };
+	forwardToHandler(packet);
+	CHECK(packet.get() == address);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_regression_crash.cpp
+++ b/src/tests/test_regression_crash.cpp
@@ -4,8 +4,12 @@
 #include "../otpch.h"
 
 #include "../creature.h"
+#include "../luascript.h"
+#include "../player.h"
 
 #include "test_support.h"
+
+extern LuaEnvironment g_luaEnvironment;
 
 namespace {
 
@@ -139,6 +143,29 @@ TEST_CASE(storage_database_load_sets_and_erases_value)
 
 	creature->loadStorageValue(2000, -1);
 	CHECK(!creature->getStorageValue(2000).has_value());
+}
+
+TEST_CASE(network_message_constructor_associates_player_userdata)
+{
+	CHECK(g_luaEnvironment.initState());
+	lua_State* L = g_luaEnvironment.getLuaState();
+	CHECK(L != nullptr);
+
+	auto player = std::make_shared<Player>(nullptr);
+	player->setID();
+
+	Lua::pushUserdata<Player>(L, player.get());
+	Lua::setMetatable(L, -1, "Player");
+	lua_setglobal(L, "regressionTestPlayer");
+
+	CHECK(luaL_loadstring(L, "return NetworkMessage(regressionTestPlayer)") == LUA_OK);
+	CHECK(lua_pcall(L, 0, 1, 0) == LUA_OK);
+	CHECK(luaL_testudata(L, -1, "NetworkMessage") != nullptr);
+	CHECK(lua_getiuservalue(L, -1, 1) == LUA_TNUMBER);
+	CHECK(Lua::getInteger<uint32_t>(L, -1) == player->getID());
+
+	lua_settop(L, 0);
+	CHECK(g_luaEnvironment.closeState());
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_regression_crash.cpp
+++ b/src/tests/test_regression_crash.cpp
@@ -37,13 +37,68 @@ std::shared_ptr<TestCreature> makeTestCreature()
 
 TEST_CASE(live_creatures_thread_safe_basic)
 {
-	const Creature* rawCreature = nullptr;
+	auto creature = makeTestCreature();
+	const Creature* rawCreature = creature.get();
+	CHECK(Creature::isAlive(rawCreature));
+
+	std::mutex phaseMutex;
+	std::condition_variable phaseChanged;
+	bool workerReady = false;
+	bool startWorker = false;
+	bool workerStartedReads = false;
+	bool firstObservationAlive = false;
+	bool aliveAfterDestruction = false;
+	std::atomic<bool> destructionStarted{false};
+	std::atomic<bool> destructionComplete{false};
+
+	std::thread worker([&]() {
+		{
+			std::unique_lock lock(phaseMutex);
+			workerReady = true;
+			phaseChanged.notify_one();
+			phaseChanged.wait(lock, [&]() { return startWorker; });
+		}
+
+		firstObservationAlive = Creature::isAlive(rawCreature);
+		{
+			std::lock_guard lock(phaseMutex);
+			workerStartedReads = true;
+		}
+		phaseChanged.notify_one();
+
+		while (!destructionStarted.load(std::memory_order_acquire)) {
+			std::this_thread::yield();
+		}
+		for (uint32_t i = 0; i < 4096; ++i) {
+			(void)Creature::isAlive(rawCreature);
+			std::this_thread::yield();
+		}
+		while (!destructionComplete.load(std::memory_order_acquire)) {
+			std::this_thread::yield();
+		}
+
+		for (uint32_t i = 0; i < 1024; ++i) {
+			if (Creature::isAlive(rawCreature)) {
+				aliveAfterDestruction = true;
+			}
+		}
+	});
+
 	{
-		auto creature = makeTestCreature();
-		rawCreature = creature.get();
-		CHECK(Creature::isAlive(rawCreature));
+		std::unique_lock lock(phaseMutex);
+		phaseChanged.wait(lock, [&]() { return workerReady; });
+		startWorker = true;
+		phaseChanged.notify_one();
+		phaseChanged.wait(lock, [&]() { return workerStartedReads; });
 	}
 
+	destructionStarted.store(true, std::memory_order_release);
+	creature.reset();
+	destructionComplete.store(true, std::memory_order_release);
+	worker.join();
+
+	CHECK(firstObservationAlive);
+	CHECK(!aliveAfterDestruction);
 	CHECK(!Creature::isAlive(rawCreature));
 }
 

--- a/src/tests/test_regression_crash.cpp
+++ b/src/tests/test_regression_crash.cpp
@@ -16,17 +16,21 @@ public:
 	const std::string& getNameDescription() const override { return name; }
 	std::string getDescription(int32_t) const override { return name; }
 	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
-	void setID() override {}
+	void setID() override { id = nextId.fetch_add(1, std::memory_order_relaxed); }
 	void removeList() override {}
 	void addList() override {}
+	void clearDamageMapForTest() { damageMap.clear(); }
 
 private:
+	inline static std::atomic<uint32_t> nextId{1};
 	std::string name = "regression test creature";
 };
 
 std::shared_ptr<TestCreature> makeTestCreature()
 {
-	return std::make_shared<TestCreature>();
+	auto creature = std::make_shared<TestCreature>();
+	creature->setID();
+	return creature;
 }
 
 } // namespace
@@ -52,24 +56,34 @@ TEST_CASE(damage_map_snapshot_is_independent)
 	auto snapshot = creature->getDamageMapSnapshot();
 	CHECK(snapshot.size() == 2U);
 
-	creature->getDamageMap().clear();
+	creature->clearDamageMapForTest();
 	CHECK(snapshot.size() == 2U);
 }
 
-TEST_CASE(storage_set_normalizes_minus_one)
+TEST_CASE(storage_spawn_load_normalizes_minus_one_without_lua_callback)
 {
 	auto creature = makeTestCreature();
-	creature->setStorageValue(1000, std::optional<int64_t>{42});
+	creature->setStorageValue(1000, std::optional<int64_t>{42}, true);
 	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
 
-	creature->setStorageValue(1000, std::optional<int64_t>{-1});
+	creature->setStorageValue(1000, std::optional<int64_t>{-1}, true);
 	CHECK(!creature->getStorageValue(1000).has_value());
 
-	creature->setStorageValue(1000, std::optional<int64_t>{-1});
+	creature->setStorageValue(1000, std::optional<int64_t>{-1}, true);
 	CHECK(!creature->getStorageValue(1000).has_value());
 
-	creature->setStorageValue(1000, std::optional<int64_t>{42});
+	creature->setStorageValue(1000, std::optional<int64_t>{42}, true);
 	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
+}
+
+TEST_CASE(storage_database_load_does_not_require_lua_events)
+{
+	auto creature = makeTestCreature();
+	creature->loadStorageValue(2000, 84);
+	CHECK(creature->getStorageValue(2000).value_or(-2) == 84);
+
+	creature->loadStorageValue(2000, -1);
+	CHECK(!creature->getStorageValue(2000).has_value());
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_regression_crash.cpp
+++ b/src/tests/test_regression_crash.cpp
@@ -4,14 +4,27 @@
 #include "../otpch.h"
 
 #include "../creature.h"
+#include "../events.h"
 #include "../luascript.h"
 #include "../player.h"
+#include "../scriptmanager.h"
 
 #include "test_support.h"
 
 extern LuaEnvironment g_luaEnvironment;
 
 namespace {
+
+class EventsGuard
+{
+public:
+	EventsGuard() : previous(g_events) { g_events = &events; }
+	~EventsGuard() { g_events = previous; }
+
+private:
+	Events* previous;
+	Events events;
+};
 
 class TestCreature final : public Creature
 {
@@ -23,7 +36,12 @@ public:
 	void setID() override { id = nextId.fetch_add(1, std::memory_order_relaxed); }
 	void removeList() override {}
 	void addList() override {}
-	void clearDamageMapForTest() { damageMap.clear(); }
+	double snapshotDamageRatioAfterClear(const std::shared_ptr<Creature>& attacker)
+	{
+		const auto snapshot = getDamageMapSnapshot();
+		damageMap.clear();
+		return getDamageRatio(attacker, snapshot);
+	}
 
 private:
 	inline static std::atomic<uint32_t> nextId{1};
@@ -106,33 +124,16 @@ TEST_CASE(live_creatures_thread_safe_basic)
 	CHECK(!Creature::isAlive(rawCreature));
 }
 
-TEST_CASE(damage_map_snapshot_is_independent)
+TEST_CASE(damage_map_snapshot_keeps_experience_ratio_after_reentrant_clear)
 {
 	auto creature = makeTestCreature();
-	creature->addDamagePoints(makeTestCreature(), 100);
+	auto primaryAttacker = makeTestCreature();
+	creature->addDamagePoints(primaryAttacker, 100);
 	creature->addDamagePoints(makeTestCreature(), 50);
 
-	auto snapshot = creature->getDamageMapSnapshot();
-	CHECK(snapshot.size() == 2U);
-
-	creature->clearDamageMapForTest();
-	CHECK(snapshot.size() == 2U);
-}
-
-TEST_CASE(storage_spawn_load_normalizes_minus_one)
-{
-	auto creature = makeTestCreature();
-	creature->setStorageValue(1000, std::optional<int64_t>{42}, true);
-	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
-
-	creature->setStorageValue(1000, std::optional<int64_t>{-1}, true);
-	CHECK(!creature->getStorageValue(1000).has_value());
-
-	creature->setStorageValue(1000, std::optional<int64_t>{-1}, true);
-	CHECK(!creature->getStorageValue(1000).has_value());
-
-	creature->setStorageValue(1000, std::optional<int64_t>{42}, true);
-	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
+	const double ratio = creature->snapshotDamageRatioAfterClear(primaryAttacker);
+	CHECK(std::abs(ratio - (2.0 / 3.0)) < 0.000001);
+	CHECK(creature->getDamageMap().empty());
 }
 
 TEST_CASE(storage_database_load_sets_and_erases_value)
@@ -143,6 +144,18 @@ TEST_CASE(storage_database_load_sets_and_erases_value)
 
 	creature->loadStorageValue(2000, -1);
 	CHECK(!creature->getStorageValue(2000).has_value());
+}
+
+TEST_CASE(storage_live_update_normalizes_minus_one)
+{
+	EventsGuard eventsGuard;
+	auto creature = makeTestCreature();
+
+	creature->setStorageValue(3000, 42);
+	CHECK(creature->getStorageValue(3000).value_or(-2) == 42);
+
+	creature->setStorageValue(3000, -1);
+	CHECK(!creature->getStorageValue(3000).has_value());
 }
 
 TEST_CASE(network_message_constructor_associates_player_userdata)

--- a/src/tests/test_regression_crash.cpp
+++ b/src/tests/test_regression_crash.cpp
@@ -1,0 +1,75 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../creature.h"
+
+#include "test_support.h"
+
+namespace {
+
+class TestCreature final : public Creature
+{
+public:
+	const std::string& getName() const override { return name; }
+	const std::string& getNameDescription() const override { return name; }
+	std::string getDescription(int32_t) const override { return name; }
+	CreatureType_t getType() const override { return CREATURETYPE_MONSTER; }
+	void setID() override {}
+	void removeList() override {}
+	void addList() override {}
+
+private:
+	std::string name = "regression test creature";
+};
+
+std::shared_ptr<TestCreature> makeTestCreature()
+{
+	return std::make_shared<TestCreature>();
+}
+
+} // namespace
+
+TEST_CASE(live_creatures_thread_safe_basic)
+{
+	const Creature* rawCreature = nullptr;
+	{
+		auto creature = makeTestCreature();
+		rawCreature = creature.get();
+		CHECK(Creature::isAlive(rawCreature));
+	}
+
+	CHECK(!Creature::isAlive(rawCreature));
+}
+
+TEST_CASE(damage_map_snapshot_is_independent)
+{
+	auto creature = makeTestCreature();
+	creature->addDamagePoints(makeTestCreature(), 100);
+	creature->addDamagePoints(makeTestCreature(), 50);
+
+	auto snapshot = creature->getDamageMapSnapshot();
+	CHECK(snapshot.size() == 2U);
+
+	creature->getDamageMap().clear();
+	CHECK(snapshot.size() == 2U);
+}
+
+TEST_CASE(storage_set_normalizes_minus_one)
+{
+	auto creature = makeTestCreature();
+	creature->setStorageValue(1000, std::optional<int64_t>{42});
+	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
+
+	creature->setStorageValue(1000, std::optional<int64_t>{-1});
+	CHECK(!creature->getStorageValue(1000).has_value());
+
+	creature->setStorageValue(1000, std::optional<int64_t>{-1});
+	CHECK(!creature->getStorageValue(1000).has_value());
+
+	creature->setStorageValue(1000, std::optional<int64_t>{42});
+	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_regression_crash.cpp
+++ b/src/tests/test_regression_crash.cpp
@@ -115,7 +115,7 @@ TEST_CASE(damage_map_snapshot_is_independent)
 	CHECK(snapshot.size() == 2U);
 }
 
-TEST_CASE(storage_spawn_load_normalizes_minus_one_without_lua_callback)
+TEST_CASE(storage_spawn_load_normalizes_minus_one)
 {
 	auto creature = makeTestCreature();
 	creature->setStorageValue(1000, std::optional<int64_t>{42}, true);
@@ -131,7 +131,7 @@ TEST_CASE(storage_spawn_load_normalizes_minus_one_without_lua_callback)
 	CHECK(creature->getStorageValue(1000).value_or(-2) == 42);
 }
 
-TEST_CASE(storage_database_load_does_not_require_lua_events)
+TEST_CASE(storage_database_load_sets_and_erases_value)
 {
 	auto creature = makeTestCreature();
 	creature->loadStorageValue(2000, 84);

--- a/tools/check-protocolgame-handshake.cmake
+++ b/tools/check-protocolgame-handshake.cmake
@@ -24,12 +24,18 @@ function(require_occurrences text needle expected context)
 endfunction()
 
 extract_block("void ProtocolGame::login" "void ProtocolGame::finishLogin" login_block)
+extract_block("void ProtocolGame::finishLogin" "void ProtocolGame::spectate" finish_login_block)
 extract_block("void ProtocolGame::connect" "void ProtocolGame::logout" connect_block)
+extract_block("void ProtocolGame::onRecvFirstMessage" "void ProtocolGame::onConnect" first_message_block)
 
 require_occurrences("${login_block}" "sendFeatures\\(isAstraClient\\)" 1 "login feature negotiation")
 require_occurrences("${login_block}" "opcodeMessage\\.addByte\\(0x32\\)" 1 "login extended-opcode negotiation")
 require_occurrences("${connect_block}" "sendFeatures\\(" 0 "reconnect duplicate feature negotiation")
 require_occurrences("${connect_block}" "opcodeMessage\\.addByte\\(0x32\\)" 0 "reconnect duplicate extended-opcode negotiation")
+require_occurrences("${finish_login_block}" "sendFeatures\\(" 0 "finishLogin duplicate feature negotiation")
+require_occurrences("${finish_login_block}" "opcodeMessage\\.addByte\\(0x32\\)" 0 "finishLogin duplicate extended-opcode negotiation")
+require_occurrences("${first_message_block}" "sendFeatures\\(" 0 "first-message duplicate feature negotiation")
+require_occurrences("${first_message_block}" "opcodeMessage\\.addByte\\(0x32\\)" 0 "first-message duplicate extended-opcode negotiation")
 
 string(FIND "${login_block}" "sendFeatures(isAstraClient);" features_position)
 string(FIND "${login_block}" "connect(foundPlayer->getID(), operatingSystem);" reconnect_position)

--- a/tools/check-protocolgame-handshake.cmake
+++ b/tools/check-protocolgame-handshake.cmake
@@ -1,0 +1,38 @@
+if(NOT DEFINED PROJECT_SOURCE_DIR)
+    message(FATAL_ERROR "PROJECT_SOURCE_DIR is required")
+endif()
+
+file(READ "${PROJECT_SOURCE_DIR}/src/protocolgame.cpp" protocolgame_source)
+
+function(extract_block start_marker end_marker output_var)
+    string(FIND "${protocolgame_source}" "${start_marker}" block_start)
+    string(FIND "${protocolgame_source}" "${end_marker}" block_end)
+    if(block_start EQUAL -1 OR block_end EQUAL -1 OR block_end LESS_EQUAL block_start)
+        message(FATAL_ERROR "Unable to locate ProtocolGame block: ${start_marker}")
+    endif()
+    math(EXPR block_length "${block_end} - ${block_start}")
+    string(SUBSTRING "${protocolgame_source}" ${block_start} ${block_length} block)
+    set(${output_var} "${block}" PARENT_SCOPE)
+endfunction()
+
+function(require_occurrences text needle expected context)
+    string(REGEX MATCHALL "${needle}" matches "${text}")
+    list(LENGTH matches count)
+    if(NOT count EQUAL expected)
+        message(FATAL_ERROR "${context}: expected ${expected} occurrence(s) of ${needle}, found ${count}")
+    endif()
+endfunction()
+
+extract_block("void ProtocolGame::login" "void ProtocolGame::finishLogin" login_block)
+extract_block("void ProtocolGame::connect" "void ProtocolGame::logout" connect_block)
+
+require_occurrences("${login_block}" "sendFeatures\\(isAstraClient\\)" 1 "login feature negotiation")
+require_occurrences("${login_block}" "opcodeMessage\\.addByte\\(0x32\\)" 1 "login extended-opcode negotiation")
+require_occurrences("${connect_block}" "sendFeatures\\(" 0 "reconnect duplicate feature negotiation")
+require_occurrences("${connect_block}" "opcodeMessage\\.addByte\\(0x32\\)" 0 "reconnect duplicate extended-opcode negotiation")
+
+string(FIND "${login_block}" "sendFeatures(isAstraClient);" features_position)
+string(FIND "${login_block}" "connect(foundPlayer->getID(), operatingSystem);" reconnect_position)
+if(features_position EQUAL -1 OR reconnect_position EQUAL -1 OR features_position GREATER reconnect_position)
+    message(FATAL_ERROR "Astra features must be negotiated before the reconnect path")
+endif()

--- a/tools/patches/lua-5.5.0-write-barrier.patch
+++ b/tools/patches/lua-5.5.0-write-barrier.patch
@@ -1,0 +1,30 @@
+diff --git a/lvm.c b/lvm.c
+index f9e87b61bb..f83d47d1c8 100644
+--- a/lvm.c
++++ b/lvm.c
+@@ -360,13 +360,19 @@ void luaV_finishset (lua_State *L, const TValue *t, TValue *key,
+       luaT_callTM(L, tm, t, key, val);
+       return;
+     }
+-    t = tm;  /* else repeat assignment over 'tm' */
+-    luaV_fastset(t, key, val, hres, luaH_pset);
+-    if (hres == HOK) {
+-      luaV_finishfastset(L, t, val);
+-      return;  /* done */
++    t = tm;  /* else must repeat assignment over 'tm' */
++    /* do the equivalent to 'luaV_fastset', but saving 'h' */
++    if (!ttistable(t))
++      hres = HNOTATABLE;
++    else {
++      Table *h = hvalue(t);  /* next call can change the value at 't' */
++      hres = luaH_pset(h, key, val);
++      if (hres == HOK) {
++        luaC_barrierback(L, obj2gco(h), val);  /* luaV_finishfastset */
++        return;  /* done */
++      }
+     }
+-    /* else 'return luaV_finishset(L, t, key, val, slot)' (loop) */
++    /* else 'return luaV_finishset(L, t, key, val, hres)' (loop) */
+   }
+   luaG_runerror(L, "'__newindex' chain too long; possible loop");
+ }

--- a/tools/stress/stress_login_storage.lua
+++ b/tools/stress/stress_login_storage.lua
@@ -1,5 +1,5 @@
 --[[
-    Server-side login/storage stress test for TFS 1.8.
+    Server-side login/storage stress diagnostic for TFS 1.8.
 
     Commands (account type 6 / access group only):
       /stress_login prepare,Player One|Player Two|Player Three,25000

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -396,6 +396,7 @@
     <ClInclude Include="..\src\otserv.h" />
     <ClInclude Include="..\src\outfit.h" />
     <ClInclude Include="..\src\outputmessage.h" />
+    <ClInclude Include="..\src\packet_backlog.h" />
     <ClInclude Include="..\src\party.h" />
     <ClInclude Include="..\src\performance_metrics.h" />
     <ClInclude Include="..\src\player.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -280,6 +280,7 @@
     <ClInclude Include="..\src\otserv.h" />
     <ClInclude Include="..\src\outfit.h" />
     <ClInclude Include="..\src\outputmessage.h" />
+    <ClInclude Include="..\src\packet_backlog.h" />
     <ClInclude Include="..\src\party.h" />
     <ClInclude Include="..\src\player.h" />
     <ClInclude Include="..\src\position.h" />

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "overlay-ports": [
+    "vcpkg-overlays"
+  ]
+}

--- a/vcpkg-overlays/lua/CMakeLists.txt
+++ b/vcpkg-overlays/lua/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.31)
+
+option(COMPILE_AS_CPP "Enable the lua C++ library")
+option(INSTALL_TOOLS "Install compiler and interpreter")
+
+project(lua)
+
+set(CMAKE_C_STANDARD 99)
+
+if(WIN32)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
+if(UNIX)
+    add_compile_definitions(LUA_USE_POSIX LUA_USE_DLOPEN)
+    find_library(HAVE_LIBM NAMES m)
+endif()
+
+set(SRC_LUAI "${PROJECT_SOURCE_DIR}/src/lua.c")
+set(SRC_LUAC "${PROJECT_SOURCE_DIR}/src/luac.c")
+file(GLOB SRC_LIBLUA "${PROJECT_SOURCE_DIR}/src/*.c")
+list(REMOVE_ITEM SRC_LIBLUA "${SRC_LUAI}" "${SRC_LUAC}")
+
+add_library(lua ${SRC_LIBLUA})
+target_include_directories(lua PUBLIC
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
+    $<INSTALL_INTERFACE:include>
+)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    target_compile_definitions(lua PUBLIC LUA_BUILD_AS_DLL)
+endif()
+
+if(UNIX)
+    target_link_libraries(lua PRIVATE ${CMAKE_DL_LIBS})
+    if(HAVE_LIBM)
+        target_link_libraries(lua PRIVATE m)
+    endif()
+endif()
+
+install(FILES src/lualib.h src/lua.h src/luaconf.h src/lauxlib.h src/lua.hpp
+    DESTINATION include
+)
+install(TARGETS lua
+    EXPORT unofficial-lua-config
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+if(COMPILE_AS_CPP)
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/cpp")
+    file(COPY ${SRC_LIBLUA} DESTINATION "${PROJECT_BINARY_DIR}/cpp")
+    file(GLOB SRC_LIBLUACPP "${PROJECT_BINARY_DIR}/cpp/*.c")
+    set_source_files_properties(${SRC_LIBLUACPP} PROPERTIES LANGUAGE CXX)
+    add_library(lua-cpp ${SRC_LIBLUACPP})
+    set_target_properties(lua-cpp PROPERTIES OUTPUT_NAME "lua-c++")
+    target_include_directories(lua-cpp PUBLIC
+        "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
+        $<INSTALL_INTERFACE:include>
+    )
+
+    if(WIN32 AND BUILD_SHARED_LIBS)
+        target_compile_definitions(lua-cpp PUBLIC LUA_BUILD_AS_DLL)
+    endif()
+
+    if(UNIX)
+        target_compile_definitions(lua-cpp PUBLIC LUA_USE_DLOPEN)
+        target_link_libraries(lua-cpp PRIVATE ${CMAKE_DL_LIBS})
+        if(HAVE_LIBM)
+            target_link_libraries(lua-cpp PRIVATE m)
+        endif()
+    endif()
+
+    install(TARGETS lua-cpp
+        EXPORT unofficial-lua-config
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+endif()
+
+if(INSTALL_TOOLS)
+    add_executable(luac "${SRC_LUAC}" $<TARGET_OBJECTS:lua>)
+    target_include_directories(luac PRIVATE "${PROJECT_SOURCE_DIR}/src")
+    if(UNIX AND HAVE_LIBM)
+        target_link_libraries(luac PRIVATE m)
+    endif()
+
+    add_executable(luai "${SRC_LUAI}")
+    set_target_properties(luai PROPERTIES OUTPUT_NAME "lua" PDB_NAME "luai")
+    target_link_libraries(luai PRIVATE lua)
+    if(UNIX)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(PC_READLINE readline REQUIRED)
+        target_compile_definitions(luai PRIVATE LUA_USE_READLINE)
+        target_include_directories(luai PRIVATE ${PC_READLINE_INCLUDE_DIRS})
+        target_link_libraries(luai PRIVATE ${PC_READLINE_LINK_LIBRARIES})
+    endif()
+
+    install(TARGETS luai luac DESTINATION bin)
+endif()
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/unofficial-lua-config-version.cmake"
+    VERSION "${VERSION}"
+    COMPATIBILITY "SameMajorVersion"
+)
+install(FILES "${PROJECT_BINARY_DIR}/unofficial-lua-config-version.cmake"
+    DESTINATION share/unofficial-lua
+)
+install(EXPORT unofficial-lua-config
+    NAMESPACE unofficial::lua::
+    DESTINATION share/unofficial-lua
+)

--- a/vcpkg-overlays/lua/fix-ios-system.patch
+++ b/vcpkg-overlays/lua/fix-ios-system.patch
@@ -1,0 +1,29 @@
+diff --git a/src/loslib.c b/src/loslib.c
+index ad5a927..7812011 100644
+--- a/src/loslib.c
++++ b/src/loslib.c
+@@ -4,6 +4,10 @@
+ ** See Copyright Notice in lua.h
+ */
+ 
++#if defined(__APPLE__)
++#include <TargetConditionals.h>
++#endif
++
+ #define loslib_c
+ #define LUA_LIB
+ 
+@@ -143,7 +147,12 @@ static int os_execute (lua_State *L) {
+   const char *cmd = luaL_optstring(L, 1, NULL);
+   int stat;
+   errno = 0;
+-  stat = l_system(cmd);
++#if defined(__APPLE__) && !TARGET_OS_OSX
++   // system() is __IOS_PROHIBITED, __WATCHOS_PROHIBITED, and __TVOS_PROHIBITED.
++   stat = 127; // error: shell execution failed
++#else
++   stat = system(cmd);
++#endif
+   if (cmd != NULL)
+     return luaL_execresult(L, stat);
+   else {

--- a/vcpkg-overlays/lua/lua-5.5.0-write-barrier.patch
+++ b/vcpkg-overlays/lua/lua-5.5.0-write-barrier.patch
@@ -1,0 +1,30 @@
+diff --git a/src/lvm.c b/src/lvm.c
+index f9e87b61bb..f83d47d1c8 100644
+--- a/src/lvm.c
++++ b/src/lvm.c
+@@ -360,13 +360,19 @@ void luaV_finishset (lua_State *L, const TValue *t, TValue *key,
+       luaT_callTM(L, tm, t, key, val);
+       return;
+     }
+-    t = tm;  /* else repeat assignment over 'tm' */
+-    luaV_fastset(t, key, val, hres, luaH_pset);
+-    if (hres == HOK) {
+-      luaV_finishfastset(L, t, val);
+-      return;  /* done */
++    t = tm;  /* else must repeat assignment over 'tm' */
++    /* do the equivalent to 'luaV_fastset', but saving 'h' */
++    if (!ttistable(t))
++      hres = HNOTATABLE;
++    else {
++      Table *h = hvalue(t);  /* next call can change the value at 't' */
++      hres = luaH_pset(h, key, val);
++      if (hres == HOK) {
++        luaC_barrierback(L, obj2gco(h), val);  /* luaV_finishfastset */
++        return;  /* done */
++      }
+     }
+-    /* else 'return luaV_finishset(L, t, key, val, slot)' (loop) */
++    /* else 'return luaV_finishset(L, t, key, val, hres)' (loop) */
+   }
+   luaG_runerror(L, "'__newindex' chain too long; possible loop");
+ }

--- a/vcpkg-overlays/lua/portfile.cmake
+++ b/vcpkg-overlays/lua/portfile.cmake
@@ -1,0 +1,58 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.lua.org/ftp/lua-${VERSION}.tar.gz"
+    FILENAME "lua-${VERSION}.tar.gz"
+    SHA512 3253d2cdc929da6438095a30d66ef16a1abdbb0ada8fee238705b3b38492f14be9553640fdca6b25661e01155ba5582032e0a2ef064e4c283e85efc0a128cabe
+)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        vs2015-impl-c99.patch
+        fix-ios-system.patch
+        uwp-no-popen.diff
+        lua-5.5.0-write-barrier.patch
+)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cpp     COMPILE_AS_CPP
+        tools   INSTALL_TOOLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DVERSION=${VERSION}
+    OPTIONS_DEBUG
+        -DINSTALL_TOOLS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-lua CONFIG_PATH share/unofficial-lua)
+
+if("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES lua luac AUTO_CLEAN)
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/luaconf.h" "defined(LUA_BUILD_AS_DLL)" "1")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(READ "${SOURCE_PATH}/doc/readme.html" readme)
+string(REGEX REPLACE "^.*<H2><A NAME=\"license\">License</A></H2>" "" license "${readme}")
+string(REGEX REPLACE [[<A HREF="([^"]+)">([^<]*)</A>]] "\\2 [\\1]" license "${license}")
+string(REGEX REPLACE "<[^>]*>" "" license "${license}")
+string(REGEX REPLACE "\n\n+" "\n\n" license "${license}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "${license}")

--- a/vcpkg-overlays/lua/usage
+++ b/vcpkg-overlays/lua/usage
@@ -1,0 +1,10 @@
+lua provides CMake integration for the C library:
+
+  find_package(Lua REQUIRED)
+  target_include_directories(main PRIVATE ${LUA_INCLUDE_DIR})
+  target_link_libraries(main PRIVATE ${LUA_LIBRARIES})
+
+lua[cpp] provides a C++ library with exception handling:
+
+  find_package(unofficial-lua)
+  target_link_libraries(main PRIVATE unofficial::lua::lua-cpp)

--- a/vcpkg-overlays/lua/uwp-no-popen.diff
+++ b/vcpkg-overlays/lua/uwp-no-popen.diff
@@ -1,0 +1,24 @@
+diff --git a/src/liolib.c b/src/liolib.c
+index 57615e6..70e5899 100644
+--- a/src/liolib.c
++++ b/src/liolib.c
+@@ -23,6 +23,9 @@
+ #include "lualib.h"
+ #include "llimits.h"
+ 
++#if defined(_WIN32)
++#include <winapifamily.h>
++#endif
+ 
+ /*
+ ** Change this macro to accept other modes for 'fopen' besides
+@@ -58,7 +61,8 @@ static int l_checkmode (const char *mode) {
+ #define l_popen(L,c,m)		(fflush(NULL), popen(c,m))
+ #define l_pclose(L,file)	(pclose(file))
+ 
+-#elif defined(LUA_USE_WINDOWS)	/* }{ */
++#elif defined(LUA_USE_WINDOWS)	/* }{ */ \
++      && !(defined(WINAPI_FAMILY_PARTITION) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP))
+ 
+ #define l_popen(L,c,m)		(_popen(c,m))
+ #define l_pclose(L,file)	(_pclose(file))

--- a/vcpkg-overlays/lua/vcpkg-cmake-wrapper.cmake
+++ b/vcpkg-overlays/lua/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,13 @@
+# FindLua.cmake does not reliably handle new Lua versions and multi-config builds.
+_find_package(${ARGS} NAMES unofficial-lua)
+if(Lua_FOUND)
+    get_filename_component(LUA_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}" PATH)
+    get_filename_component(LUA_INCLUDE_DIR "${LUA_INCLUDE_DIR}" PATH)
+    set(LUA_INCLUDE_DIR ${LUA_INCLUDE_DIR}/include)
+    set(LUA_LIBRARIES unofficial::lua::lua)
+    set(LUA_FOUND 1)
+    set(LUA_VERSION_STRING "${Lua_VERSION}")
+    set(LUA_VERSION_MAJOR "${Lua_VERSION_MAJOR}")
+    set(LUA_VERSION_MINOR "${Lua_VERSION_MINOR}")
+    set(LUA_VERSION_PATCH "${Lua_VERSION_PATCH}")
+endif()

--- a/vcpkg-overlays/lua/vcpkg.json
+++ b/vcpkg-overlays/lua/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "lua",
+  "version": "5.5.0",
+  "port-version": 2,
+  "description": "Lua 5.5.0 with the official luaV_finishset write-barrier fix",
+  "homepage": "https://www.lua.org",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cpp": {
+      "description": "Builds Lua for C++ linkage"
+    },
+    "tools": {
+      "description": "Builds Lua compiler and interpreter",
+      "supports": "!ios",
+      "dependencies": [
+        {
+          "name": "readline-unix",
+          "platform": "!windows"
+        }
+      ]
+    }
+  }
+}

--- a/vcpkg-overlays/lua/vs2015-impl-c99.patch
+++ b/vcpkg-overlays/lua/vs2015-impl-c99.patch
@@ -1,0 +1,10 @@
+--- a/src/luaconf.h
++++ b/src/luaconf.h
+@@ -54,6 +54,6 @@
+ 
+ #if defined(LUA_USE_WINDOWS)
+ #define LUA_DL_DLL	/* enable support for DLL */
+-#define LUA_USE_C89	/* broadly, Windows is C89 */
++//#define LUA_USE_C89	/* broadly, Windows is C89 */
+ #endif
+ 


### PR DESCRIPTION
…ture clear

Fixed 4 critical crash causes related to Abseil assertion and access violations: 1. Moved damageMap.clear() to AFTER callbacks. 2. Eliminated dangling reference in addDamagePoints. 3. Fixed reentrant access in setStorageValue. 4. onDeath now uses damageMap snapshot.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a serialized `/stress_login` stress-testing command (disabled by default) with multiple subcommands.
* **Bug Fixes**
  * Improved stability during creature removal and storage update handling, including reliable `-1` → “no value” storage clearing and corrected Lua storage event old/new ordering.
  * Switched damage tracking and creature lookups used by scripting to safer snapshot/validity behavior.
  * Improved packet backlog admission reliability.
  * Adjusted market offer fulfillment messages to match offer type.
* **Gameplay / Scripting**
  * Refreshed exercise training validation, scheduling, and logout/login cleanup flow.
* **Tests**
  * Added regression crash/storage/damage snapshot tests and networking pipeline/handshake checks.
* **Documentation**
  * Updated README configuration and NPC System setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses four root-cause crashes traced to Abseil flat_hash_map reentrant access and dangling references: it snapshots `damageMap` before `onDeath` callbacks, uses `try_emplace` in `addDamagePoints` to avoid invalidated iterators, mutates `storageMap` before invoking Lua in `setStorageValue`, and protects `liveCreatures` with a `shared_mutex`. Alongside the crash fixes, packet parsing is moved entirely onto the dispatcher thread via a new `parsePacketOnDispatcher` path, a per-connection `PacketBacklog` flood-control gate is introduced, and a signal-safe crash-context logger aids post-mortem debugging.

- **Crash fixes**: `damageMap` snapshot in `onDeath`, `try_emplace` in `addDamagePoints`, storageMap mutation before Lua callback, and `shared_mutex`-protected `liveCreatures` — all four are well-tested by the new regression suite.
- **Packet pipeline refactor**: `parsePacket` copies the message and schedules `parsePacketOnDispatcher` on the dispatcher; all game-state calls that previously wrapped `g_dispatcher.addTask` now execute directly since they're already on the dispatcher thread.
- **Storage event cleanup**: `isSpawn` parameter removed, argument order corrected to `(new, old)` throughout C++ and Lua, and `loadStorageValue` introduced so DB loading never fires Lua callbacks or marks keys dirty.

<h3>Confidence Score: 4/5</h3>

The four targeted crash fixes are well-reasoned and covered by new regression tests; the packet pipeline refactor is architecturally sound. The connect() path for OTC/Astra reconnects is still missing feature negotiation (noted in a prior review round and not yet addressed in this PR).

The crash fixes and storage event corrections are solid — each has a test, the logic is traceable, and the changes are isolated. The main open item from a previous review (feature negotiation absent on push-login reconnects for OTC/Astra clients) remains unresolved in this iteration, which is the primary reason the score is not at the ceiling.

src/protocolgame.cpp — the connect() function handles push-login reconnects but no longer advertises OTC/Astra features to the reconnecting client.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/creature.cpp | Four crash fixes: damageMap snapshot for onDeath, try_emplace to eliminate dangling ref in addDamagePoints, storageMap mutation before Lua callback in setStorageValue, and proper oldValue normalization. Logic is correct and backed by regression tests. |
| src/game.cpp | removeCreature hardened with null tile guard, damageMap.clear() moved after callbacks, and ReleaseCreature deduplication via ToReleaseCreatureSet; getCreatureByName replaced with shared-pointer variant to avoid raw-pointer lifetime gaps. |
| src/protocolgame.cpp | Packet parsing moved to dispatcher thread via parsePacketOnDispatcher; packet backlog flood-control gate added in parsePacket; sendFeatures consolidated into login() only — OTC reconnect path in connect() still missing feature negotiation (flagged in prior review). |
| src/packet_backlog.h | New lock-free per-connection flood gate with RAII ticket and once-only disconnect signal; observedPending is not set in the flood-triggered early-exit path, giving misleading 0 to diagnostics code on that branch. |
| src/player.cpp | setStorageValue drops isSpawn, loadStorageValue avoids triggering Lua or dirty tracking; postAddNotification now skips during loading (isLoading guard) and is fired explicitly on the dispatcher in loadPlayerWorldData — correct sequencing. |
| src/events.cpp | eventCreatureOnUpdateStorage signature corrected (int64_t, no isSpawn), argument order fixed (new, old), setCreatureMetatable replaces generic Creature metatable, dispatcher-thread guard added — all correct. |
| src/tests/test_regression_crash.cpp | New regression tests cover thread-safe liveCreatures, damageMap snapshot after clear, storage load/live-update semantics; good breadth for the four fixed crash paths. |
| src/tests/test_protocolgame_pipeline.cpp | New tests cover NetworkMessage copy, PacketBacklog flood-control, ticket lifecycle, ordering, and expiration policy — expiration test omits opcodes 0x70 and 0x71 which are present in the implementation. |
| src/logger.cpp | Adds signal-safe double-buffered crash context (interface, script, phase) written to stderr on SIGSEGV/SIGABRT; SA_SIGINFO handler provides fault address; implementation is correctly async-signal-safe (only write() and lock-free atomics). |
| data/lib/functions/exercise_training.lua | Stores weapon reference directly instead of searching by ID each tick; LeaveTraining refactored to clear the reference; reentrant-replacement guard (currentTraining ~= training) added at end; logic is sound. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ASIO as ASIO Thread
    participant PG as ProtocolGame::parsePacket
    participant BL as PacketBacklog
    participant DISP as Dispatcher Thread
    participant PGD as parsePacketOnDispatcher
    participant GAME as Game / Player state

    ASIO->>PG: incoming NetworkMessage
    PG->>BL: tryAcquire()
    alt flood gate open
        BL-->>PG: "Admission{ticket, observedPending}"
        PG->>PG: copy message (make_network_message)
        PG->>DISP: addTask(lambda[packet, ticket])
        note over DISP: ticket decrements pending on drop
    else flood triggered
        BL-->>PG: "Admission{empty} requestDisconnect?"
        PG->>DISP: addTask(disconnect) [once]
    end

    DISP->>PGD: parsePacketOnDispatcher(packet)
    PGD->>PGD: read opcode, check acceptPackets
    alt spectator path
        PGD->>PGD: spectatorTurn / sendCastChannel / etc.
    else player path
        PGD->>GAME: g_game.playerMove / playerTurn / etc.
        GAME-->>PGD: result
    end
    note over PGD: ticket released → pending--
```

<sub>Reviews (8): Last reviewed commit: ["fix(tests): use supported check macro"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/97d8b7afdfca8e6fac901cd8ba30839f255bab8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46037373)</sub>

<!-- /greptile_comment -->