### PR TITLE
dynamic endpoint

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -65,6 +65,8 @@ expFromPlayersLevelRange = 75
 -- NOTE: maxPlayers set to 0 means no limit
 -- NOTE: allowWalkthrough is only applicable to players
 -- NOTE: statusCountMaxPlayersPerIp allows you to only count up to X players per IP in status response (0 = disabled)
+-- Sent as IPv4 + gameProtocolPort in the standard CIP 8.60 character list
+-- (opcode 0x64). Use the public DNS name or public IP in production.
 ip = "127.0.0.1"
 bindOnlyGlobalAddress = false
 loginProtocolPort = 7171

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -73,6 +73,9 @@ loginProtocolPort = 7171
 gameProtocolPort = 7172
 statusProtocolPort = 7171
 adminPort = 7170
+-- Use a unique 64-character hexadecimal key. The
+-- TFS_DLL_CHECK_HMAC_KEY environment variable takes precedence.
+dllCheckHmacKey = ""
 maxPlayers = 500
 motd = "Welcome to The Forgotten Server!"
 onePlayerOnlinePerAccount = true

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -551,6 +551,10 @@ bool ConfigManager::load()
 	strings[String::NPC_SYSTEM] = getGlobalString(L, "npcSystem", "tfs");
 	strings[String::DUAL_WIELDING_MODE] = getGlobalString(L, "dualWieldingMode", "allweapons");
 	strings[String::RAID_SPAWNFILE_DIRECTORY] = getGlobalString(L, "raidSpawnFileDirectory", "data/raids");
+	const char* dllCheckKeyFromEnvironment = std::getenv("TFS_DLL_CHECK_HMAC_KEY");
+	strings[String::DLL_CHECK_HMAC_KEY] = dllCheckKeyFromEnvironment ?
+	                                        dllCheckKeyFromEnvironment :
+	                                        getGlobalString(L, "dllCheckHmacKey", "");
 
 	Monster::despawnRange = getGlobalInteger(L, "deSpawnRange", 2);
 	Monster::despawnRadius = getGlobalInteger(L, "deSpawnRadius", 50);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -177,6 +177,7 @@ enum String
 	NPC_SYSTEM,
 	DUAL_WIELDING_MODE,
 	RAID_SPAWNFILE_DIRECTORY,
+	DLL_CHECK_HMAC_KEY,
 
 	LAST_STRING /* this must be the last one */
 };

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -43,40 +43,10 @@ uint32_t ProtocolGame::spectatorId = 1;
 std::set<std::string> ProtocolGame::spectatorNames;
 extern Monsters g_monsters;
 
-namespace {
-
 namespace DllCheckProtocol {
-
-constexpr uint8_t OPCODE = 0xDE;
-constexpr uint8_t DLL_CHECK_WIRE_VERSION = 4;
-constexpr uint8_t CHALLENGE_KIND = 0x31;
-constexpr uint8_t RESPONSE_KIND = 0x72;
-constexpr uint32_t BUILD_ID = 2026072201;
-constexpr uint32_t INTEGRITY_FLAG = 0x80000000;
-constexpr uint32_t BUILD_MASK = 0x7FFFFFFF;
-constexpr uint32_t INITIAL_SEQUENCE = 0x6B19D3A7;
-constexpr int64_t INTERVAL_MS = 5000;
-constexpr int64_t TIMEOUT_MS = 5000;
-constexpr std::size_t PAYLOAD_SIZE = 64;
-constexpr std::size_t AUTHENTICATED_SIZE = 32;
-constexpr std::size_t TAG_OFFSET = AUTHENTICATED_SIZE;
-constexpr std::size_t TAG_SIZE = 32;
-constexpr std::size_t MAX_ENCODED_PAYLOAD_SIZE = 256;
 
 constexpr std::string_view BASE64_ALPHABET =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-constexpr std::array<uint8_t, 32> KEY_FRAGMENT_A = {
-    0x48, 0x2C, 0xC5, 0x8F, 0x31, 0xCB, 0x47, 0xAE,
-    0x08, 0x6C, 0x50, 0xCA, 0x80, 0x29, 0xEE, 0xC0,
-    0x1C, 0xB9, 0xE9, 0x42, 0xF4, 0xAE, 0x74, 0x29,
-    0x10, 0x4F, 0x29, 0xDD, 0x5F, 0xB3, 0x0F, 0xE7
-};
-constexpr std::array<uint8_t, 32> KEY_FRAGMENT_B = {
-    0xE0, 0xBC, 0x2F, 0x24, 0xAA, 0xB3, 0xED, 0xCE,
-    0x44, 0x42, 0xC3, 0x49, 0x0B, 0x83, 0xE8, 0xE4,
-    0xEF, 0x46, 0xCF, 0x3A, 0x13, 0x0C, 0xF8, 0xAA,
-    0xC6, 0xAE, 0x41, 0x3A, 0xBE, 0x6E, 0xF9, 0x54
-};
 
 constexpr bool hasUniqueAlphabetCharacters()
 {
@@ -99,17 +69,38 @@ constexpr bool hasUniqueAlphabetCharacters()
 static_assert(BASE64_ALPHABET.size() == 64);
 static_assert(hasUniqueAlphabetCharacters());
 
-using Payload = std::array<uint8_t, PAYLOAD_SIZE>;
-using Tag = std::array<uint8_t, TAG_SIZE>;
-
-struct Fields
+int hexValue(char character)
 {
-	uint32_t build = 0;
-	uint64_t timestamp = 0;
-	uint64_t sessionId = 0;
-	uint32_t sequence = 0;
-	uint32_t nonce = 0;
-};
+	if (character >= '0' && character <= '9') {
+		return character - '0';
+	}
+	if (character >= 'a' && character <= 'f') {
+		return character - 'a' + 10;
+	}
+	if (character >= 'A' && character <= 'F') {
+		return character - 'A' + 10;
+	}
+	return -1;
+}
+
+bool decodeHmacKey(std::string_view encoded, HmacKey& key)
+{
+	key.fill(0);
+	if (encoded.size() != key.size() * 2) {
+		return false;
+	}
+
+	for (std::size_t index = 0; index < key.size(); ++index) {
+		const int high = hexValue(encoded[index * 2]);
+		const int low = hexValue(encoded[index * 2 + 1]);
+		if (high < 0 || low < 0) {
+			key.fill(0);
+			return false;
+		}
+		key[index] = static_cast<uint8_t>((high << 4) | low);
+	}
+	return true;
+}
 
 void writeU16(Payload& payload, std::size_t offset, uint16_t value)
 {
@@ -167,25 +158,19 @@ Tag getTag(const Payload& payload)
 	return tag;
 }
 
-bool computeTag(const Payload& payload, Tag& tag)
+bool computeTag(const HmacKey& key, const Payload& payload, Tag& tag)
 {
-	std::array<uint8_t, 32> key = {};
-	for (std::size_t index = 0; index < key.size(); ++index) {
-		key[index] = KEY_FRAGMENT_A[index] ^ KEY_FRAGMENT_B[index];
-	}
-
 	unsigned int tagLength = 0;
 	const unsigned char* result =
 	    HMAC(EVP_sha256(), key.data(), static_cast<int>(key.size()), payload.data(),
 	         AUTHENTICATED_SIZE, tag.data(), &tagLength);
-	OPENSSL_cleanse(key.data(), key.size());
 	return result != nullptr && tagLength == static_cast<unsigned int>(tag.size());
 }
 
-bool hasValidTag(const Payload& payload)
+bool hasValidTag(const HmacKey& key, const Payload& payload)
 {
 	Tag expected = {};
-	if (!computeTag(payload, expected)) {
+	if (!computeTag(key, payload, expected)) {
 		return false;
 	}
 
@@ -195,8 +180,19 @@ bool hasValidTag(const Payload& payload)
 	return valid;
 }
 
-bool buildChallenge(uint64_t timestamp, uint64_t sessionId, uint32_t sequence,
-                    uint32_t nonce, Payload& payload)
+bool signPayload(const HmacKey& key, Payload& payload)
+{
+	Tag tag = {};
+	if (!computeTag(key, payload, tag)) {
+		return false;
+	}
+	setTag(payload, tag);
+	OPENSSL_cleanse(tag.data(), tag.size());
+	return true;
+}
+
+bool buildChallenge(const HmacKey& key, uint64_t timestamp, uint64_t sessionId,
+                    uint32_t sequence, uint32_t nonce, Payload& payload)
 {
 	payload = {};
 	payload[0] = DLL_CHECK_WIRE_VERSION;
@@ -208,19 +204,13 @@ bool buildChallenge(uint64_t timestamp, uint64_t sessionId, uint32_t sequence,
 	writeU32(payload, 24, sequence);
 	writeU32(payload, 28, nonce);
 
-	Tag tag = {};
-	if (!computeTag(payload, tag)) {
-		return false;
-	}
-	setTag(payload, tag);
-	OPENSSL_cleanse(tag.data(), tag.size());
-	return true;
+	return signPayload(key, payload);
 }
 
-bool parseResponse(const Payload& payload, Fields& fields)
+bool parseResponse(const HmacKey& key, const Payload& payload, Fields& fields)
 {
 	if (payload[0] != DLL_CHECK_WIRE_VERSION || payload[1] != RESPONSE_KIND ||
-	    readU16(payload, 2) != PAYLOAD_SIZE || !hasValidTag(payload)) {
+	    readU16(payload, 2) != PAYLOAD_SIZE || !hasValidTag(key, payload)) {
 		return false;
 	}
 
@@ -231,6 +221,19 @@ bool parseResponse(const Payload& payload, Fields& fields)
 	fields.nonce = readU32(payload, 28);
 	return fields.timestamp != 0 && fields.sessionId != 0 && fields.sequence != 0 &&
 	       (fields.build & BUILD_MASK) == BUILD_ID && (fields.build & INTEGRITY_FLAG) != 0;
+}
+
+bool matchesExpectedResponse(const Fields& fields, const Fields& expected)
+{
+	return fields.timestamp == expected.timestamp &&
+	       fields.sessionId == expected.sessionId &&
+	       fields.sequence == expected.sequence &&
+	       fields.nonce == expected.nonce;
+}
+
+bool isResponseWindowValid(bool pending, int64_t sentAt, int64_t receivedAt)
+{
+	return pending && receivedAt >= sentAt && receivedAt - sentAt < TIMEOUT_MS;
 }
 
 std::string base64Encode(const std::vector<uint8_t>& bytes)
@@ -341,6 +344,14 @@ bool decodePayload(std::string_view encoded, Payload& payload)
 }
 
 } // namespace DllCheckProtocol
+
+namespace {
+
+bool getConfiguredDllCheckKey(DllCheckProtocol::HmacKey& key)
+{
+	return DllCheckProtocol::decodeHmacKey(
+	    ConfigManager::getString(ConfigManager::DLL_CHECK_HMAC_KEY), key);
+}
 
 // 0x3C is reserved for native ZoneId weather on negotiated custom clients.
 constexpr uint8_t ZONE_WEATHER_OPCODE = 0x3C;
@@ -3989,12 +4000,16 @@ void ProtocolGame::sendDllCheck()
 	}
 
 	DllCheckProtocol::Payload payload = {};
-	if (!DllCheckProtocol::buildChallenge(
+	DllCheckProtocol::HmacKey key = {};
+	if (!getConfiguredDllCheckKey(key) || !DllCheckProtocol::buildChallenge(
+	        key,
 	        dllCheckExpectedTimestamp, dllCheckExpectedSessionId,
 	        dllCheckExpectedSequence, dllCheckExpectedRandom, payload)) {
+		OPENSSL_cleanse(key.data(), key.size());
 		failDllCheck();
 		return;
 	}
+	OPENSSL_cleanse(key.data(), key.size());
 	const std::string encoded = DllCheckProtocol::encodePayload(payload);
 
 	NetworkMessage msg;
@@ -4075,7 +4090,7 @@ void ProtocolGame::parseDllCheckResponse(NetworkMessage& msg)
 void ProtocolGame::validateDllCheckResponse(std::string response, int64_t receivedAt)
 {
 	if (!dllCheckPending || clientOperatingSystem != CLIENTOS_CUSTOM_DLL ||
-	    receivedAt < dllCheckSentAt || receivedAt - dllCheckSentAt >= DllCheckProtocol::TIMEOUT_MS) {
+	    !DllCheckProtocol::isResponseWindowValid(dllCheckPending, dllCheckSentAt, receivedAt)) {
 		failDllCheck();
 		return;
 	}
@@ -4086,14 +4101,20 @@ void ProtocolGame::validateDllCheckResponse(std::string response, int64_t receiv
 		failDllCheck();
 		return;
 	}
-	if (!DllCheckProtocol::parseResponse(payload, fields)) {
+	DllCheckProtocol::HmacKey key = {};
+	if (!getConfiguredDllCheckKey(key) ||
+	    !DllCheckProtocol::parseResponse(key, payload, fields)) {
+		OPENSSL_cleanse(key.data(), key.size());
 		failDllCheck();
 		return;
 	}
-	if (fields.timestamp != dllCheckExpectedTimestamp ||
-	    fields.sessionId != dllCheckExpectedSessionId ||
-	    fields.sequence != dllCheckExpectedSequence ||
-	    fields.nonce != dllCheckExpectedRandom) {
+	OPENSSL_cleanse(key.data(), key.size());
+	DllCheckProtocol::Fields expected;
+	expected.timestamp = dllCheckExpectedTimestamp;
+	expected.sessionId = dllCheckExpectedSessionId;
+	expected.sequence = dllCheckExpectedSequence;
+	expected.nonce = dllCheckExpectedRandom;
+	if (!DllCheckProtocol::matchesExpectedResponse(fields, expected)) {
 		failDllCheck();
 		return;
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -26,6 +26,7 @@
 #include "scriptmanager.h"
 #include "thread_pool.h"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <limits>
@@ -33,6 +34,10 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
 
 uint32_t ProtocolGame::spectatorId = 1;
 std::set<std::string> ProtocolGame::spectatorNames;
@@ -43,33 +48,34 @@ namespace {
 namespace DllCheckProtocol {
 
 constexpr uint8_t OPCODE = 0xDE;
-constexpr uint8_t DLL_CHECK_WIRE_VERSION = 3;
-constexpr uint8_t CHALLENGE_KIND = 0x71;
-constexpr uint8_t RESPONSE_KIND = 0xA6;
-constexpr uint32_t BUILD_ID = 2026071903;
+constexpr uint8_t DLL_CHECK_WIRE_VERSION = 4;
+constexpr uint8_t CHALLENGE_KIND = 0x31;
+constexpr uint8_t RESPONSE_KIND = 0x72;
+constexpr uint32_t BUILD_ID = 2026072201;
+constexpr uint32_t INTEGRITY_FLAG = 0x80000000;
+constexpr uint32_t BUILD_MASK = 0x7FFFFFFF;
 constexpr uint32_t INITIAL_SEQUENCE = 0x6B19D3A7;
 constexpr int64_t INTERVAL_MS = 5000;
 constexpr int64_t TIMEOUT_MS = 5000;
 constexpr std::size_t PAYLOAD_SIZE = 64;
-constexpr std::size_t MAX_ENCODED_PAYLOAD_SIZE = 512;
+constexpr std::size_t AUTHENTICATED_SIZE = 32;
+constexpr std::size_t TAG_OFFSET = AUTHENTICATED_SIZE;
+constexpr std::size_t TAG_SIZE = 32;
+constexpr std::size_t MAX_ENCODED_PAYLOAD_SIZE = 256;
 
 constexpr std::string_view BASE64_ALPHABET =
-    "s5cvbxqZe8Ph9mS7R/0fMNrzoKlDQdgHkYVja4UEX621LnTCpA+3FBWiJwtIGyuO";
-constexpr std::string_view XOR_KEY =
-    "vZ3LrhkGjHs97RvQfnap7Q1IIdrzduw046pIL689hQpAFR4ILQZYfHYC43TurO3Z4LcYPT4w";
-
-constexpr std::array<uint8_t, 8> SERVER_MAGIC = {
-    0x53, 0xA6, 0x9C, 0xC6, 0xC3, 0x30, 0xE2, 0xD6
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+constexpr std::array<uint8_t, 32> KEY_FRAGMENT_A = {
+    0x48, 0x2C, 0xC5, 0x8F, 0x31, 0xCB, 0x47, 0xAE,
+    0x08, 0x6C, 0x50, 0xCA, 0x80, 0x29, 0xEE, 0xC0,
+    0x1C, 0xB9, 0xE9, 0x42, 0xF4, 0xAE, 0x74, 0x29,
+    0x10, 0x4F, 0x29, 0xDD, 0x5F, 0xB3, 0x0F, 0xE7
 };
-constexpr std::array<uint8_t, 8> CLIENT_MAGIC = {
-    0xB6, 0x57, 0xD9, 0x1B, 0xA3, 0x72, 0xED, 0x60
-};
-constexpr std::array<uint8_t, 16> FIXED_TEXT = {
-    'N', 'E', 'X', 'A', '8', '6', '0', '-', 'C', 'H', 'E', 'C', 'K', '-', 'V', '3'
-};
-constexpr std::array<uint8_t, 16> PRIVATE_SALT = {
-    0x37, 0x89, 0xFF, 0xBA, 0xF5, 0xA8, 0x93, 0x0E,
-    0x79, 0xD8, 0xE2, 0xC6, 0xA5, 0xD2, 0xD1, 0x79
+constexpr std::array<uint8_t, 32> KEY_FRAGMENT_B = {
+    0xE0, 0xBC, 0x2F, 0x24, 0xAA, 0xB3, 0xED, 0xCE,
+    0x44, 0x42, 0xC3, 0x49, 0x0B, 0x83, 0xE8, 0xE4,
+    0xEF, 0x46, 0xCF, 0x3A, 0x13, 0x0C, 0xF8, 0xAA,
+    0xC6, 0xAE, 0x41, 0x3A, 0xBE, 0x6E, 0xF9, 0x54
 };
 
 constexpr bool hasUniqueAlphabetCharacters()
@@ -92,15 +98,17 @@ constexpr bool hasUniqueAlphabetCharacters()
 
 static_assert(BASE64_ALPHABET.size() == 64);
 static_assert(hasUniqueAlphabetCharacters());
-static_assert(!XOR_KEY.empty());
 
 using Payload = std::array<uint8_t, PAYLOAD_SIZE>;
+using Tag = std::array<uint8_t, TAG_SIZE>;
 
 struct Fields
 {
+	uint32_t build = 0;
 	uint64_t timestamp = 0;
+	uint64_t sessionId = 0;
 	uint32_t sequence = 0;
-	uint32_t randomValue = 0;
+	uint32_t nonce = 0;
 };
 
 void writeU16(Payload& payload, std::size_t offset, uint16_t value)
@@ -147,61 +155,82 @@ uint64_t readU64(const Payload& payload, std::size_t offset)
 	return value;
 }
 
-template <std::size_t N>
-void writeArray(Payload& payload, std::size_t offset, const std::array<uint8_t, N>& value)
+void setTag(Payload& payload, const Tag& tag)
 {
-	for (std::size_t i = 0; i < N; ++i) {
-		payload[offset + i] = value[i];
-	}
+	std::copy(tag.begin(), tag.end(), payload.begin() + TAG_OFFSET);
 }
 
-template <std::size_t N>
-bool matchesArray(const Payload& payload, std::size_t offset, const std::array<uint8_t, N>& value)
+Tag getTag(const Payload& payload)
 {
-	for (std::size_t i = 0; i < N; ++i) {
-		if (payload[offset + i] != value[i]) {
-			return false;
-		}
-	}
-	return true;
+	Tag tag = {};
+	std::copy_n(payload.begin() + TAG_OFFSET, TAG_SIZE, tag.begin());
+	return tag;
 }
 
-Payload buildChallenge(uint64_t timestamp, uint32_t sequence, uint32_t randomValue)
+bool computeTag(const Payload& payload, Tag& tag)
 {
-	Payload payload = {};
-	writeArray(payload, 0, SERVER_MAGIC);
-	payload[8] = DLL_CHECK_WIRE_VERSION;
-	payload[9] = CHALLENGE_KIND;
-	writeU16(payload, 10, static_cast<uint16_t>(PAYLOAD_SIZE));
-	writeU32(payload, 12, BUILD_ID);
-	writeU64(payload, 16, timestamp);
+	std::array<uint8_t, 32> key = {};
+	for (std::size_t index = 0; index < key.size(); ++index) {
+		key[index] = KEY_FRAGMENT_A[index] ^ KEY_FRAGMENT_B[index];
+	}
+
+	unsigned int tagLength = 0;
+	const unsigned char* result =
+	    HMAC(EVP_sha256(), key.data(), static_cast<int>(key.size()), payload.data(),
+	         AUTHENTICATED_SIZE, tag.data(), &tagLength);
+	OPENSSL_cleanse(key.data(), key.size());
+	return result != nullptr && tagLength == static_cast<unsigned int>(tag.size());
+}
+
+bool hasValidTag(const Payload& payload)
+{
+	Tag expected = {};
+	if (!computeTag(payload, expected)) {
+		return false;
+	}
+
+	const Tag received = getTag(payload);
+	const bool valid = CRYPTO_memcmp(expected.data(), received.data(), TAG_SIZE) == 0;
+	OPENSSL_cleanse(expected.data(), expected.size());
+	return valid;
+}
+
+bool buildChallenge(uint64_t timestamp, uint64_t sessionId, uint32_t sequence,
+                    uint32_t nonce, Payload& payload)
+{
+	payload = {};
+	payload[0] = DLL_CHECK_WIRE_VERSION;
+	payload[1] = CHALLENGE_KIND;
+	writeU16(payload, 2, static_cast<uint16_t>(PAYLOAD_SIZE));
+	writeU64(payload, 4, timestamp);
+	writeU64(payload, 12, sessionId);
+	writeU32(payload, 20, BUILD_ID);
 	writeU32(payload, 24, sequence);
-	writeU32(payload, 28, randomValue);
-	writeArray(payload, 32, FIXED_TEXT);
-	writeArray(payload, 48, PRIVATE_SALT);
-	return payload;
+	writeU32(payload, 28, nonce);
+
+	Tag tag = {};
+	if (!computeTag(payload, tag)) {
+		return false;
+	}
+	setTag(payload, tag);
+	OPENSSL_cleanse(tag.data(), tag.size());
+	return true;
 }
 
 bool parseResponse(const Payload& payload, Fields& fields)
 {
-	if (!matchesArray(payload, 0, CLIENT_MAGIC) || payload[8] != DLL_CHECK_WIRE_VERSION ||
-	    payload[9] != RESPONSE_KIND || readU16(payload, 10) != PAYLOAD_SIZE ||
-	    readU32(payload, 12) != BUILD_ID || !matchesArray(payload, 32, FIXED_TEXT) ||
-	    !matchesArray(payload, 48, PRIVATE_SALT)) {
+	if (payload[0] != DLL_CHECK_WIRE_VERSION || payload[1] != RESPONSE_KIND ||
+	    readU16(payload, 2) != PAYLOAD_SIZE || !hasValidTag(payload)) {
 		return false;
 	}
 
-	fields.timestamp = readU64(payload, 16);
+	fields.timestamp = readU64(payload, 4);
+	fields.sessionId = readU64(payload, 12);
+	fields.build = readU32(payload, 20);
 	fields.sequence = readU32(payload, 24);
-	fields.randomValue = readU32(payload, 28);
-	return fields.timestamp != 0 && fields.sequence != 0;
-}
-
-void xorCrypt(std::vector<uint8_t>& bytes)
-{
-	for (std::size_t i = 0; i < bytes.size(); ++i) {
-		bytes[i] ^= static_cast<uint8_t>(XOR_KEY[i % XOR_KEY.size()]);
-	}
+	fields.nonce = readU32(payload, 28);
+	return fields.timestamp != 0 && fields.sessionId != 0 && fields.sequence != 0 &&
+	       (fields.build & BUILD_MASK) == BUILD_ID && (fields.build & INTEGRITY_FLAG) != 0;
 }
 
 std::string base64Encode(const std::vector<uint8_t>& bytes)
@@ -292,14 +321,13 @@ bool base64Decode(std::string_view encoded, std::vector<uint8_t>& decoded)
 	return true;
 }
 
-std::string encodeProtected(const Payload& payload)
+std::string encodePayload(const Payload& payload)
 {
 	std::vector<uint8_t> bytes(payload.begin(), payload.end());
-	xorCrypt(bytes);
 	return base64Encode(bytes);
 }
 
-bool decodeProtected(std::string_view encoded, Payload& payload)
+bool decodePayload(std::string_view encoded, Payload& payload)
 {
 	if (encoded.empty() || encoded.size() > MAX_ENCODED_PAYLOAD_SIZE) {
 		return false;
@@ -308,10 +336,7 @@ bool decodeProtected(std::string_view encoded, Payload& payload)
 	if (!base64Decode(encoded, bytes) || bytes.size() != PAYLOAD_SIZE) {
 		return false;
 	}
-	xorCrypt(bytes);
-	for (std::size_t i = 0; i < PAYLOAD_SIZE; ++i) {
-		payload[i] = bytes[i];
-	}
+	std::copy(bytes.begin(), bytes.end(), payload.begin());
 	return true;
 }
 
@@ -364,6 +389,13 @@ uint32_t nextDllCheckRandom()
 	static std::mt19937 generator(randomDevice());
 	static std::uniform_int_distribution<uint32_t> distribution(1, (std::numeric_limits<uint32_t>::max)());
 	return distribution(generator);
+}
+
+uint64_t nextDllCheckSessionId()
+{
+	const uint64_t high = nextDllCheckRandom();
+	const uint64_t low = nextDllCheckRandom();
+	return (high << 32) | low;
 }
 
 std::string anonymizeIPv4ForFile(uint32_t ip)
@@ -3949,15 +3981,21 @@ void ProtocolGame::sendDllCheck()
 	}
 
 	dllCheckExpectedTimestamp = static_cast<uint64_t>(OTSYS_TIME());
+	dllCheckExpectedSessionId = nextDllCheckSessionId();
 	dllCheckExpectedSequence = dllCheckSequence;
 	dllCheckExpectedRandom = nextDllCheckRandom();
 	if (++dllCheckSequence == 0) {
 		dllCheckSequence = 1;
 	}
 
-	const auto payload = DllCheckProtocol::buildChallenge(
-	    dllCheckExpectedTimestamp, dllCheckExpectedSequence, dllCheckExpectedRandom);
-	const std::string encoded = DllCheckProtocol::encodeProtected(payload);
+	DllCheckProtocol::Payload payload = {};
+	if (!DllCheckProtocol::buildChallenge(
+	        dllCheckExpectedTimestamp, dllCheckExpectedSessionId,
+	        dllCheckExpectedSequence, dllCheckExpectedRandom, payload)) {
+		failDllCheck();
+		return;
+	}
+	const std::string encoded = DllCheckProtocol::encodePayload(payload);
 
 	NetworkMessage msg;
 	msg.addByte(DllCheckProtocol::OPCODE);
@@ -3997,6 +4035,7 @@ void ProtocolGame::resetDllCheckState()
 	dllCheckExpectedSequence = 0;
 	dllCheckExpectedRandom = 0;
 	dllCheckExpectedTimestamp = 0;
+	dllCheckExpectedSessionId = 0;
 	dllCheckSentAt = 0;
 }
 
@@ -4043,7 +4082,7 @@ void ProtocolGame::validateDllCheckResponse(std::string response, int64_t receiv
 
 	DllCheckProtocol::Payload payload = {};
 	DllCheckProtocol::Fields fields;
-	if (!DllCheckProtocol::decodeProtected(response, payload)) {
+	if (!DllCheckProtocol::decodePayload(response, payload)) {
 		failDllCheck();
 		return;
 	}
@@ -4052,8 +4091,9 @@ void ProtocolGame::validateDllCheckResponse(std::string response, int64_t receiv
 		return;
 	}
 	if (fields.timestamp != dllCheckExpectedTimestamp ||
+	    fields.sessionId != dllCheckExpectedSessionId ||
 	    fields.sequence != dllCheckExpectedSequence ||
-	    fields.randomValue != dllCheckExpectedRandom) {
+	    fields.nonce != dllCheckExpectedRandom) {
 		failDllCheck();
 		return;
 	}

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -11,7 +11,10 @@
 #include "tasks.h"
 #include "zoneweather.h"
 
+#include <array>
 #include <optional>
+#include <string>
+#include <string_view>
 
 class NetworkMessage;
 class Player;
@@ -26,6 +29,50 @@ using ProtocolGame_ptr = std::shared_ptr<ProtocolGame>;
 class ProtocolSpectator;
 
 extern Game g_game;
+
+namespace DllCheckProtocol {
+
+inline constexpr uint8_t OPCODE = 0xDE;
+inline constexpr uint8_t DLL_CHECK_WIRE_VERSION = 4;
+inline constexpr uint8_t CHALLENGE_KIND = 0x31;
+inline constexpr uint8_t RESPONSE_KIND = 0x72;
+inline constexpr uint32_t BUILD_ID = 2026072201;
+inline constexpr uint32_t INTEGRITY_FLAG = 0x80000000;
+inline constexpr uint32_t BUILD_MASK = 0x7FFFFFFF;
+inline constexpr uint32_t INITIAL_SEQUENCE = 0x6B19D3A7;
+inline constexpr int64_t INTERVAL_MS = 5000;
+inline constexpr int64_t TIMEOUT_MS = 5000;
+inline constexpr std::size_t PAYLOAD_SIZE = 64;
+inline constexpr std::size_t AUTHENTICATED_SIZE = 32;
+inline constexpr std::size_t TAG_OFFSET = AUTHENTICATED_SIZE;
+inline constexpr std::size_t TAG_SIZE = 32;
+inline constexpr std::size_t KEY_SIZE = 32;
+inline constexpr std::size_t MAX_ENCODED_PAYLOAD_SIZE = 256;
+
+using HmacKey = std::array<uint8_t, KEY_SIZE>;
+using Payload = std::array<uint8_t, PAYLOAD_SIZE>;
+using Tag = std::array<uint8_t, TAG_SIZE>;
+
+struct Fields
+{
+	uint32_t build = 0;
+	uint64_t timestamp = 0;
+	uint64_t sessionId = 0;
+	uint32_t sequence = 0;
+	uint32_t nonce = 0;
+};
+
+bool decodeHmacKey(std::string_view encoded, HmacKey& key);
+bool signPayload(const HmacKey& key, Payload& payload);
+bool buildChallenge(const HmacKey& key, uint64_t timestamp, uint64_t sessionId,
+                    uint32_t sequence, uint32_t nonce, Payload& payload);
+bool parseResponse(const HmacKey& key, const Payload& payload, Fields& fields);
+bool matchesExpectedResponse(const Fields& fields, const Fields& expected);
+bool isResponseWindowValid(bool pending, int64_t sentAt, int64_t receivedAt);
+std::string encodePayload(const Payload& payload);
+bool decodePayload(std::string_view encoded, Payload& payload);
+
+} // namespace DllCheckProtocol
 
 struct TextMessage
 {

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -422,6 +422,7 @@ private:
 	uint32_t dllCheckExpectedSequence = 0;
 	uint32_t dllCheckExpectedRandom = 0;
 	uint64_t dllCheckExpectedTimestamp = 0;
+	uint64_t dllCheckExpectedSessionId = 0;
 	int64_t dllCheckSentAt = 0;
 
 	int64_t moveWindowStart = 0;

--- a/src/tests/test_dllcheck_protocol.cpp
+++ b/src/tests/test_dllcheck_protocol.cpp
@@ -1,0 +1,160 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../protocolgame.h"
+
+#include "test_support.h"
+
+namespace {
+
+constexpr std::string_view TEST_KEY =
+    "000102030405060708090a0b0c0d0e0f"
+    "101112131415161718191a1b1c1d1e1f";
+constexpr std::string_view CHALLENGE_FIXTURE =
+    "BDFAAAgHBgUEAwIBGBcWFRQTEhGJaMN4JCMiITQzMjHDmsDWwZyBL2x0JkeLnfZK"
+    "uh5cquN3PjXdZF9jFhODjw==";
+constexpr std::string_view RESPONSE_FIXTURE =
+    "BHJAAAgHBgUEAwIBGBcWFRQTEhGJaMP4JCMiITQzMjFUzlGlLxZziNzvjm35FsDk"
+    "EQML/nLhCLkPmDgXlG6RaA==";
+
+constexpr uint64_t TIMESTAMP = 0x0102030405060708;
+constexpr uint64_t SESSION_ID = 0x1112131415161718;
+constexpr uint32_t SEQUENCE = 0x21222324;
+constexpr uint32_t NONCE = 0x31323334;
+
+void clearBytes(DllCheckProtocol::Payload& payload, std::size_t offset, std::size_t count)
+{
+	std::fill_n(payload.begin() + offset, count, 0);
+}
+
+bool resignAndParse(const DllCheckProtocol::HmacKey& key,
+                    DllCheckProtocol::Payload payload)
+{
+	CHECK(DllCheckProtocol::signPayload(key, payload));
+	DllCheckProtocol::Fields fields;
+	return DllCheckProtocol::parseResponse(key, payload, fields);
+}
+
+} // namespace
+
+TEST_CASE(dllcheck_v4_known_fixtures_match_wire_format)
+{
+	DllCheckProtocol::HmacKey key = {};
+	CHECK(DllCheckProtocol::decodeHmacKey(TEST_KEY, key));
+
+	DllCheckProtocol::Payload challenge = {};
+	CHECK(DllCheckProtocol::buildChallenge(
+	    key, TIMESTAMP, SESSION_ID, SEQUENCE, NONCE, challenge));
+	CHECK(DllCheckProtocol::encodePayload(challenge) == CHALLENGE_FIXTURE);
+
+	DllCheckProtocol::Payload response = {};
+	CHECK(DllCheckProtocol::decodePayload(RESPONSE_FIXTURE, response));
+	CHECK(DllCheckProtocol::encodePayload(response) == RESPONSE_FIXTURE);
+
+	DllCheckProtocol::Fields fields;
+	CHECK(DllCheckProtocol::parseResponse(key, response, fields));
+	CHECK(fields.timestamp == TIMESTAMP);
+	CHECK(fields.sessionId == SESSION_ID);
+	CHECK(fields.build == (DllCheckProtocol::BUILD_ID | DllCheckProtocol::INTEGRITY_FLAG));
+	CHECK(fields.sequence == SEQUENCE);
+	CHECK(fields.nonce == NONCE);
+}
+
+TEST_CASE(dllcheck_v4_rejects_invalid_key_and_base64)
+{
+	DllCheckProtocol::HmacKey key = {};
+	CHECK(DllCheckProtocol::decodeHmacKey(TEST_KEY, key));
+	CHECK(!DllCheckProtocol::decodeHmacKey(TEST_KEY.substr(2), key));
+	CHECK(!DllCheckProtocol::decodeHmacKey(
+	    "g00102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", key));
+
+	DllCheckProtocol::Payload payload = {};
+	CHECK(!DllCheckProtocol::decodePayload("", payload));
+	CHECK(!DllCheckProtocol::decodePayload("AAAA", payload));
+	std::string malformed(RESPONSE_FIXTURE);
+	malformed[5] = '!';
+	CHECK(!DllCheckProtocol::decodePayload(malformed, payload));
+	CHECK(!DllCheckProtocol::decodePayload(RESPONSE_FIXTURE.substr(0, 84), payload));
+}
+
+TEST_CASE(dllcheck_v4_rejects_each_authenticated_field_error)
+{
+	DllCheckProtocol::HmacKey key = {};
+	CHECK(DllCheckProtocol::decodeHmacKey(TEST_KEY, key));
+	DllCheckProtocol::Payload valid = {};
+	CHECK(DllCheckProtocol::decodePayload(RESPONSE_FIXTURE, valid));
+
+	auto payload = valid;
+	payload[0] = 3;
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	payload[1] = DllCheckProtocol::CHALLENGE_KIND;
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	payload[2] = 63;
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	clearBytes(payload, 4, 8);
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	clearBytes(payload, 12, 8);
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	payload[20] ^= 0x01;
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	payload[23] &= 0x7F;
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	clearBytes(payload, 24, 4);
+	CHECK(!resignAndParse(key, payload));
+
+	payload = valid;
+	payload.back() ^= 0x01;
+	DllCheckProtocol::Fields fields;
+	CHECK(!DllCheckProtocol::parseResponse(key, payload, fields));
+
+	DllCheckProtocol::HmacKey otherKey = key;
+	otherKey[0] ^= 0xFF;
+	CHECK(!DllCheckProtocol::parseResponse(otherKey, valid, fields));
+}
+
+TEST_CASE(dllcheck_v4_rejects_wrong_session_and_response_window)
+{
+	DllCheckProtocol::Fields expected;
+	expected.timestamp = TIMESTAMP;
+	expected.sessionId = SESSION_ID;
+	expected.sequence = SEQUENCE;
+	expected.nonce = NONCE;
+	DllCheckProtocol::Fields received = expected;
+	CHECK(DllCheckProtocol::matchesExpectedResponse(received, expected));
+
+	++received.timestamp;
+	CHECK(!DllCheckProtocol::matchesExpectedResponse(received, expected));
+	received = expected;
+	++received.sessionId;
+	CHECK(!DllCheckProtocol::matchesExpectedResponse(received, expected));
+	received = expected;
+	++received.sequence;
+	CHECK(!DllCheckProtocol::matchesExpectedResponse(received, expected));
+	received = expected;
+	++received.nonce;
+	CHECK(!DllCheckProtocol::matchesExpectedResponse(received, expected));
+
+	CHECK(DllCheckProtocol::isResponseWindowValid(true, 1000, 1000));
+	CHECK(DllCheckProtocol::isResponseWindowValid(true, 1000, 5999));
+	CHECK(!DllCheckProtocol::isResponseWindowValid(false, 1000, 1000));
+	CHECK(!DllCheckProtocol::isResponseWindowValid(true, 1000, 999));
+	CHECK(!DllCheckProtocol::isResponseWindowValid(true, 1000, 6000));
+}
+
+TFS_TEST_MAIN()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened custom client validation with authenticated challenge and response checks.
  * Added verification of session, sequence, nonce, and build information to improve connection integrity.

* **Documentation**
  * Clarified connection settings for IPv4, protocol port usage, and production DNS or public IP configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the custom-client validation protocol.
- Migrates DLL checks to an HMAC-authenticated version-four challenge/response format.
- Adds session, nonce, sequence, build, integrity, and response-window validation.
- Adds configurable HMAC key loading and protocol regression fixtures covering valid and rejected responses.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/protocolgame.cpp | Implements authenticated DLL-check challenge generation and strict response validation. |
| src/protocolgame.h | Defines the version-four wire contract and tracks the additional per-session validation state. |
| src/tests/test_dllcheck_protocol.cpp | Adds executable wire-format fixtures and rejection coverage that address the previous review thread. |
| src/configmanager.cpp | Loads the DLL-check HMAC key from configuration with an environment-variable override. |
| config.lua.dist | Documents the new DLL-check key and endpoint configuration. |

<sub>Reviews (2): Last reviewed commit: ["feat(protocol): configure DLL check key"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/a1db879f8d764577f9d1a902c012387a2d94d621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46660194)</sub>

<!-- /greptile_comment -->