### PR TITLE
Fix critical bonuses and outfit handling

### DIFF
--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -197,7 +197,7 @@ local func = function(cid, text, type, e, pcid)
 		return
 	end
 
-	creature:say(text, type, false, pcid, creature:getPosition())
+	creature:say(text, type, false, player, creature:getPosition())
 	e.done = true
 end
 

--- a/data/scripts/spells/attack/knight/brutal_strike.lua
+++ b/data/scripts/spells/attack/knight/brutal_strike.lua
@@ -1,0 +1,41 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITAREA)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_WEAPONTYPE)
+combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
+combat:setParameter(COMBAT_PARAM_USECHARGES, true)
+
+local function calculateBaseDamageHealing(level)
+	local step = math.floor((math.sqrt(2 * level + 2025) + 5) / 10)
+	return math.floor((level + 1000) / step) + 50 * step - 450
+end
+
+local function callback(player, skill, attack, factor)
+	local skillTotal = skill * attack
+	local levelTotal = calculateBaseDamageHealing(player:getLevel())
+	local min = (((skillTotal * 0.02) + 4) + levelTotal) * 1.28
+	local max = (((skillTotal * 0.04) + 9) + levelTotal) * 1.28
+	return -min, -max
+end
+
+combat:setCallback(CallBackParam.SKILLVALUE, callback)
+
+local spell = Spell("instant")
+function spell.onCastSpell(creature, variant) return combat:execute(creature, variant) end
+
+spell:group("attack")
+spell:id(61)
+spell:name("Brutal Strike")
+spell:words("exori ico")
+spell:level(16)
+spell:mana(30)
+spell:isPremium(false)
+spell:range(1)
+spell:needTarget(true)
+spell:isBlockingWalls(true)
+spell:needWeapon(true)
+spell:cooldown(6 * 1000)
+spell:groupCooldown(2 * 1000)
+spell:needLearn(false)
+spell:vocation("knight", "elite knight")
+spell:register()

--- a/data/scripts/spells/attack/knight/front_sweep.lua
+++ b/data/scripts/spells/attack/knight/front_sweep.lua
@@ -1,0 +1,40 @@
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITAREA)
+combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
+combat:setParameter(COMBAT_PARAM_USECHARGES, true)
+combat:setArea(createCombatArea(AREA_WAVE6, AREADIAGONAL_WAVE6))
+
+local function calculateBaseDamageHealing(level)
+	local step = math.floor((math.sqrt(2 * level + 2025) + 5) / 10)
+	return math.floor((level + 1000) / step) + 50 * step - 450
+end
+
+local function callback(player, skill, attack, factor)
+	local skillTotal = skill * attack
+	local levelTotal = calculateBaseDamageHealing(player:getLevel())
+	local baseScale = 80 / 72
+	local min = (((skillTotal * 0.04) + 31) + levelTotal) * 1.1 * baseScale
+	local max = (((skillTotal * 0.08) + 45) + levelTotal) * 1.1 * baseScale
+	return -min, -max
+end
+
+combat:setCallback(CallBackParam.SKILLVALUE, callback)
+
+local spell = Spell("instant")
+function spell.onCastSpell(creature, variant) return combat:execute(creature, variant) end
+
+spell:group("attack")
+spell:id(59)
+spell:name("Front Sweep")
+spell:words("exori min")
+spell:level(70)
+spell:mana(200)
+spell:isPremium(true)
+spell:needDirection(true)
+spell:needWeapon(true)
+spell:cooldown(6 * 1000)
+spell:groupCooldown(2 * 1000)
+spell:needLearn(false)
+spell:vocation("knight", "elite knight")
+spell:register()

--- a/src/astraclient.h
+++ b/src/astraclient.h
@@ -13,23 +13,6 @@ namespace AstraClient {
 
 inline constexpr std::string_view LOGIN_MARKER = "A";
 inline constexpr std::string_view REQUIRED_MESSAGE = "This server requires AstraClient.";
-inline constexpr uint16_t CLIENT_860_MAX_OUTFIT_LOOKTYPE = 1921;
-inline constexpr uint16_t CLIENT_860_FALLBACK_OUTFIT_LOOKTYPE = 128;
-
-inline constexpr bool supports860OutfitLookType(uint16_t lookType)
-{
-	return lookType <= CLIENT_860_MAX_OUTFIT_LOOKTYPE;
-}
-
-inline constexpr uint16_t sanitize860OutfitLookType(uint16_t lookType)
-{
-	return supports860OutfitLookType(lookType) ? lookType : CLIENT_860_FALLBACK_OUTFIT_LOOKTYPE;
-}
-
-inline constexpr uint16_t sanitize860MountLookType(uint16_t lookType)
-{
-	return supports860OutfitLookType(lookType) ? lookType : 0;
-}
 
 inline uint32_t rotateLeft(uint32_t value, uint8_t bits)
 {

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1149,10 +1149,15 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 
 	bool success = false;
 	if (damage.primary.type != COMBAT_MANADRAIN) {
-		if (g_game.combatBlockHit(damage, caster, target, params.blockedByShield, params.blockedByArmor,
-		                          params.itemId != 0, params.ignoreResistances)) {
+		const int32_t perfectShotDamage = damage.perfectShotDamage;
+		damage.perfectShotDamage = 0;
+		const bool fullyBlocked =
+		    g_game.combatBlockHit(damage, caster, target, params.blockedByShield, params.blockedByArmor,
+		                          params.itemId != 0, params.ignoreResistances);
+		if (fullyBlocked && (perfectShotDamage == 0 || damage.blockType == BLOCK_NONE)) {
 			return;
 		}
+		damage.primary.value += perfectShotDamage;
 
 		if (target && target->getPlayer() &&
 				damage.primary.type != COMBAT_HEALING &&

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1212,10 +1212,10 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 				int32_t skill = std::max<int32_t>(
 				    0, static_cast<int32_t>(casterPlayer->getSpecialSkill(SPECIALSKILL_CRITICALHITAMOUNT)) +
 				           damage.criticalDamage + savageBonus);
-				if (skill == 0 && chance > 0) {
+				const int32_t roll = uniform_random(1, 10000);
+				if (skill == 0 && lowBlowBonus > 0 && roll > baseChance) {
 					skill = 5000;
 				}
-				const int32_t roll = uniform_random(1, 10000);
 				if (chance > 0 && skill > 0 && roll <= chance) {
 					damage.primary.value += std::round(damage.primary.value * (skill / 10000.));
 					damage.secondary.value += std::round(damage.secondary.value * (skill / 10000.));
@@ -1513,7 +1513,6 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		    0, static_cast<int32_t>(casterPlayer->getSpecialSkill(SPECIALSKILL_CRITICALHITAMOUNT)) +
 		           damage.criticalDamage);
 
-		if (skill == 0 && chance > 0) { skill = 5000; }
 		if (chance > 0 && skill > 0 && uniform_random(1, 10000) <= chance) {
 			criticalPrimary = std::round(damage.primary.value * (skill / 10000.));
 			criticalSecondary = std::round(damage.secondary.value * (skill / 10000.));

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1154,10 +1154,14 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 		const bool fullyBlocked =
 		    g_game.combatBlockHit(damage, caster, target, params.blockedByShield, params.blockedByArmor,
 		                          params.itemId != 0, params.ignoreResistances);
-		if (fullyBlocked && (perfectShotDamage == 0 || damage.blockType == BLOCK_NONE)) {
+		const bool perfectShotBypassesBlock =
+		    damage.blockType == BLOCK_DEFENSE || damage.blockType == BLOCK_ARMOR;
+		if (fullyBlocked && (perfectShotDamage == 0 || !perfectShotBypassesBlock)) {
 			return;
 		}
-		damage.primary.value += perfectShotDamage;
+		if (damage.blockType == BLOCK_NONE || perfectShotBypassesBlock) {
+			damage.primary.value += perfectShotDamage;
+		}
 
 		if (target && target->getPlayer() &&
 				damage.primary.type != COMBAT_HEALING &&

--- a/src/enums.h
+++ b/src/enums.h
@@ -782,6 +782,7 @@ struct CombatDamage
 	bool preyApplied = false;
 	int32_t criticalDamage = 0;
 	int32_t criticalChance = 0;
+	int32_t perfectShotDamage = 0;
 	int32_t lifeLeech = 0;
 	int32_t manaLeech = 0;
 	std::string instantSpellName;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -713,10 +713,10 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result, bool deferWorl
 				}
 
 				if (pid < 0) {
-					int32_t townId = ((-pid) - 1) / 20;
+					int32_t depotTownId = ((-pid) - 1) / 20;
 					int32_t boxIndex = ((-pid) - 1) % 20;
 					if (boxIndex >= 0 && boxIndex < 17) {
-						DepotChest* chest = player->getDepotChest(townId, true);
+						DepotChest* chest = player->getDepotChest(depotTownId, true);
 						for (const auto& boxItem : chest->getItemList()) {
 							if (boxItem->getID() == static_cast<uint16_t>(ITEM_DEPOT_BOX_1 + boxIndex)) {
 								transferLoadedItem(boxItem->getContainer(), item);

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -4171,6 +4171,7 @@ int luaPlayerReloadData(lua_State* L)
 
 	player->sendSkills();
 	player->sendStats();
+	player->sendBasicData();
 	pushBoolean(L, true);
 	return 1;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -1283,6 +1283,12 @@ public:
 	void sendItemValues() const;
 	void sendPing();
 	void sendStats();
+	void sendBasicData() const
+	{
+		if (client) {
+			client->sendBasicData();
+		}
+	}
 	void sendSkills() const
 	{
 		if (client) {

--- a/src/player.h
+++ b/src/player.h
@@ -827,13 +827,7 @@ public:
 
 	uint16_t getSpecialSkill(uint8_t skill) const
 	{
-		int32_t base = 0;
-		if (skill == SPECIALSKILL_CRITICALHITCHANCE) {
-			base = 500;
-		} else if (skill == SPECIALSKILL_CRITICALHITAMOUNT) {
-			base = 1000;
-		}
-		return static_cast<uint16_t>(std::max<int32_t>(0, base + varSpecialSkills[skill]));
+		return static_cast<uint16_t>(std::max<int32_t>(0, varSpecialSkills[skill]));
 	}
 	uint16_t getSkillLevel(uint8_t skill) const
 	{

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4783,9 +4783,8 @@ void ProtocolGame::sendOutfitWindow()
 
 	const bool monkVocationEnabled = ConfigManager::getBoolean(ConfigManager::MONK_VOCATION_ENABLED);
 	const bool isAstra860 = isAstraClient && getVersion() == 860;
-	auto isHiddenOutfit = [monkVocationEnabled, isAstra860](const Outfit* outfit) {
-		return outfit && ((!monkVocationEnabled && outfit->name == "Monk") ||
-		                  (isAstra860 && !AstraClient::supports860OutfitLookType(outfit->lookType)));
+	auto isHiddenOutfit = [monkVocationEnabled](const Outfit* outfit) {
+		return outfit && !monkVocationEnabled && outfit->name == "Monk";
 	};
 	auto firstVisibleOutfit = [&outfits, &isHiddenOutfit]() -> const Outfit* {
 		for (const Outfit* outfit : outfits) {
@@ -5327,11 +5326,9 @@ void ProtocolGame::AddPlayerSkills(NetworkMessage& msg)
 
 void ProtocolGame::AddOutfit(NetworkMessage& msg, const Outfit_t& outfit)
 {
-	const bool sanitize860Outfits = getVersion() == 860 && (isAstraClient || isOTC);
-	const uint16_t lookType = sanitize860Outfits ? AstraClient::sanitize860OutfitLookType(outfit.lookType) : outfit.lookType;
-	msg.add<uint16_t>(lookType);
+	msg.add<uint16_t>(outfit.lookType);
 
-	if (lookType != 0) {
+	if (outfit.lookType != 0) {
 		msg.addByte(outfit.lookHead);
 		msg.addByte(outfit.lookBody);
 		msg.addByte(outfit.lookLegs);
@@ -5342,7 +5339,7 @@ void ProtocolGame::AddOutfit(NetworkMessage& msg, const Outfit_t& outfit)
 	}
 
 	if (isOTC || getVersion() != 861) {
-		msg.add<uint16_t>(sanitize860Outfits ? AstraClient::sanitize860MountLookType(outfit.lookMount) : outfit.lookMount);
+		msg.add<uint16_t>(outfit.lookMount);
 	}
 }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -24,6 +24,7 @@
 #include "logger.h"
 #include "scheduler.h"
 #include "scriptmanager.h"
+#include "spells.h"
 #include "thread_pool.h"
 
 #include <algorithm>
@@ -3361,6 +3362,10 @@ void ProtocolGame::sendStats()
 
 void ProtocolGame::sendBasicData()
 {
+	if (!player || !isAstraClient) {
+		return;
+	}
+
 	NetworkMessage msg;
 	msg.addByte(0x9F);
 
@@ -3373,8 +3378,24 @@ void ProtocolGame::sendBasicData()
 	// prey - OTC client expects 1 byte for prey status when GamePrey feature is enabled
 	msg.addByte(0x00);
 
-	// spells - send known spells count + ids
-	msg.add<uint16_t>(0); // spell count = 0 (protocol 8.60 doesn't use this packet for spells)
+	std::vector<uint16_t> knownSpells;
+	if (g_spells) {
+		for (const auto& entry : g_spells->getInstantSpells()) {
+			const auto& spell = entry.second;
+			if (spell.getId() != 0 && spell.canCast(player.get())) {
+				knownSpells.push_back(spell.getId());
+			}
+		}
+	}
+
+	std::ranges::sort(knownSpells);
+	knownSpells.erase(std::unique(knownSpells.begin(), knownSpells.end()), knownSpells.end());
+
+	msg.add<uint16_t>(static_cast<uint16_t>(knownSpells.size()));
+	for (uint16_t spellId : knownSpells) {
+		msg.add<uint16_t>(spellId);
+	}
+	msg.addByte(player->getVocation()->getMagicShield());
 
 	writeToOutputBuffer(msg);
 }
@@ -4412,7 +4433,7 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	sendStats();
 	sendSkills();
 
-	if (isOTC) {
+	if (isAstraClient) {
 		sendBasicData();
 	}
 

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -79,7 +79,6 @@ LoginBoostedEntry getBoostedCreatureLoginEntry()
 	entry.raceId = monsterType->raceId;
 	entry.name = monsterType->name;
 	entry.outfit = monsterType->info.outfit;
-	entry.outfit.lookType = AstraClient::sanitize860OutfitLookType(entry.outfit.lookType);
 	return entry;
 }
 
@@ -106,7 +105,7 @@ LoginBoostedEntry getBoostedBossLoginEntry()
 
 	entry.raceId = result->getNumber<uint32_t>("raceid");
 	entry.name = std::string{result->getString("boostname")};
-	entry.outfit.lookType = AstraClient::sanitize860OutfitLookType(result->getNumber<uint16_t>("looktype"));
+	entry.outfit.lookType = result->getNumber<uint16_t>("looktype");
 	entry.outfit.lookHead = result->getNumber<uint8_t>("lookhead");
 	entry.outfit.lookBody = result->getNumber<uint8_t>("lookbody");
 	entry.outfit.lookLegs = result->getNumber<uint8_t>("looklegs");
@@ -279,7 +278,7 @@ void ProtocolLogin::getCharacterList(std::string_view accountName, std::string_v
 			CharacterListEntry character;
 			character.name = std::string{result->getString("name")};
 			character.level = result->getNumber<uint32_t>("level");
-			character.lookType = AstraClient::sanitize860OutfitLookType(result->getNumber<uint16_t>("looktype"));
+			character.lookType = result->getNumber<uint16_t>("looktype");
 			character.lookHead = result->getNumber<uint8_t>("lookhead");
 			character.lookBody = result->getNumber<uint8_t>("lookbody");
 			character.lookLegs = result->getNumber<uint8_t>("looklegs");

--- a/src/protocolspectator.h
+++ b/src/protocolspectator.h
@@ -518,6 +518,18 @@ class ProtocolSpectator {
                 spy->sendStats();
         }
 
+        void sendBasicData() {
+            auto o = owner.lock();
+            if (o)
+                o->sendBasicData();
+
+            for (auto &it : spectators)
+                it->sendBasicData();
+
+            for (auto &spy : spyClients_)
+                spy->sendBasicData();
+        }
+
         void sendTextMessage(const TextMessage &message) {
             auto o = owner.lock();
             if (o)

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -444,6 +444,8 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int
 			if (!chainCombat->doCombatChain(player, target, params.aggressive)) {
 				Combat::doTargetCombat(player, target, damage, params);
 			} else if (perfectShotDelta != 0) {
+				damage.primary.value += perfectShotDelta;
+
 				// doCombatChain recomputes damage per target and ignores our boosted `damage`, so the
 				// primary target would otherwise lose the perfect shot bonus. Deliver just the bonus to
 				// it as an extra flat hit, re-resolving by id since the chain may have freed the target.

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -61,8 +61,7 @@ int32_t getPerfectShotDamage(const Player* player, const Item* attackingItem, co
 	return perfectShotDamage;
 }
 
-// Folds the perfect shot bonus into damage and returns the signed delta it applied (0 if none), so
-// callers that route damage elsewhere (e.g. the chain system) can re-deliver the same bonus.
+// Stores the perfect shot bonus separately so combat blocking cannot absorb the flat damage.
 int32_t applyPerfectShotDamage(const Player* player, const Item* item, const Creature* target, CombatDamage& damage)
 {
 	if (damage.origin != ORIGIN_RANGED && damage.origin != ORIGIN_WAND) {
@@ -81,7 +80,7 @@ int32_t applyPerfectShotDamage(const Player* player, const Item* item, const Cre
 		delta = perfectShotDamage;
 	}
 
-	damage.primary.value += delta;
+	damage.perfectShotDamage = delta;
 	return delta;
 }
 
@@ -452,7 +451,7 @@ void Weapon::internalUseWeapon(Player* player, Item* item, Creature* target, int
 					CombatDamage perfectShotHit;
 					perfectShotHit.origin = damage.origin;
 					perfectShotHit.primary.type = damage.primary.type;
-					perfectShotHit.primary.value = perfectShotDelta;
+					perfectShotHit.perfectShotDamage = perfectShotDelta;
 
 					CombatParams perfectShotParams;
 					perfectShotParams.combatType = damage.primary.type;


### PR DESCRIPTION
## Summary

- Remove the hardcoded base critical hit chance and extra damage from every player.
- Respect zero critical damage instead of applying a general 50% fallback, while preserving the explicit Low Blow rule.
- Remove the obsolete 8.60 outfit sanitizer so the AstraClient receives supported outfit and mount looktypes unchanged.

## Root cause

`Player::getSpecialSkill` granted every character +5% critical chance and +10% damage without an active bonus source. After removing those defaults, the general combat fallback could turn chance-only bonuses into 50% extra damage. The outfit sanitizer also used an outdated maximum looktype of `1921`, while the current AstraClient data supports creature IDs through `1975`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combat damage handling so perfect-shot bonuses are preserved when attacks are blocked.
  * Adjusted critical-hit calculations for more consistent skill and charm interactions.
  * Fixed delayed speech events to correctly identify the speaking player.
  * Removed unintended hardcoded baseline values from special-skill calculations.

* **Compatibility**
  * Improved outfit and mount handling for supported clients, including Monk outfit visibility and appearance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects critical-hit bonus handling and updates AstraClient appearance compatibility.
- Removes unconditional baseline critical-hit chance and damage from players.
- Restricts the zero-amount 50% fallback to Low Blow’s explicit critical-chance segment while preserving its area-combat handling.
- Preserves perfect-shot damage through armor and defense blocking.
- Sends supported outfit and mount looktypes without the obsolete 8.60 sanitizer.
- Adds AstraClient spell data refreshes, two knight attack spells, and related compatibility fixes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported zero-amount critical fallback is fixed: ordinary chance-only bonuses no longer receive 50% extra damage, while Low Blow retains its explicit fallback on the probability segment supplied by that charm.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/combat.cpp | Correctly confines the 50% zero-amount fallback to Low Blow and preserves perfect-shot damage across block processing. |
| src/player.h | Removes unintended baseline critical skills and exposes guarded basic-data forwarding. |
| src/weapons.cpp | Tracks perfect-shot damage separately so block processing and chain attacks retain the flat bonus. |
| src/protocolgame.cpp | Sends AstraClient spell metadata and removes obsolete outfit and mount filtering. |
| src/protocollogin.cpp | Preserves configured appearance looktypes in AstraClient login payloads. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(login): avoid shadowed town id"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/4219d4b3c4bf72dfb0e332f37d85a1fe9a13a09f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47316627)</sub>

<!-- /greptile_comment -->