### PR TITLE
feat(items): add optional assets.dat item source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,7 @@ pip-log.txt
 #############
 config.lua
 jenkins-credentials.txt
+data/items/assets.dat
 
 # Ignorar ejecutable principal en linux
 tfs

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -328,6 +328,13 @@ mysqlDatabase = "forgottenserver"
 mysqlPort = 3306
 mysqlSock = ""
 
+-- Items
+-- To enable assets.dat, copy Tibia.dat from your Tibia 8.60 client into
+-- data/items, rename the copy to assets.dat, and then set useAssetsDat to true.
+-- Keep the original client file unchanged. Use assetsDatPath for a different copied location.
+useAssetsDat = false
+assetsDatPath = "data/items/assets.dat"
+
 -- Misc.
 -- NOTE: classicAttackSpeed set to true makes players constantly attack at regular
 -- intervals regardless of other actions such as item (potion) use. This setting

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -40133,7 +40133,7 @@
 	</item>
 	<item id="22327" article="a" name="stone spiked club">
 	</item>
-	<item fromid="22328" toid="22323" article="a" name="large totem pole" />
+	<item fromid="22328" toid="22333" article="a" name="large totem pole" />
 	<item fromid="22334" toid="22335" article="a" name="clay hut">
 	</item>
 	<item fromid="22336" toid="22337" article="a" name="clay hut entrance">
@@ -43404,7 +43404,7 @@
 		<attribute key="decayTo" value="0" />
 	</item>
 	<item fromid="25135" toid="25138" name="unknown item" />
-	<item fromid="25139" toid="25134" name="RESERVED SPRITE" />
+	<item fromid="25139" toid="25140" name="RESERVED SPRITE" />
 	<item id="25141" name="unknown item" />
 	<item id="25142" name="dragon lair wall" />
 	<item fromid="25143" toid="25145" name="RESERVED SPRITE" />
@@ -56542,7 +56542,7 @@
 	</item>
 	<item id="33211" article="a" name="cornerstone" />
 	<item fromid="33212" toid="33226" article="a" name="wall" />
-	<item fromid="33231" toid="33227" article="a" name="buttress" />
+	<item fromid="33227" toid="33231" article="a" name="buttress" />
 	<item id="33232" article="a" name="ramp" />
 	<item id="33233" article="a" name="ramp">
 		<attribute key="floorchange" value="north" />
@@ -72930,7 +72930,7 @@
 		<attribute key="description" value="Drinking this potion temporarily increases your fist skill" />
 		<attribute key="weight" value="290" />
 	</item>
-	<item toid="49282" fromid="49329" article="a" name="brick wall" />
+	<item fromid="49282" toid="49329" article="a" name="brick wall" />
 	<item id="49371" article="a" name="lesser spiritualist gem" plural="lesser spiritualist gems">
 		<attribute key="description" value="Shines with the strength of monks." />
 		<attribute key="weight" value="20" />

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -385,6 +385,10 @@ bool ConfigManager::load()
 		integers[Integer::MARKET_OFFER_DURATION] = getGlobalInteger(L, "marketOfferDuration", 30 * 24 * 60 * 60);
 	}
 
+	// Item source is reloadable; keep both values outside the one-time block.
+	booleans[Boolean::USE_ASSETS_DAT] = getGlobalBoolean(L, "useAssetsDat", false);
+	strings[String::ASSETS_DAT_PATH] = getGlobalString(L, "assetsDatPath", "data/items/assets.dat");
+
 	booleans[Boolean::ALLOW_CHANGEOUTFIT] = getGlobalBoolean(L, "allowChangeOutfit", true);
 	booleans[Boolean::ONE_PLAYER_ON_ACCOUNT] = getGlobalBoolean(L, "onePlayerOnlinePerAccount", true);
 	booleans[Boolean::AIMBOT_HOTKEY_ENABLED] = getGlobalBoolean(L, "hotkeyAimbotEnabled", true);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -141,6 +141,7 @@ enum Boolean
 	SOULSEALS_SYSTEM_ENABLED,
 	CLEAVE_SYSTEM_ENABLED,
 	CHARACTER_BAZAAR_ENABLED,
+	USE_ASSETS_DAT,
 
 	LAST_BOOLEAN /* this must be the last one */
 };
@@ -178,6 +179,7 @@ enum String
 	DUAL_WIELDING_MODE,
 	RAID_SPAWNFILE_DIRECTORY,
 	DLL_CHECK_HMAC_KEY,
+	ASSETS_DAT_PATH,
 
 	LAST_STRING /* this must be the last one */
 };

--- a/src/datitemloader.h
+++ b/src/datitemloader.h
@@ -1,0 +1,49 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_DATITEMLOADER_H
+#define FS_DATITEMLOADER_H
+
+#include <cstdint>
+
+// Thing flags used by the Tibia 8.60 DAT item section.
+enum class ItemDatFlag : uint8_t
+{
+	Ground = 0,
+	GroundBorder = 1,
+	OnBottom = 2,
+	OnTop = 3,
+	Container = 4,
+	Stackable = 5,
+	ForceUse = 6,
+	MultiUse = 7,
+	Writable = 8,
+	WritableOnce = 9,
+	FluidContainer = 10,
+	Fluid = 11,
+	IsUnpassable = 12,
+	IsUnmoveable = 13,
+	BlockMissiles = 14,
+	BlockPathfinder = 15,
+	Pickupable = 16,
+	Hangable = 17,
+	IsHorizontal = 18,
+	IsVertical = 19,
+	Rotatable = 20,
+	HasLight = 21,
+	DontHide = 22,
+	Translucent = 23,
+	HasOffset = 24,
+	HasElevation = 25,
+	Lying = 26,
+	AnimateAlways = 27,
+	Minimap = 28,
+	LensHelp = 29,
+	FullGround = 30,
+	IgnoreLook = 31,
+	Cloth = 32,
+	MarketItem = 33,
+	LastFlag = 255,
+};
+
+#endif

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -57,6 +57,15 @@ bool transferMapItem(Cylinder* cylinder, std::shared_ptr<Item>& item)
 	return true;
 }
 
+void logMapItemSourceCompatibility()
+{
+	if (Item::items.isLoadedFromDat()) {
+		g_logger().info(">> Map item source compatibility: DAT client IDs");
+	} else {
+		g_logger().info(">> Map item source compatibility: OTB");
+	}
+}
+
 void appendEscapedProperties(std::vector<uint8_t>& output, OTB::Loader& loader, const OTB::Node& node)
 {
 	if (node.propsBegin == node.propsEnd) {
@@ -214,6 +223,7 @@ bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName, bool usePer
             map->housefile = houseFile;
             g_logger().info(">> Persistent map cache hit completed in {:.3f} seconds.",
                             std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count());
+            logMapItemSourceCompatibility();
 			if (reportStartupProgress) {
 				startupProgress().updateFraction(1.0, "persistent cache loaded");
 			}
@@ -262,25 +272,27 @@ bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName, bool usePer
             return false;
         }
 
-        if (root_header.majorVersionItems < 3) {
-            setLastErrorString(
-                "This map need to be upgraded by using the latest map editor version to be able to load correctly.");
-            return false;
-        }
+        if (!Item::items.isLoadedFromDat()) {
+            if (root_header.majorVersionItems < 3) {
+                setLastErrorString(
+                    "This map need to be upgraded by using the latest map editor version to be able to load correctly.");
+                return false;
+            }
 
-        if (root_header.majorVersionItems > Item::items.majorVersion) {
-            setLastErrorString(
-                "The map was saved with a different items.otb version, an upgraded items.otb is required.");
-            return false;
-        }
+            if (root_header.majorVersionItems > Item::items.majorVersion) {
+                setLastErrorString(
+                    "The map was saved with a different items.otb version, an upgraded items.otb is required.");
+                return false;
+            }
 
-        if (root_header.minorVersionItems < CLIENT_VERSION_810) {
-            setLastErrorString("This map needs to be updated.");
-            return false;
-        }
+            if (root_header.minorVersionItems < CLIENT_VERSION_810) {
+                setLastErrorString("This map needs to be updated.");
+                return false;
+            }
 
-        if (root_header.minorVersionItems > Item::items.minorVersion) {
-            g_logger().warn("This map needs an updated items.otb.");
+            if (root_header.minorVersionItems > Item::items.minorVersion) {
+                g_logger().warn("This map needs an updated items.otb.");
+            }
         }
 
         g_logger().info(">> Map size: {}x{}.", root_header.width, root_header.height);
@@ -368,6 +380,7 @@ bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName, bool usePer
     MapCache::flush();
     g_logger().info(">> Map loading time: {:.3f} seconds.",
                     std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count());
+    logMapItemSourceCompatibility();
 	if (reportStartupProgress) {
 		startupProgress().updateFraction(1.0, "OTBM ready");
 	}
@@ -519,9 +532,25 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
                     }
 
                     case OTBM_AttrTypes_t::ITEM: {
+                        PropStream idStream = tilePropStream;
+                        uint16_t serializedId = 0;
+                        if (!idStream.read<uint16_t>(serializedId)) {
+                            setLastErrorString(
+                                fmt::format("[x:{:d}, y:{:d}, z:{:d}] Could not read map item id.", x, y, z));
+                            return false;
+                        }
+                        if (Item::items.isLoadedFromDat() && !Item::items.isValidItemId(serializedId)) {
+                            setLastErrorString(fmt::format(
+                                "[x:{:d}, y:{:d}, z:{:d}] Map contains unknown item id {} for the selected DAT source.",
+                                x, y, z, serializedId));
+                            return false;
+                        }
+
                         auto item = Item::CreateItem(tilePropStream);
                         if (!item) {
-                            setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Failed to create item.", x, y, z));
+                            setLastErrorString(fmt::format(
+                                "[x:{:d}, y:{:d}, z:{:d}] Failed to create map item id {} for the selected {} source.",
+                                x, y, z, serializedId, Item::items.isLoadedFromDat() ? "DAT" : "OTB"));
                             return false;
                         }
 
@@ -575,9 +604,25 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
                     return false;
                 }
 
+                PropStream idStream = stream;
+                uint16_t serializedId = 0;
+                if (!idStream.read<uint16_t>(serializedId)) {
+                    setLastErrorString(
+                        fmt::format("[x:{:d}, y:{:d}, z:{:d}] Could not read map item id.", x, y, z));
+                    return false;
+                }
+                if (Item::items.isLoadedFromDat() && !Item::items.isValidItemId(serializedId)) {
+                    setLastErrorString(fmt::format(
+                        "[x:{:d}, y:{:d}, z:{:d}] Map contains unknown item id {} for the selected DAT source.", x, y,
+                        z, serializedId));
+                    return false;
+                }
+
                 auto item = Item::CreateItem(stream);
                 if (!item) {
-                    setLastErrorString(fmt::format("[x:{:d}, y:{:d}, z:{:d}] Failed to create item.", x, y, z));
+                    setLastErrorString(fmt::format(
+                        "[x:{:d}, y:{:d}, z:{:d}] Failed to create map item id {} for the selected {} source.", x, y, z,
+                        serializedId, Item::items.isLoadedFromDat() ? "DAT" : "OTB"));
                     return false;
                 }
 
@@ -631,10 +676,14 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
                 return false;
             }
 
-            uint8_t xOffset, yOffset;
-            auto basicTile = MapCache::parseBasicTile(&loader, &tileNode, xOffset, yOffset);
+            uint8_t xOffset = 0;
+            uint8_t yOffset = 0;
+            std::string tileError;
+            auto basicTile = MapCache::parseBasicTile(&loader, &tileNode, xOffset, yOffset, tileError);
             if (!basicTile) {
-                setLastErrorString("Failed to parse basic tile.");
+                setLastErrorString(fmt::format("[x:{}, y:{}, z:{}] Failed to parse basic tile: {}", base_x + xOffset,
+                                               base_y + yOffset, z,
+                                               tileError.empty() ? "unknown error" : tileError));
                 return false;
             }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -138,37 +138,39 @@ std::shared_ptr<Item> Item::CreateItem(PropStream& propStream)
 		return nullptr;
 	}
 
-	switch (id) {
-		case ITEM_FIREFIELD_PVP_FULL:
-			id = ITEM_FIREFIELD_PERSISTENT_FULL;
-			break;
+	if (!Item::items.isLoadedFromDat()) {
+		switch (id) {
+			case ITEM_FIREFIELD_PVP_FULL:
+				id = ITEM_FIREFIELD_PERSISTENT_FULL;
+				break;
 
-		case ITEM_FIREFIELD_PVP_MEDIUM:
-			id = ITEM_FIREFIELD_PERSISTENT_MEDIUM;
-			break;
+			case ITEM_FIREFIELD_PVP_MEDIUM:
+				id = ITEM_FIREFIELD_PERSISTENT_MEDIUM;
+				break;
 
-		case ITEM_FIREFIELD_PVP_SMALL:
-			id = ITEM_FIREFIELD_PERSISTENT_SMALL;
-			break;
+			case ITEM_FIREFIELD_PVP_SMALL:
+				id = ITEM_FIREFIELD_PERSISTENT_SMALL;
+				break;
 
-		case ITEM_ENERGYFIELD_PVP:
-			id = ITEM_ENERGYFIELD_PERSISTENT;
-			break;
+			case ITEM_ENERGYFIELD_PVP:
+				id = ITEM_ENERGYFIELD_PERSISTENT;
+				break;
 
-		case ITEM_POISONFIELD_PVP:
-			id = ITEM_POISONFIELD_PERSISTENT;
-			break;
+			case ITEM_POISONFIELD_PVP:
+				id = ITEM_POISONFIELD_PERSISTENT;
+				break;
 
-		case ITEM_MAGICWALL:
-			id = ITEM_MAGICWALL_PERSISTENT;
-			break;
+			case ITEM_MAGICWALL:
+				id = ITEM_MAGICWALL_PERSISTENT;
+				break;
 
-		case ITEM_WILDGROWTH:
-			id = ITEM_WILDGROWTH_PERSISTENT;
-			break;
+			case ITEM_WILDGROWTH:
+				id = ITEM_WILDGROWTH_PERSISTENT;
+				break;
 
-		default:
-			break;
+			default:
+				break;
+		}
 	}
 
 	return Item::CreateItem(id, 0);

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -1103,11 +1103,13 @@ bool Items::reload()
 	// all non-side-effecting XML attributes have been validated.
 	swapState(loadedItems);
 
-	const bool registriesLoaded = g_moveEvents->reload() && g_weapons->reload() &&
-	                              loadFromXmlDocument(doc, true, true) && g_scripts->loadScripts("items", false, true);
+	// Item scripts share the global revscript Lua state, which cannot be rolled
+	// back atomically. Leave script loading to the script-system reload.
+	const bool registriesLoaded =
+	    g_moveEvents->reload() && g_weapons->reload() && loadFromXmlDocument(doc, true, true);
 	if (!registriesLoaded) {
 		const std::string registryError =
-		    "Unable to rebuild item moveevents, weapons or item scripts; previous item state restored.";
+		    "Unable to rebuild item moveevents or weapons; previous item state restored.";
 		swapState(loadedItems);
 
 		// Restore registries against the old ItemType table using the already
@@ -1115,9 +1117,7 @@ bool Items::reload()
 		const bool moveEventsRestored = g_moveEvents->reload();
 		const bool weaponsRestored = g_weapons->reload();
 		const bool itemXmlRegistriesRestored = loadFromXmlDocument(doc, true, true);
-		const bool itemScriptsRestored = g_scripts->loadScripts("items", false, true);
-		const bool restored =
-		    moveEventsRestored && weaponsRestored && itemXmlRegistriesRestored && itemScriptsRestored;
+		const bool restored = moveEventsRestored && weaponsRestored && itemXmlRegistriesRestored;
 		g_weapons->loadDefaults();
 		if (!restored) {
 			LOG_ERROR(

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -807,6 +807,33 @@ bool skipDatSpriteLayout(DatReader& reader, uint16_t itemId, size_t spriteIdByte
 	return skipDatBytes(reader, spriteBytes, error, fmt::format("sprite IDs for item {}", itemId));
 }
 
+bool validateDatVisualSection(DatReader& reader, uint16_t count, std::string_view sectionName,
+                              size_t spriteIdBytes, DatParseError& error)
+{
+	for (uint32_t id = 1; id <= count; ++id) {
+		// Visual records use the same bounded attribute and sprite-layout encoding
+		// as items, but their parsed values are intentionally discarded.
+		ItemType discardedType;
+		uint32_t discardedMarketItemCount = 0;
+		DatParseError recordError;
+		if (!readDatAttributes(discardedType, static_cast<uint16_t>(id), reader, recordError,
+		                       discardedMarketItemCount)) {
+			error.set(recordError.offset,
+			          fmt::format("{} {}: {}", sectionName, id, recordError.message));
+			return false;
+		}
+
+		uint8_t discardedFrameCount = 0;
+		if (!skipDatSpriteLayout(reader, static_cast<uint16_t>(id), spriteIdBytes, discardedFrameCount,
+		                         recordError)) {
+			error.set(recordError.offset,
+			          fmt::format("{} {}: {}", sectionName, id, recordError.message));
+			return false;
+		}
+	}
+	return true;
+}
+
 struct DatParseResult
 {
 	std::vector<ItemType> items;
@@ -870,17 +897,14 @@ bool parseDatBuffer(const std::vector<uint8_t>& buffer, size_t spriteIdBytes, Da
 		itemType.isAnimation = itemType.isAnimation || frameCount > 1;
 	}
 
-	size_t visualCount = static_cast<size_t>(result.outfitCount) + result.effectCount + result.distanceEffectCount;
-	if (visualCount == 0 && reader.remaining() != 0) {
-		error.set(reader.position(),
-		          fmt::format("{} unexpected bytes remain after the item section", reader.remaining()));
+	if (!validateDatVisualSection(reader, result.outfitCount, "outfit", spriteIdBytes, error) ||
+	    !validateDatVisualSection(reader, result.effectCount, "effect", spriteIdBytes, error) ||
+	    !validateDatVisualSection(reader, result.distanceEffectCount, "distance effect", spriteIdBytes, error)) {
 		return false;
 	}
-	size_t minimumVisualBytes = 0;
-	if (!checkedMultiply(visualCount, 7 + spriteIdBytes, minimumVisualBytes) ||
-	    reader.remaining() < minimumVisualBytes) {
+	if (reader.remaining() != 0) {
 		error.set(reader.position(),
-		          fmt::format("only {} bytes remain for {} declared visual entries", reader.remaining(), visualCount));
+		          fmt::format("{} unexpected bytes remain after the declared DAT sections", reader.remaining()));
 		return false;
 	}
 
@@ -1088,8 +1112,12 @@ bool Items::reload()
 
 		// Restore registries against the old ItemType table using the already
 		// parsed XML document. No source or XML file is reopened during rollback.
-		const bool restored = g_moveEvents->reload() && g_weapons->reload() && loadFromXmlDocument(doc, true, true) &&
-		                      g_scripts->loadScripts("items", false, true);
+		const bool moveEventsRestored = g_moveEvents->reload();
+		const bool weaponsRestored = g_weapons->reload();
+		const bool itemXmlRegistriesRestored = loadFromXmlDocument(doc, true, true);
+		const bool itemScriptsRestored = g_scripts->loadScripts("items", false, true);
+		const bool restored =
+		    moveEventsRestored && weaponsRestored && itemXmlRegistriesRestored && itemScriptsRestored;
 		g_weapons->loadDefaults();
 		if (!restored) {
 			LOG_ERROR(

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -5,18 +5,20 @@
 
 #include "items.h"
 
+#include "configmanager.h"
+#include "datitemloader.h"
+#include "itemloader.h"
+#include "logger.h"
 #include "movement.h"
 #include "pugicast.h"
 #include "script.h"
 #include "scriptmanager.h"
 #include "spells.h"
 #include "weapons.h"
-#include "logger.h"
+#include <charconv>
 #include <fmt/format.h>
 #include <fstream>
-#include <cstring>
-#include "configmanager.h"
-#include "itemloader.h"
+#include <limits>
 
 namespace {
 
@@ -239,6 +241,7 @@ const std::unordered_map<std::string, ItemParseAttributes_t> ItemParseAttributes
     {"worth", ITEM_PARSE_WORTH},
     {"imbuementslot", ITEM_PARSE_IMBUEMENTSLOT},
     {"wrapableto", ITEM_PARSE_WRAPABLETO},
+    {"stackable", ITEM_PARSE_STACKABLE},
     {"stacksize", ITEM_PARSE_STACKSIZE},
     {"supply", ITEM_PARSE_SUPPLY},
     {"experienceratebase", ITEM_PARSE_EXPERIENCERATE_BASE},
@@ -380,6 +383,525 @@ Direction getDirection(std::string_view string)
 	return DIRECTION_NORTH;
 }
 
+constexpr uint32_t TIBIA_860_DAT_SIGNATURE = 0x4C2C7993;
+constexpr size_t MAX_ASSETS_DAT_FILE_SIZE = 256ULL * 1024 * 1024;
+constexpr uint32_t MAX_DAT_OUTFITS = 20'000;
+constexpr uint32_t MAX_DAT_EFFECTS = 10'000;
+constexpr uint32_t MAX_DAT_DISTANCE_EFFECTS = 10'000;
+constexpr uint8_t MAX_DAT_SPRITE_DIMENSION = 32;
+constexpr uint8_t MAX_DAT_LAYERS = 8;
+constexpr uint8_t MAX_DAT_PATTERN_DIMENSION = 32;
+constexpr size_t MAX_DAT_SPRITES_PER_ITEM = 65'536;
+constexpr uint16_t FIRST_DAT_ITEM_ID = 100;
+constexpr uint16_t FIRST_SERVER_ONLY_ITEM_ID = 65'000;
+constexpr size_t MAX_DAT_MARKET_NAME_LENGTH = 1'024;
+
+struct DatParseError
+{
+	size_t offset = 0;
+	std::string message;
+
+	void set(size_t errorOffset, std::string errorMessage)
+	{
+		if (message.empty()) {
+			offset = errorOffset;
+			message = std::move(errorMessage);
+		}
+	}
+};
+
+class DatReader
+{
+public:
+	explicit DatReader(const std::vector<uint8_t>& input) : buffer(input) {}
+
+	size_t position() const { return offset; }
+	size_t remaining() const { return buffer.size() - offset; }
+
+	bool readU8(uint8_t& value)
+	{
+		if (remaining() < 1) {
+			return false;
+		}
+		value = buffer[offset++];
+		return true;
+	}
+
+	bool readU16LE(uint16_t& value)
+	{
+		if (remaining() < 2) {
+			return false;
+		}
+		value = static_cast<uint16_t>(buffer[offset]) | (static_cast<uint16_t>(buffer[offset + 1]) << 8);
+		offset += 2;
+		return true;
+	}
+
+	bool readU32LE(uint32_t& value)
+	{
+		if (remaining() < 4) {
+			return false;
+		}
+		value = static_cast<uint32_t>(buffer[offset]) | (static_cast<uint32_t>(buffer[offset + 1]) << 8) |
+		        (static_cast<uint32_t>(buffer[offset + 2]) << 16) | (static_cast<uint32_t>(buffer[offset + 3]) << 24);
+		offset += 4;
+		return true;
+	}
+
+	bool skipChecked(size_t count)
+	{
+		if (count > remaining()) {
+			return false;
+		}
+		offset += count;
+		return true;
+	}
+
+private:
+	const std::vector<uint8_t>& buffer;
+	size_t offset = 0;
+};
+
+bool readDatU8(DatReader& reader, uint8_t& value, DatParseError& error, std::string_view context)
+{
+	const size_t offset = reader.position();
+	if (reader.readU8(value)) {
+		return true;
+	}
+	error.set(offset, fmt::format("truncated data while reading {}", context));
+	return false;
+}
+
+bool readDatU16(DatReader& reader, uint16_t& value, DatParseError& error, std::string_view context)
+{
+	const size_t offset = reader.position();
+	if (reader.readU16LE(value)) {
+		return true;
+	}
+	error.set(offset, fmt::format("truncated data while reading {}", context));
+	return false;
+}
+
+bool readDatU32(DatReader& reader, uint32_t& value, DatParseError& error, std::string_view context)
+{
+	const size_t offset = reader.position();
+	if (reader.readU32LE(value)) {
+		return true;
+	}
+	error.set(offset, fmt::format("truncated data while reading {}", context));
+	return false;
+}
+
+bool skipDatBytes(DatReader& reader, size_t count, DatParseError& error, std::string_view context)
+{
+	const size_t offset = reader.position();
+	if (reader.skipChecked(count)) {
+		return true;
+	}
+	error.set(offset, fmt::format("truncated data while skipping {} ({} bytes requested, {} remain)", context, count,
+	                              reader.remaining()));
+	return false;
+}
+
+bool checkedMultiply(size_t left, size_t right, size_t& result)
+{
+	if (left != 0 && right > (std::numeric_limits<size_t>::max)() / left) {
+		return false;
+	}
+	result = left * right;
+	return true;
+}
+
+bool readDatAttributes(ItemType& itemType, uint16_t itemId, DatReader& reader, DatParseError& error,
+                       uint32_t& marketItemCount)
+{
+	for (;;) {
+		const size_t flagOffset = reader.position();
+		uint8_t rawFlag = 0;
+		if (!readDatU8(reader, rawFlag, error, fmt::format("flag for item {}", itemId))) {
+			return false;
+		}
+
+		switch (static_cast<ItemDatFlag>(rawFlag)) {
+			case ItemDatFlag::Ground: {
+				uint16_t speed = 0;
+				if (!readDatU16(reader, speed, error, fmt::format("ground speed for item {}", itemId))) {
+					return false;
+				}
+				itemType.group = ITEM_GROUP_GROUND;
+				itemType.speed = speed;
+				break;
+			}
+
+			case ItemDatFlag::GroundBorder:
+				itemType.alwaysOnTopOrder = 1;
+				break;
+
+			case ItemDatFlag::OnBottom:
+				itemType.alwaysOnTopOrder = 2;
+				break;
+
+			case ItemDatFlag::OnTop:
+				itemType.alwaysOnTopOrder = 3;
+				break;
+
+			case ItemDatFlag::Container:
+				itemType.group = ITEM_GROUP_CONTAINER;
+				itemType.type = ITEM_TYPE_CONTAINER;
+				break;
+
+			case ItemDatFlag::Stackable:
+				itemType.stackable = true;
+				break;
+
+			case ItemDatFlag::ForceUse:
+				itemType.forceUse = true;
+				break;
+
+			case ItemDatFlag::MultiUse:
+				itemType.useable = true;
+				break;
+
+			case ItemDatFlag::Writable: {
+				uint16_t maxTextLength = 0;
+				if (!readDatU16(reader, maxTextLength, error, fmt::format("writable length for item {}", itemId))) {
+					return false;
+				}
+				itemType.canWriteText = true;
+				itemType.canReadText = true;
+				itemType.maxTextLen = maxTextLength;
+				break;
+			}
+
+			case ItemDatFlag::WritableOnce: {
+				uint16_t maxTextLength = 0;
+				if (!readDatU16(reader, maxTextLength, error, fmt::format("write-once length for item {}", itemId))) {
+					return false;
+				}
+				itemType.canReadText = true;
+				itemType.maxTextLen = maxTextLength;
+				break;
+			}
+
+			case ItemDatFlag::FluidContainer:
+				itemType.group = ITEM_GROUP_FLUID;
+				break;
+
+			case ItemDatFlag::Fluid:
+				itemType.group = ITEM_GROUP_SPLASH;
+				break;
+
+			case ItemDatFlag::IsUnpassable:
+				itemType.blockSolid = true;
+				break;
+
+			case ItemDatFlag::IsUnmoveable:
+				itemType.moveable = false;
+				break;
+
+			case ItemDatFlag::BlockMissiles:
+				itemType.blockProjectile = true;
+				break;
+
+			case ItemDatFlag::BlockPathfinder:
+				itemType.blockPathFind = true;
+				break;
+
+			case ItemDatFlag::Pickupable:
+				itemType.pickupable = true;
+				break;
+
+			case ItemDatFlag::Hangable:
+				itemType.isHangable = true;
+				break;
+
+			case ItemDatFlag::IsHorizontal:
+				itemType.isHorizontal = true;
+				break;
+
+			case ItemDatFlag::IsVertical:
+				itemType.isVertical = true;
+				break;
+
+			case ItemDatFlag::Rotatable:
+				itemType.rotatable = true;
+				break;
+
+			case ItemDatFlag::HasLight: {
+				uint16_t lightLevel = 0;
+				uint16_t lightColor = 0;
+				if (!readDatU16(reader, lightLevel, error, fmt::format("light level for item {}", itemId)) ||
+				    !readDatU16(reader, lightColor, error, fmt::format("light color for item {}", itemId))) {
+					return false;
+				}
+				if (lightLevel > (std::numeric_limits<uint8_t>::max)() ||
+				    lightColor > (std::numeric_limits<uint8_t>::max)()) {
+					error.set(flagOffset, fmt::format("light payload for item {} exceeds uint8 limits", itemId));
+					return false;
+				}
+				itemType.lightLevel = static_cast<uint8_t>(lightLevel);
+				itemType.lightColor = static_cast<uint8_t>(lightColor);
+				break;
+			}
+
+			case ItemDatFlag::DontHide:
+			case ItemDatFlag::Translucent:
+			case ItemDatFlag::Lying:
+			case ItemDatFlag::FullGround:
+				// These visual/client stacking flags have no server-side ItemType consumer.
+				break;
+
+			case ItemDatFlag::HasOffset:
+				if (!skipDatBytes(reader, 4, error, fmt::format("offset payload for item {}", itemId))) {
+					return false;
+				}
+				break;
+
+			case ItemDatFlag::HasElevation:
+				if (!skipDatBytes(reader, 2, error, fmt::format("elevation payload for item {}", itemId))) {
+					return false;
+				}
+				itemType.hasHeight = true;
+				break;
+
+			case ItemDatFlag::AnimateAlways:
+				itemType.isAnimation = true;
+				break;
+
+			case ItemDatFlag::Minimap:
+				if (!skipDatBytes(reader, 2, error, fmt::format("minimap payload for item {}", itemId))) {
+					return false;
+				}
+				break;
+
+			case ItemDatFlag::LensHelp: {
+				uint16_t lensHelp = 0;
+				if (!readDatU16(reader, lensHelp, error, fmt::format("lens-help payload for item {}", itemId))) {
+					return false;
+				}
+				if (lensHelp == 1112) {
+					itemType.canReadText = true;
+				}
+				break;
+			}
+
+			case ItemDatFlag::IgnoreLook:
+				itemType.lookThrough = true;
+				break;
+
+			case ItemDatFlag::Cloth:
+				if (!skipDatBytes(reader, 2, error, fmt::format("cloth payload for item {}", itemId))) {
+					return false;
+				}
+				break;
+
+			case ItemDatFlag::MarketItem: {
+				uint16_t category = 0;
+				uint16_t tradeAs = 0;
+				uint16_t showAs = 0;
+				uint16_t nameLength = 0;
+				uint16_t restrictedVocation = 0;
+				uint16_t minimumLevel = 0;
+				if (!readDatU16(reader, category, error, fmt::format("market category for item {}", itemId)) ||
+				    !readDatU16(reader, tradeAs, error, fmt::format("market tradeAs for item {}", itemId)) ||
+				    !readDatU16(reader, showAs, error, fmt::format("market showAs for item {}", itemId)) ||
+				    !readDatU16(reader, nameLength, error, fmt::format("market name length for item {}", itemId))) {
+					return false;
+				}
+				if (nameLength > MAX_DAT_MARKET_NAME_LENGTH) {
+					error.set(flagOffset, fmt::format("market name for item {} is too long ({})", itemId, nameLength));
+					return false;
+				}
+				if (!skipDatBytes(reader, nameLength, error, fmt::format("market name for item {}", itemId)) ||
+				    !readDatU16(reader, restrictedVocation, error,
+				                fmt::format("market vocation for item {}", itemId)) ||
+				    !readDatU16(reader, minimumLevel, error, fmt::format("market minimum level for item {}", itemId))) {
+					return false;
+				}
+
+				// wareId is not consumed by this server's custom Market or Supply Stash,
+				// which trade direct IDs and obtain names/restrictions from items.xml.
+				// Preserve the DAT tradeAs mapping for compatibility with future consumers.
+				itemType.wareId = tradeAs;
+				++marketItemCount;
+				(void)category;
+				(void)showAs;
+				(void)restrictedVocation;
+				(void)minimumLevel;
+				break;
+			}
+
+			case ItemDatFlag::LastFlag:
+				itemType.alwaysOnTop = itemType.alwaysOnTopOrder != 0;
+				return true;
+
+			default:
+				error.set(flagOffset, fmt::format("unknown flag {} for item {}", rawFlag, itemId));
+				return false;
+		}
+	}
+}
+
+bool skipDatSpriteLayout(DatReader& reader, uint16_t itemId, size_t spriteIdBytes, uint8_t& frameCount,
+                         DatParseError& error)
+{
+	uint8_t width = 0;
+	uint8_t height = 0;
+	uint8_t layers = 0;
+	uint8_t patternX = 0;
+	uint8_t patternY = 0;
+	uint8_t patternZ = 0;
+	if (!readDatU8(reader, width, error, fmt::format("sprite width for item {}", itemId)) ||
+	    !readDatU8(reader, height, error, fmt::format("sprite height for item {}", itemId))) {
+		return false;
+	}
+	if (width == 0 || height == 0 || width > MAX_DAT_SPRITE_DIMENSION || height > MAX_DAT_SPRITE_DIMENSION) {
+		error.set(reader.position() - 2,
+		          fmt::format("invalid sprite dimensions {}x{} for item {}", width, height, itemId));
+		return false;
+	}
+
+	if (width > 1 || height > 1) {
+		uint8_t exactSize = 0;
+		if (!readDatU8(reader, exactSize, error, fmt::format("exact sprite size for item {}", itemId))) {
+			return false;
+		}
+	}
+
+	if (!readDatU8(reader, layers, error, fmt::format("layers for item {}", itemId)) ||
+	    !readDatU8(reader, patternX, error, fmt::format("patternX for item {}", itemId)) ||
+	    !readDatU8(reader, patternY, error, fmt::format("patternY for item {}", itemId)) ||
+	    !readDatU8(reader, patternZ, error, fmt::format("patternZ for item {}", itemId)) ||
+	    !readDatU8(reader, frameCount, error, fmt::format("frame count for item {}", itemId))) {
+		return false;
+	}
+
+	if (layers == 0 || layers > MAX_DAT_LAYERS || patternX == 0 || patternX > MAX_DAT_PATTERN_DIMENSION ||
+	    patternY == 0 || patternY > MAX_DAT_PATTERN_DIMENSION || patternZ == 0 ||
+	    patternZ > MAX_DAT_PATTERN_DIMENSION || frameCount == 0) {
+		error.set(reader.position() - 5,
+		          fmt::format("invalid sprite layout for item {} (layers {}, patterns {}x{}x{}, frames {})", itemId,
+		                      layers, patternX, patternY, patternZ, frameCount));
+		return false;
+	}
+
+	size_t spriteCount = width;
+	for (const size_t factor :
+	     {static_cast<size_t>(height), static_cast<size_t>(layers), static_cast<size_t>(patternX),
+	      static_cast<size_t>(patternY), static_cast<size_t>(patternZ), static_cast<size_t>(frameCount)}) {
+		if (!checkedMultiply(spriteCount, factor, spriteCount)) {
+			error.set(reader.position(), fmt::format("sprite count overflow for item {}", itemId));
+			return false;
+		}
+	}
+	if (spriteCount > MAX_DAT_SPRITES_PER_ITEM) {
+		error.set(reader.position(), fmt::format("sprite count {} exceeds limit for item {}", spriteCount, itemId));
+		return false;
+	}
+
+	size_t spriteBytes = 0;
+	if (!checkedMultiply(spriteCount, spriteIdBytes, spriteBytes)) {
+		error.set(reader.position(), fmt::format("sprite byte count overflow for item {}", itemId));
+		return false;
+	}
+	return skipDatBytes(reader, spriteBytes, error, fmt::format("sprite IDs for item {}", itemId));
+}
+
+struct DatParseResult
+{
+	std::vector<ItemType> items;
+	uint16_t itemCount = 0;
+	uint16_t outfitCount = 0;
+	uint16_t effectCount = 0;
+	uint16_t distanceEffectCount = 0;
+	uint32_t marketItemCount = 0;
+};
+
+bool parseDatBuffer(const std::vector<uint8_t>& buffer, size_t spriteIdBytes, DatParseResult& result,
+                    DatParseError& error)
+{
+	if (spriteIdBytes != sizeof(uint16_t) && spriteIdBytes != sizeof(uint32_t)) {
+		error.set(0, "unsupported sprite ID width");
+		return false;
+	}
+
+	DatReader reader(buffer);
+	uint32_t signature = 0;
+	if (!readDatU32(reader, signature, error, "DAT signature") ||
+	    !readDatU16(reader, result.itemCount, error, "item count") ||
+	    !readDatU16(reader, result.outfitCount, error, "outfit count") ||
+	    !readDatU16(reader, result.effectCount, error, "effect count") ||
+	    !readDatU16(reader, result.distanceEffectCount, error, "distance-effect count")) {
+		return false;
+	}
+
+	if (signature != TIBIA_860_DAT_SIGNATURE) {
+		error.set(0, fmt::format("unsupported DAT signature 0x{:08X}; expected Tibia 8.60 signature 0x{:08X}",
+		                         signature, TIBIA_860_DAT_SIGNATURE));
+		return false;
+	}
+	if (result.itemCount < FIRST_DAT_ITEM_ID || result.itemCount >= ITEM_BROWSEFIELD) {
+		error.set(4, fmt::format("invalid itemCount {}", result.itemCount));
+		return false;
+	}
+	if (result.outfitCount > MAX_DAT_OUTFITS || result.effectCount > MAX_DAT_EFFECTS ||
+	    result.distanceEffectCount > MAX_DAT_DISTANCE_EFFECTS) {
+		error.set(6, fmt::format("visual section counts are unreasonable (outfits {}, effects {}, distance effects {})",
+		                         result.outfitCount, result.effectCount, result.distanceEffectCount));
+		return false;
+	}
+
+	std::vector<ItemType> parsedItems(static_cast<size_t>(result.itemCount) + 1);
+	for (uint32_t id = FIRST_DAT_ITEM_ID; id <= result.itemCount; ++id) {
+		ItemType& itemType = parsedItems[id];
+		itemType.id = static_cast<uint16_t>(id);
+		// DAT semantics default each real item to movable; the global ItemType
+		// default remains false for reserved, server-only and uninitialized IDs.
+		itemType.moveable = true;
+
+		if (!readDatAttributes(itemType, itemType.id, reader, error, result.marketItemCount)) {
+			return false;
+		}
+
+		uint8_t frameCount = 0;
+		if (!skipDatSpriteLayout(reader, itemType.id, spriteIdBytes, frameCount, error)) {
+			return false;
+		}
+		itemType.isAnimation = itemType.isAnimation || frameCount > 1;
+	}
+
+	size_t visualCount = static_cast<size_t>(result.outfitCount) + result.effectCount + result.distanceEffectCount;
+	if (visualCount == 0 && reader.remaining() != 0) {
+		error.set(reader.position(),
+		          fmt::format("{} unexpected bytes remain after the item section", reader.remaining()));
+		return false;
+	}
+	size_t minimumVisualBytes = 0;
+	if (!checkedMultiply(visualCount, 7 + spriteIdBytes, minimumVisualBytes) ||
+	    reader.remaining() < minimumVisualBytes) {
+		error.set(reader.position(),
+		          fmt::format("only {} bytes remain for {} declared visual entries", reader.remaining(), visualCount));
+		return false;
+	}
+
+	result.items = std::move(parsedItems);
+	return true;
+}
+
+bool parseXmlItemId(const pugi::xml_attribute& attribute, uint32_t& value)
+{
+	const std::string_view text = attribute.value();
+	if (text.empty()) {
+		return false;
+	}
+	const char* begin = text.data();
+	const char* end = begin + text.size();
+	const auto [ptr, ec] = std::from_chars(begin, end, value);
+	return ec == std::errc() && ptr == end;
+}
+
+bool isExplicitServerOnlyItemId(uint16_t id) { return id >= FIRST_SERVER_ONLY_ITEM_ID && id < ITEM_BROWSEFIELD; }
+
 } // namespace
 
 std::string Items::getAugmentNameByType(Augment_t augmentType)
@@ -490,26 +1012,143 @@ void Items::clear()
 	nameToItems.clear();
 	currencyItems.clear();
 	inventory.clear();
+	majorVersion = 0;
+	minorVersion = 0;
+	buildNumber = 0;
+	loadedSource = Source::NONE;
+	loadedSourcePath.clear();
+	lastError.clear();
+	datItemCount = 0;
+	datSpriteIdBytes = 0;
+	datMarketItemCount = 0;
+}
+
+void Items::initializeInternalItemTypes()
+{
+	if (ITEM_BROWSEFIELD >= items.size()) {
+		items.resize(static_cast<size_t>(ITEM_BROWSEFIELD) + 1);
+	}
+
+	ItemType& browseFieldType = items[ITEM_BROWSEFIELD];
+	browseFieldType.id = ITEM_BROWSEFIELD;
+	browseFieldType.name = "browse field";
+	browseFieldType.group = ITEM_GROUP_CONTAINER;
+	browseFieldType.type = ITEM_TYPE_CONTAINER;
+	browseFieldType.maxItems = 30;
+}
+
+void Items::swapState(Items& other) noexcept
+{
+	using std::swap;
+	items.swap(other.items);
+	nameToItems.swap(other.nameToItems);
+	currencyItems.swap(other.currencyItems);
+	inventory.swap(other.inventory);
+	swap(majorVersion, other.majorVersion);
+	swap(minorVersion, other.minorVersion);
+	swap(buildNumber, other.buildNumber);
+	swap(loadedSource, other.loadedSource);
+	loadedSourcePath.swap(other.loadedSourcePath);
+	lastError.swap(other.lastError);
+	swap(datItemCount, other.datItemCount);
+	swap(datSpriteIdBytes, other.datSpriteIdBytes);
+	swap(datMarketItemCount, other.datMarketItemCount);
 }
 
 bool Items::reload()
 {
-	clear();
-	loadFromOtb("data/items/items.otb");
-
-	g_moveEvents->reload();
-	g_weapons->reload();
-
-	if (!loadFromXml()) {
+	Items loadedItems;
+	if (!loadedItems.loadFromConfiguredSource()) {
+		lastError = loadedItems.lastError;
 		return false;
 	}
 
-	g_scripts->loadScripts("items", false, true);
+	pugi::xml_document doc;
+	const pugi::xml_parse_result xmlResult = doc.load_file("data/items/items.xml");
+	if (!xmlResult) {
+		printXMLError("Error - Items::reload", "data/items/items.xml", xmlResult);
+		lastError = fmt::format("Unable to reload items.xml: {}", xmlResult.description());
+		return false;
+	}
+	if (!loadedItems.loadFromXmlDocument(doc, false, false)) {
+		lastError = loadedItems.lastError;
+		return false;
+	}
+
+	// The currently live state remains untouched until the complete source and
+	// all non-side-effecting XML attributes have been validated.
+	swapState(loadedItems);
+
+	const bool registriesLoaded = g_moveEvents->reload() && g_weapons->reload() &&
+	                              loadFromXmlDocument(doc, true, true) && g_scripts->loadScripts("items", false, true);
+	if (!registriesLoaded) {
+		const std::string registryError =
+		    "Unable to rebuild item moveevents, weapons or item scripts; previous item state restored.";
+		swapState(loadedItems);
+
+		// Restore registries against the old ItemType table using the already
+		// parsed XML document. No source or XML file is reopened during rollback.
+		const bool restored = g_moveEvents->reload() && g_weapons->reload() && loadFromXmlDocument(doc, true, true) &&
+		                      g_scripts->loadScripts("items", false, true);
+		g_weapons->loadDefaults();
+		if (!restored) {
+			LOG_ERROR(
+			    "[Error - Items::reload] Item state was restored, but one or more script registries could not be rebuilt.");
+		}
+		lastError = registryError;
+		LOG_ERROR("[Error - Items::reload] {}", registryError);
+		return false;
+	}
+
 	g_weapons->loadDefaults();
 	return true;
 }
 
 constexpr auto OTBI = OTB::Identifier{{'O', 'T', 'B', 'I'}};
+
+bool Items::loadFromConfiguredSource()
+{
+	lastError.clear();
+	const bool useAssetsDat = ConfigManager::getBoolean(ConfigManager::USE_ASSETS_DAT);
+	const std::string path =
+	    useAssetsDat ? std::string{ConfigManager::getString(ConfigManager::ASSETS_DAT_PATH)} : "data/items/items.otb";
+
+	bool loaded = false;
+	try {
+		loaded = useAssetsDat ? loadFromDat(path) : loadFromOtb(path);
+	} catch (const std::exception& error) {
+		lastError = fmt::format("Unable to load items from {} at '{}': {}", useAssetsDat ? "assets.dat" : "items.otb",
+		                        path, error.what());
+		LOG_ERROR("[Error - Items::loadFromConfiguredSource] {}", lastError);
+		return false;
+	}
+
+	if (!loaded) {
+		if (lastError.empty()) {
+			lastError = fmt::format(
+			    "Unable to load items from {} at '{}': parser rejected the file. "
+			    "Verify the configured file and its client version.",
+			    useAssetsDat ? "assets.dat" : "items.otb", path);
+		}
+		LOG_ERROR("[Error - Items::loadFromConfiguredSource] {}", lastError);
+		return false;
+	}
+
+	if (useAssetsDat) {
+		LOG_INFO(">> Item source: assets.dat");
+		LOG_INFO(">> Assets DAT: {} item IDs loaded (sprite IDs: uint{})",
+		         static_cast<uint32_t>(datItemCount) - FIRST_DAT_ITEM_ID + 1,
+		         static_cast<uint32_t>(datSpriteIdBytes) * 8);
+		if (datMarketItemCount == 0) {
+			LOG_INFO(
+			    ">> Assets DAT: no MarketItem payloads; Market and Supply Stash use direct IDs and items.xml metadata.");
+		}
+	} else {
+		LOG_INFO(">> Item source: items.otb");
+		LOG_INFO(">> OTB v{}.{}.{}", majorVersion, minorVersion, buildNumber);
+	}
+	return true;
+}
 
 bool Items::loadFromOtb(const std::string& file)
 {
@@ -740,92 +1379,256 @@ bool Items::loadFromOtb(const std::string& file)
 		iType.alwaysOnTopOrder = alwaysOnTopOrder;
 	}
 
-	if (ITEM_BROWSEFIELD >= items.size()) {
-		items.resize(ITEM_BROWSEFIELD + 1);
-	}
-
-	ItemType& browseFieldType = items[ITEM_BROWSEFIELD];
-	browseFieldType.id = ITEM_BROWSEFIELD;
-	browseFieldType.name = "browse field";
-	browseFieldType.group = ITEM_GROUP_CONTAINER;
-	browseFieldType.type = ITEM_TYPE_CONTAINER;
-	browseFieldType.maxItems = 30;
-
+	initializeInternalItemTypes();
 	items.shrink_to_fit();
+	loadedSource = Source::OTB;
+	loadedSourcePath = file;
+	datItemCount = 0;
+	datSpriteIdBytes = 0;
+	datMarketItemCount = 0;
 	return true;
 }
 
-bool Items::loadFromXml()
+bool Items::loadFromDat(std::string_view file)
+{
+	lastError.clear();
+	if (file.empty()) {
+		lastError = "Unable to load items from assets.dat: assetsDatPath is empty.";
+		return false;
+	}
+
+	const std::string filePath(file);
+	std::ifstream stream(filePath, std::ios::binary | std::ios::ate);
+	if (!stream) {
+		lastError = fmt::format(
+		    "Unable to load items from assets.dat: file not found or unreadable: '{}'. "
+		    "Copy Tibia.dat from your Tibia 8.60 client into 'data/items', rename the copy to 'assets.dat', "
+		    "and keep assetsDatPath = \"data/items/assets.dat\" (or point assetsDatPath to another copied DAT).",
+		    filePath);
+		return false;
+	}
+
+	const std::streamoff endPosition = stream.tellg();
+	if (endPosition <= 0) {
+		lastError = fmt::format("Unable to load items from assets.dat: file is empty or tellg failed: '{}'.", filePath);
+		return false;
+	}
+	const uint64_t unsignedSize = static_cast<uint64_t>(endPosition);
+	if (unsignedSize > MAX_ASSETS_DAT_FILE_SIZE) {
+		lastError = fmt::format(
+		    "Unable to load items from assets.dat: file '{}' is {} bytes; "
+		    "the documented safety limit is {} bytes.",
+		    filePath, unsignedSize, MAX_ASSETS_DAT_FILE_SIZE);
+		return false;
+	}
+	if (unsignedSize > (std::numeric_limits<size_t>::max)() ||
+	    unsignedSize > static_cast<uint64_t>((std::numeric_limits<std::streamsize>::max)())) {
+		lastError = fmt::format("Unable to load items from assets.dat: file '{}' does not fit in memory or streamsize.",
+		                        filePath);
+		return false;
+	}
+
+	const size_t fileSize = static_cast<size_t>(unsignedSize);
+	stream.seekg(0, std::ios::beg);
+	if (!stream) {
+		lastError = fmt::format("Unable to load items from assets.dat: failed to seek '{}'.", filePath);
+		return false;
+	}
+
+	std::vector<uint8_t> buffer(fileSize);
+	stream.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(fileSize));
+	if (stream.gcount() != static_cast<std::streamsize>(fileSize)) {
+		lastError = fmt::format("Unable to load items from assets.dat: incomplete read of '{}' ({} of {} bytes).",
+		                        filePath, stream.gcount(), fileSize);
+		return false;
+	}
+
+	DatParseResult parsed;
+	DatParseError uint16Error;
+	size_t spriteIdBytes = sizeof(uint16_t);
+	if (!parseDatBuffer(buffer, spriteIdBytes, parsed, uint16Error)) {
+		parsed = DatParseResult{};
+		DatParseError uint32Error;
+		spriteIdBytes = sizeof(uint32_t);
+		if (!parseDatBuffer(buffer, spriteIdBytes, parsed, uint32Error)) {
+			lastError = fmt::format(
+			    "Unable to load items from assets.dat '{}': {} at offset {}. "
+			    "The file may be truncated, corrupt, or from an incompatible client.",
+			    filePath, uint32Error.message.empty() ? "invalid item section" : uint32Error.message,
+			    uint32Error.offset);
+			return false;
+		}
+	}
+
+	items = std::move(parsed.items);
+	initializeInternalItemTypes();
+	items.shrink_to_fit();
+	majorVersion = 0;
+	minorVersion = 0;
+	buildNumber = 0;
+	loadedSource = Source::DAT;
+	loadedSourcePath = filePath;
+	datItemCount = parsed.itemCount;
+	datSpriteIdBytes = static_cast<uint8_t>(spriteIdBytes);
+	datMarketItemCount = parsed.marketItemCount;
+	return true;
+}
+
+bool Items::loadFromXml(bool parseScriptAttributes, bool scriptAttributesOnly)
 {
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file("data/items/items.xml");
 	if (!result) {
 		printXMLError("Error - Items::loadFromXml", "data/items/items.xml", result);
+		lastError = fmt::format("Unable to load items.xml: {}", result.description());
 		return false;
 	}
+	return loadFromXmlDocument(doc, parseScriptAttributes, scriptAttributesOnly);
+}
+
+bool Items::loadFromXmlDocument(const pugi::xml_document& doc, bool parseScriptAttributes, bool scriptAttributesOnly)
+{
+	std::unordered_set<uint16_t> seenIds;
+	std::unordered_set<std::string> seenNames;
+	size_t duplicateNameCount = 0;
 
 	for (auto itemNode : doc.child("items").children()) {
 		pugi::xml_attribute idAttribute = itemNode.attribute("id");
 		if (idAttribute) {
-			parseItemNode(itemNode, pugi::cast<uint16_t>(idAttribute.value()));
+			uint32_t parsedId = 0;
+			if (!parseXmlItemId(idAttribute, parsedId) || parsedId == 0 ||
+			    parsedId > (std::numeric_limits<uint16_t>::max)()) {
+				lastError = fmt::format("Invalid items.xml item id '{}'.", idAttribute.value());
+				LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+				return false;
+			}
+
+			const uint16_t id = static_cast<uint16_t>(parsedId);
+			if (!scriptAttributesOnly && !seenIds.insert(id).second) {
+				lastError = fmt::format("Duplicate items.xml item id {}.", id);
+				LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+				return false;
+			}
+			if (!scriptAttributesOnly && isLoadedFromDat() && id >= FIRST_DAT_ITEM_ID && id > datItemCount &&
+			    !isExplicitServerOnlyItemId(id)) {
+				lastError = fmt::format(
+				    "items.xml id {} has no DAT client mapping (DAT itemCount {}). "
+				    "Only explicit server-only IDs {}-{} may be defined above itemCount.",
+				    id, datItemCount, FIRST_SERVER_ONLY_ITEM_ID, ITEM_BROWSEFIELD - 1);
+				LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+				return false;
+			}
+			if (!scriptAttributesOnly && (id < FIRST_DAT_ITEM_ID || isExplicitServerOnlyItemId(id))) {
+				ItemType& itemType = items[id];
+				itemType.id = id;
+			}
+
+			const std::string name = asLowerCaseString(itemNode.attribute("name").as_string());
+			if (!scriptAttributesOnly && !name.empty() && !seenNames.insert(name).second) {
+				++duplicateNameCount;
+			}
+			if (!parseItemNode(itemNode, id, parseScriptAttributes, scriptAttributesOnly)) {
+				return false;
+			}
 			continue;
 		}
 
 		pugi::xml_attribute fromIdAttribute = itemNode.attribute("fromid");
 		if (!fromIdAttribute) {
-			LOG_WARN("[Warning - Items::loadFromXml] No item id found");
-			continue;
+			lastError = "items.xml entry has neither id nor fromid.";
+			LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+			return false;
 		}
 
 		pugi::xml_attribute toIdAttribute = itemNode.attribute("toid");
 		if (!toIdAttribute) {
-			LOG_WARN(fmt::format("[Warning - Items::loadFromXml] fromid ({}) without toid", fromIdAttribute.value()));
-			continue;
+			lastError = fmt::format("items.xml fromid {} has no toid.", fromIdAttribute.value());
+			LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+			return false;
 		}
 
-		uint16_t id = pugi::cast<uint16_t>(fromIdAttribute.value());
-		uint16_t toId = pugi::cast<uint16_t>(toIdAttribute.value());
-		while (id <= toId) {
-			parseItemNode(itemNode, id++);
+		uint32_t fromId = 0;
+		uint32_t toId = 0;
+		if (!parseXmlItemId(fromIdAttribute, fromId) || !parseXmlItemId(toIdAttribute, toId) || fromId == 0 ||
+		    fromId > toId || toId > (std::numeric_limits<uint16_t>::max)()) {
+			lastError = fmt::format("Invalid items.xml range {}-{}.", fromIdAttribute.value(), toIdAttribute.value());
+			LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+			return false;
 		}
+		if (isLoadedFromDat() && (fromId < FIRST_DAT_ITEM_ID || toId > datItemCount)) {
+			lastError = fmt::format(
+			    "items.xml range {}-{} is outside the DAT client ID range {}-{}. "
+			    "Server-only definitions must use an explicit id.",
+			    fromId, toId, FIRST_DAT_ITEM_ID, datItemCount);
+			LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+			return false;
+		}
+
+		const std::string name = asLowerCaseString(itemNode.attribute("name").as_string());
+		for (uint32_t currentId = fromId; currentId <= toId; ++currentId) {
+			const uint16_t id = static_cast<uint16_t>(currentId);
+			if (!scriptAttributesOnly && !seenIds.insert(id).second) {
+				lastError = fmt::format("Duplicate items.xml item id {} in range {}-{}.", id, fromId, toId);
+				LOG_ERROR("[Error - Items::loadFromXml] {}", lastError);
+				return false;
+			}
+			if (!scriptAttributesOnly && !name.empty() && !seenNames.insert(name).second) {
+				++duplicateNameCount;
+			}
+			if (!parseItemNode(itemNode, id, parseScriptAttributes, scriptAttributesOnly)) {
+				return false;
+			}
+		}
+	}
+	if (!scriptAttributesOnly && duplicateNameCount != 0) {
+		LOG_INFO(">> items.xml: {} duplicate names kept with the existing first-ID lookup behavior.",
+		         duplicateNameCount);
 	}
 	return true;
 }
 
-void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
+bool Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id, bool parseScriptAttributes,
+                          bool scriptAttributesOnly)
 {
-	if (id > 0 && id < 100) {
+	if (!scriptAttributesOnly && (id < FIRST_DAT_ITEM_ID || isExplicitServerOnlyItemId(id))) {
 		ItemType& iType = items[id];
 		iType.id = id;
 	}
 
 	ItemType& it = getItemType(id);
 	if (it.id == 0) {
-		return;
+		if (isLoadedFromDat()) {
+			lastError = fmt::format("items.xml id {} is not initialized by the selected DAT source.", id);
+			LOG_ERROR("[Error - Items::parseItemNode] {}", lastError);
+			return false;
+	}
+		return true;
 	}
 
-	if (!it.name.empty()) {
+	if (!scriptAttributesOnly && !it.name.empty()) {
 		LOG_WARN(fmt::format("[Warning - Items::parseItemNode] Duplicate item with id: {}", id));
-		return;
+		return true;
 	}
 
-	it.name = itemNode.attribute("name").as_string();
+	if (!scriptAttributesOnly) {
+		it.name = itemNode.attribute("name").as_string();
 
-	if (!it.name.empty()) {
-		std::string lowerCaseName = asLowerCaseString(it.name);
-		if (!nameToItems.contains(lowerCaseName)) {
-			nameToItems.emplace(std::move(lowerCaseName), id);
+		if (!it.name.empty()) {
+			std::string lowerCaseName = asLowerCaseString(it.name);
+			if (!nameToItems.contains(lowerCaseName)) {
+				nameToItems.emplace(std::move(lowerCaseName), id);
+			}
 		}
-	}
 
-	pugi::xml_attribute articleAttribute = itemNode.attribute("article");
-	if (articleAttribute) {
-		it.article = articleAttribute.as_string();
-	}
+		pugi::xml_attribute articleAttribute = itemNode.attribute("article");
+		if (articleAttribute) {
+			it.article = articleAttribute.as_string();
+		}
 
-	pugi::xml_attribute pluralAttribute = itemNode.attribute("plural");
-	if (pluralAttribute) {
-		it.pluralName = pluralAttribute.as_string();
+		pugi::xml_attribute pluralAttribute = itemNode.attribute("plural");
+		if (pluralAttribute) {
+			it.pluralName = pluralAttribute.as_string();
+		}
 	}
 
 	Abilities& abilities = it.getAbilities();
@@ -852,6 +1655,10 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 		std::string tmpStrValue = asLowerCaseString(keyAttribute.as_string());
 		auto parseAttribute = ItemParseAttributesMap.find(tmpStrValue);
+		if (scriptAttributesOnly &&
+		    (parseAttribute == ItemParseAttributesMap.end() || parseAttribute->second != ITEM_PARSE_SCRIPT)) {
+			continue;
+		}
 		if (parseAttribute != ItemParseAttributesMap.end()) {
 			ItemParseAttributes_t parseType = parseAttribute->second;
 			switch (parseType) {
@@ -2103,6 +2910,11 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 					break;
 				}
 
+				case ITEM_PARSE_STACKABLE: {
+					it.stackable = valueAttribute.as_bool();
+					break;
+				}
+
 				case ITEM_PARSE_EXPERIENCERATE_BASE: {
 					int32_t rate = pugi::cast<int32_t>(valueAttribute.value());
 					abilities.experienceRate[static_cast<size_t>(ExperienceRateType::BASE)] = rate;
@@ -2155,7 +2967,9 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 				}
 
 				case ITEM_PARSE_SCRIPT: {
-					parseScriptAttribute(it, attributeNode, valueAttribute);
+					if (parseScriptAttributes) {
+						parseScriptAttribute(it, attributeNode, valueAttribute);
+					}
 					break;
 				}
 
@@ -2262,11 +3076,13 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 	}
 
 	// check bed items
-	if ((it.transformToFree != 0 || it.transformToOnUse[PLAYERSEX_FEMALE] != 0 ||
+	if (!scriptAttributesOnly &&
+	    (it.transformToFree != 0 || it.transformToOnUse[PLAYERSEX_FEMALE] != 0 ||
 	     it.transformToOnUse[PLAYERSEX_MALE] != 0) &&
 	    it.type != ITEM_TYPE_BED) {
 		LOG_WARN(fmt::format("[Warning - Items::parseItemNode] Item {} is not set as a bed-type", it.id));
 	}
+	return true;
 }
 
 void Items::parseScriptAttribute(ItemType& it, const pugi::xml_node& attributeNode, const pugi::xml_attribute& valueAttribute)
@@ -2622,7 +3438,8 @@ ItemType& Items::getItemType(size_t id)
 	if (id < items.size()) {
 		return items[id];
 	}
-	return items.front();
+	static ItemType invalidItemType;
+	return invalidItemType;
 }
 
 const ItemType& Items::getItemType(size_t id) const
@@ -2630,7 +3447,13 @@ const ItemType& Items::getItemType(size_t id) const
 	if (id < items.size()) {
 		return items[id];
 	}
-	return items.front();
+	static const ItemType invalidItemType;
+	return invalidItemType;
+}
+
+bool Items::isValidItemId(size_t id) const
+{
+	return id < items.size() && items[id].id == id;
 }
 
 uint16_t Items::getItemIdByName(const std::string& name)

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -15,6 +15,7 @@
 #include "scriptmanager.h"
 #include "spells.h"
 #include "weapons.h"
+#include <array>
 #include <charconv>
 #include <fmt/format.h>
 #include <fstream>
@@ -410,6 +411,12 @@ struct DatParseError
 	}
 };
 
+struct DatFormat
+{
+	size_t spriteIdBytes;
+	bool enhancedAnimations;
+};
+
 class DatReader
 {
 public:
@@ -742,7 +749,7 @@ bool readDatAttributes(ItemType& itemType, uint16_t itemId, DatReader& reader, D
 	}
 }
 
-bool skipDatSpriteLayout(DatReader& reader, uint16_t itemId, size_t spriteIdBytes, uint8_t& frameCount,
+bool skipDatSpriteLayout(DatReader& reader, uint16_t itemId, const DatFormat& format, uint8_t& frameCount,
                          DatParseError& error)
 {
 	uint8_t width = 0;
@@ -799,39 +806,21 @@ bool skipDatSpriteLayout(DatReader& reader, uint16_t itemId, size_t spriteIdByte
 		return false;
 	}
 
+	if (format.enhancedAnimations && frameCount > 1) {
+		size_t durationBytes = 0;
+		if (!checkedMultiply(static_cast<size_t>(frameCount), sizeof(uint32_t) * 2, durationBytes) ||
+		    !skipDatBytes(reader, 1 + sizeof(uint32_t) + 1 + durationBytes, error,
+		                  fmt::format("animation data for item {}", itemId))) {
+			return false;
+		}
+	}
+
 	size_t spriteBytes = 0;
-	if (!checkedMultiply(spriteCount, spriteIdBytes, spriteBytes)) {
+	if (!checkedMultiply(spriteCount, format.spriteIdBytes, spriteBytes)) {
 		error.set(reader.position(), fmt::format("sprite byte count overflow for item {}", itemId));
 		return false;
 	}
 	return skipDatBytes(reader, spriteBytes, error, fmt::format("sprite IDs for item {}", itemId));
-}
-
-bool validateDatVisualSection(DatReader& reader, uint16_t count, std::string_view sectionName,
-                              size_t spriteIdBytes, DatParseError& error)
-{
-	for (uint32_t id = 1; id <= count; ++id) {
-		// Visual records use the same bounded attribute and sprite-layout encoding
-		// as items, but their parsed values are intentionally discarded.
-		ItemType discardedType;
-		uint32_t discardedMarketItemCount = 0;
-		DatParseError recordError;
-		if (!readDatAttributes(discardedType, static_cast<uint16_t>(id), reader, recordError,
-		                       discardedMarketItemCount)) {
-			error.set(recordError.offset,
-			          fmt::format("{} {}: {}", sectionName, id, recordError.message));
-			return false;
-		}
-
-		uint8_t discardedFrameCount = 0;
-		if (!skipDatSpriteLayout(reader, static_cast<uint16_t>(id), spriteIdBytes, discardedFrameCount,
-		                         recordError)) {
-			error.set(recordError.offset,
-			          fmt::format("{} {}: {}", sectionName, id, recordError.message));
-			return false;
-		}
-	}
-	return true;
 }
 
 struct DatParseResult
@@ -844,10 +833,10 @@ struct DatParseResult
 	uint32_t marketItemCount = 0;
 };
 
-bool parseDatBuffer(const std::vector<uint8_t>& buffer, size_t spriteIdBytes, DatParseResult& result,
+bool parseDatBuffer(const std::vector<uint8_t>& buffer, const DatFormat& format, DatParseResult& result,
                     DatParseError& error)
 {
-	if (spriteIdBytes != sizeof(uint16_t) && spriteIdBytes != sizeof(uint32_t)) {
+	if (format.spriteIdBytes != sizeof(uint16_t) && format.spriteIdBytes != sizeof(uint32_t)) {
 		error.set(0, "unsupported sprite ID width");
 		return false;
 	}
@@ -891,21 +880,10 @@ bool parseDatBuffer(const std::vector<uint8_t>& buffer, size_t spriteIdBytes, Da
 		}
 
 		uint8_t frameCount = 0;
-		if (!skipDatSpriteLayout(reader, itemType.id, spriteIdBytes, frameCount, error)) {
+		if (!skipDatSpriteLayout(reader, itemType.id, format, frameCount, error)) {
 			return false;
 		}
 		itemType.isAnimation = itemType.isAnimation || frameCount > 1;
-	}
-
-	if (!validateDatVisualSection(reader, result.outfitCount, "outfit", spriteIdBytes, error) ||
-	    !validateDatVisualSection(reader, result.effectCount, "effect", spriteIdBytes, error) ||
-	    !validateDatVisualSection(reader, result.distanceEffectCount, "distance effect", spriteIdBytes, error)) {
-		return false;
-	}
-	if (reader.remaining() != 0) {
-		error.set(reader.position(),
-		          fmt::format("{} unexpected bytes remain after the declared DAT sections", reader.remaining()));
-		return false;
 	}
 
 	result.items = std::move(parsedItems);
@@ -1471,21 +1449,34 @@ bool Items::loadFromDat(std::string_view file)
 		return false;
 	}
 
+	const std::array<DatFormat, 3> formats = {
+	    DatFormat{sizeof(uint16_t), false},
+	    DatFormat{sizeof(uint32_t), false},
+	    DatFormat{sizeof(uint32_t), true},
+	};
+
 	DatParseResult parsed;
-	DatParseError uint16Error;
-	size_t spriteIdBytes = sizeof(uint16_t);
-	if (!parseDatBuffer(buffer, spriteIdBytes, parsed, uint16Error)) {
-		parsed = DatParseResult{};
-		DatParseError uint32Error;
-		spriteIdBytes = sizeof(uint32_t);
-		if (!parseDatBuffer(buffer, spriteIdBytes, parsed, uint32Error)) {
-			lastError = fmt::format(
-			    "Unable to load items from assets.dat '{}': {} at offset {}. "
-			    "The file may be truncated, corrupt, or from an incompatible client.",
-			    filePath, uint32Error.message.empty() ? "invalid item section" : uint32Error.message,
-			    uint32Error.offset);
-			return false;
+	DatParseError bestError;
+	const DatFormat* selectedFormat = nullptr;
+	for (const DatFormat& format : formats) {
+		DatParseResult candidate;
+		DatParseError candidateError;
+		if (parseDatBuffer(buffer, format, candidate, candidateError)) {
+			parsed = std::move(candidate);
+			selectedFormat = &format;
+			break;
 		}
+		if (bestError.message.empty() || candidateError.offset > bestError.offset) {
+			bestError = std::move(candidateError);
+		}
+	}
+
+	if (!selectedFormat) {
+		lastError = fmt::format(
+		    "Unable to load items from assets.dat '{}': {} at offset {}. "
+		    "The file may be truncated, corrupt, or from an incompatible client.",
+		    filePath, bestError.message.empty() ? "invalid item section" : bestError.message, bestError.offset);
+		return false;
 	}
 
 	items = std::move(parsed.items);
@@ -1497,7 +1488,7 @@ bool Items::loadFromDat(std::string_view file)
 	loadedSource = Source::DAT;
 	loadedSourcePath = filePath;
 	datItemCount = parsed.itemCount;
-	datSpriteIdBytes = static_cast<uint8_t>(spriteIdBytes);
+	datSpriteIdBytes = static_cast<uint8_t>(selectedFormat->spriteIdBytes);
 	datMarketItemCount = parsed.marketItemCount;
 	return true;
 }

--- a/src/items.h
+++ b/src/items.h
@@ -184,6 +184,7 @@ enum ItemParseAttributes_t
 	ITEM_PARSE_ALLOWDISTREAD,
 	ITEM_PARSE_STOREITEM,
 	ITEM_PARSE_WORTH,
+	ITEM_PARSE_STACKABLE,
 	ITEM_PARSE_STACKSIZE,
 	ITEM_PARSE_REFLECTPERCENTALL,
 	ITEM_PARSE_REFLECTPERCENTELEMENTS,
@@ -503,6 +504,13 @@ private:
 class Items
 {
 public:
+	enum class Source : uint8_t
+	{
+		NONE,
+		OTB,
+		DAT,
+	};
+
 	using NameMap = std::unordered_map<std::string, uint16_t>;
 	using InventoryVector = std::vector<uint16_t>;
 
@@ -518,11 +526,14 @@ public:
 	bool reload();
 	void clear();
 
+	bool loadFromConfiguredSource();
 	bool loadFromOtb(const std::string& file);
+	bool loadFromDat(std::string_view file);
 
 	const ItemType& operator[](size_t id) const { return getItemType(id); }
 	const ItemType& getItemType(size_t id) const;
 	ItemType& getItemType(size_t id);
+	bool isValidItemId(size_t id) const;
 
 	uint16_t getItemIdByName(const std::string& name);
 
@@ -530,14 +541,20 @@ public:
 	uint32_t minorVersion = 0;
 	uint32_t buildNumber = 0;
 
-	bool loadFromXml();
-	void parseItemNode(const pugi::xml_node& itemNode, uint16_t id);
+	bool loadFromXml(bool parseScriptAttributes = true, bool scriptAttributesOnly = false);
+	bool parseItemNode(const pugi::xml_node& itemNode, uint16_t id, bool parseScriptAttributes = true,
+	                   bool scriptAttributesOnly = false);
 	void parseScriptAttribute(ItemType& it, const pugi::xml_node& attributeNode, const pugi::xml_attribute& valueAttribute);
 
 	void buildInventoryList();
 	const InventoryVector& getInventory() const { return inventory; }
 
 	size_t size() const { return items.size(); }
+	Source getLoadedSource() const { return loadedSource; }
+	bool isLoadedFromDat() const { return loadedSource == Source::DAT; }
+	std::string_view getLoadedSourcePath() const { return loadedSourcePath; }
+	const std::string& getLastError() const { return lastError; }
+	uint16_t getDatItemCount() const { return datItemCount; }
 
 	static std::string getAugmentNameByType(Augment_t augmentType);
 	static bool isAugmentWithoutValueDescription(Augment_t augmentType);
@@ -546,7 +563,17 @@ public:
 	CurrencyMap currencyItems;
 
 private:
+	bool loadFromXmlDocument(const pugi::xml_document& doc, bool parseScriptAttributes, bool scriptAttributesOnly);
+	void initializeInternalItemTypes();
+	void swapState(Items& other) noexcept;
+
 	std::vector<ItemType> items;
 	InventoryVector inventory;
+	Source loadedSource = Source::NONE;
+	std::string loadedSourcePath;
+	std::string lastError;
+	uint16_t datItemCount = 0;
+	uint8_t datSpriteIdBytes = 0;
+	uint32_t datMarketItemCount = 0;
 };
 #endif

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3035,6 +3035,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::SOULSEALS_SYSTEM_ENABLED);
 	registerEnumIn("configKeys", ConfigManager::CLEAVE_SYSTEM_ENABLED);
 
+	registerEnumIn("configKeys", ConfigManager::USE_ASSETS_DAT);
 	registerEnumIn("configKeys", ConfigManager::MAP_NAME);
 	registerEnumIn("configKeys", ConfigManager::HOUSE_RENT_PERIOD);
 	registerEnumIn("configKeys", ConfigManager::SERVER_NAME);
@@ -3053,6 +3054,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::DEFAULT_PRIORITY);
 	registerEnumIn("configKeys", ConfigManager::MAP_AUTHOR);
 
+	registerEnumIn("configKeys", ConfigManager::ASSETS_DAT_PATH);
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_NOTIFY_DURATION);
 	registerEnumIn("configKeys", ConfigManager::SQL_PORT);
 	registerEnumIn("configKeys", ConfigManager::MAX_PLAYERS);

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -15,6 +15,7 @@
 #include "iomap.h"
 #include "fileloader.h"
 #include "logger.h"
+#include "configmanager.h"
 
 #include <algorithm>
 #include <fstream>
@@ -42,6 +43,13 @@ constexpr uint32_t MAX_CACHE_ENTRIES = 100'000'000;
 std::mutex fingerprintMutex;
 std::filesystem::path fingerprintPath;
 std::optional<std::future<std::optional<MapCache::Fingerprint>>> fingerprintFuture;
+
+std::filesystem::path configuredItemSourcePath() {
+    if (ConfigManager::getBoolean(ConfigManager::USE_ASSETS_DAT)) {
+        return std::filesystem::path{ConfigManager::getString(ConfigManager::ASSETS_DAT_PATH)};
+    }
+    return std::filesystem::path{"data/items/items.otb"};
+}
 
 class CacheWriter {
 public:
@@ -172,7 +180,7 @@ bool replaceMapCacheFile(const std::filesystem::path& source, const std::filesys
     return !error;
 #endif
 }
-} // namespace
+}
 
 void MapCache::prepare(size_t sourceBytes) {
     // Estimates are deliberately based on the source size instead of map
@@ -223,23 +231,24 @@ std::optional<MapCache::Fingerprint> MapCache::fingerprint(const std::filesystem
     }
 
     const auto mapDigest = digestFile(mapPath);
-    const auto otbDigest = digestFile("data/items/items.otb");
+    const auto itemSourceDigest = digestFile(configuredItemSourcePath());
     const auto xmlDigest = digestFile("data/items/items.xml");
-    if (!mapDigest || !otbDigest || !xmlDigest) {
+    if (!mapDigest || !itemSourceDigest || !xmlDigest) {
         return std::nullopt;
     }
-    return Fingerprint{*mapDigest, *otbDigest, *xmlDigest};
+    return Fingerprint{*mapDigest, *itemSourceDigest, *xmlDigest};
 }
 
 void MapCache::precomputeFingerprint(const std::filesystem::path& mapPath) {
     std::scoped_lock lock(fingerprintMutex);
     fingerprintPath = mapPath;
-    fingerprintFuture.emplace(std::async(std::launch::async, [mapPath]() -> std::optional<Fingerprint> {
+    const std::filesystem::path itemSourcePath = configuredItemSourcePath();
+    fingerprintFuture.emplace(std::async(std::launch::async, [mapPath, itemSourcePath]() -> std::optional<Fingerprint> {
         const auto mapDigest = digestFile(mapPath);
-        const auto otbDigest = digestFile("data/items/items.otb");
+        const auto itemSourceDigest = digestFile(itemSourcePath);
         const auto xmlDigest = digestFile("data/items/items.xml");
-        if (!mapDigest || !otbDigest || !xmlDigest) return std::nullopt;
-        return Fingerprint{*mapDigest, *otbDigest, *xmlDigest};
+        if (!mapDigest || !itemSourceDigest || !xmlDigest) return std::nullopt;
+        return Fingerprint{*mapDigest, *itemSourceDigest, *xmlDigest};
     }));
 }
 
@@ -284,7 +293,7 @@ bool MapCache::savePersistent(const Map& map, const std::filesystem::path& cache
     writer.u32(Item::items.minorVersion);
     writer.u32(Item::items.buildNumber);
     writer.bytes(fingerprintValue.map.data(), fingerprintValue.map.size());
-    writer.bytes(fingerprintValue.itemsOtb.data(), fingerprintValue.itemsOtb.size());
+    writer.bytes(fingerprintValue.itemSource.data(), fingerprintValue.itemSource.size());
     writer.bytes(fingerprintValue.itemsXml.data(), fingerprintValue.itemsXml.size());
     writer.bytes(houseCacheDigest.data(), houseCacheDigest.size());
     writer.u32(map.width);
@@ -380,7 +389,7 @@ bool MapCache::loadPersistent(Map& map, const std::filesystem::path& cachePath,
         itemMajor != Item::items.majorVersion || itemMinor != Item::items.minorVersion ||
         itemBuild != Item::items.buildNumber ||
         !reader.bytes(storedFingerprint.map.data(), storedFingerprint.map.size()) ||
-        !reader.bytes(storedFingerprint.itemsOtb.data(), storedFingerprint.itemsOtb.size()) ||
+        !reader.bytes(storedFingerprint.itemSource.data(), storedFingerprint.itemSource.size()) ||
         !reader.bytes(storedFingerprint.itemsXml.data(), storedFingerprint.itemsXml.size()) ||
         !reader.bytes(storedHouseDigest.data(), storedHouseDigest.size()) ||
         storedFingerprint != expectedFingerprint || storedHouseDigest != expectedHouseDigest) {
@@ -409,6 +418,9 @@ bool MapCache::loadPersistent(Map& map, const std::filesystem::path& cachePath,
             !reader.u16(item->uniqueId) || !reader.u16(item->destX) || !reader.u16(item->destY) ||
             !reader.u16(item->doorOrDepotId) || !reader.u8(item->destZ) || !reader.string(item->text) ||
             !reader.u32(childCount) || childCount > MAX_CACHE_ENTRIES) {
+            return false;
+        }
+        if (!Item::items.isValidItemId(item->id)) {
             return false;
         }
         PendingItem pending{std::move(item), std::vector<uint32_t>(childCount)};
@@ -688,15 +700,25 @@ namespace {
 }
 
 // Helper to parse item from stream (used by both node-based and inline items)
-bool parseBasicItemFromStream(PropStream& propStream, BasicItem& item) {
-    uint16_t id;
+bool parseBasicItemFromStream(PropStream& propStream, BasicItem& item, std::string& error) {
+    uint16_t id = 0;
     if (!propStream.read<uint16_t>(id)) {
-        LOG_ERROR("[MapCache] Failed to read item ID from stream");
+        error = "Failed to read item ID from stream.";
         return false;
     }
-    
-    // ID substitutions
-    applyItemIdSubstitutions(id);
+
+    const uint16_t serializedId = id;
+    // OTB mode preserves the legacy persistent-field substitutions. DAT mode
+    // is a direct client-ID contract and must never convert map IDs.
+    if (!Item::items.isLoadedFromDat()) {
+        applyItemIdSubstitutions(id);
+    }
+    if (!Item::items.isValidItemId(id)) {
+        error = fmt::format("Map contains unknown item id {}{} for the selected {} source.", serializedId,
+                            serializedId != id ? fmt::format(" (resolved to {})", id) : "",
+                            Item::items.isLoadedFromDat() ? "DAT" : "OTB");
+        return false;
+    }
 
     item.id = id;
     
@@ -840,55 +862,59 @@ bool parseBasicItemFromStream(PropStream& propStream, BasicItem& item) {
                 break;
             
             default:
-                // Unknown attribute, log warning
-                LOG_WARN(fmt::format("[MapCache] Unknown item attribute: {}", attr_type));
-                break;
+                error = fmt::format("Unknown map item attribute {} for item {}.", attr_type, serializedId);
+                return false;
         }
     }
     return true;
 }
 
-std::shared_ptr<BasicItem> MapCache::parseBasicItem(void* loaderptr, const void* nodeptr) {
+std::shared_ptr<BasicItem> MapCache::parseBasicItem(void* loaderptr, const void* nodeptr, std::string& error) {
     OTB::Loader& loader = *static_cast<OTB::Loader*>(loaderptr);
     const OTB::Node& node = *static_cast<const OTB::Node*>(nodeptr);
     PropStream propStream;
 
     if (!loader.getProps(node, propStream)) {
-        LOG_ERROR("[MapCache] Failed to get props from item node");
+        error = "Failed to get properties from item node.";
         return nullptr;
     }
 
     BasicItem item;
-    if (!parseBasicItemFromStream(propStream, item)) {
+    if (!parseBasicItemFromStream(propStream, item, error)) {
         return nullptr;
     }
     
     // Parse children (containers)
     for (auto& childNode : node.children) {
         if (static_cast<OTBM_NodeTypes_t>(childNode.type) == OTBM_NodeTypes_t::ITEM) {
-            auto child = parseBasicItem(loaderptr, &childNode);
-            if (child) {
-                item.items.push_back(child);
+            auto child = parseBasicItem(loaderptr, &childNode, error);
+            if (!child) {
+                return nullptr;
             }
+            item.items.push_back(std::move(child));
+        } else {
+            error = fmt::format("Unknown child node type {} in map container item.", childNode.type);
+            return nullptr;
         }
     }
 
     return tryGetItemFromCache(std::move(item));
 }
 
-const BasicTile* MapCache::parseBasicTile(void* loaderptr, const void* nodeptr, uint8_t& xOffset, uint8_t& yOffset) {
+const BasicTile* MapCache::parseBasicTile(void* loaderptr, const void* nodeptr, uint8_t& xOffset, uint8_t& yOffset,
+                                          std::string& error) {
     OTB::Loader& loader = *static_cast<OTB::Loader*>(loaderptr);
     const OTB::Node& tileNode = *static_cast<const OTB::Node*>(nodeptr);
     PropStream propStream;
 
     if (!loader.getProps(tileNode, propStream)) {
-        LOG_ERROR("[MapCache] Failed to get props from tile node");
+        error = "Failed to get properties from tile node.";
         return nullptr;
     }
 
     OTBM_Tile_coords tile_coord;
     if (!propStream.read(tile_coord)) {
-        LOG_ERROR("[MapCache] Failed to read tile coordinates");
+        error = "Failed to read tile coordinates.";
         return nullptr;
     }
     
@@ -922,7 +948,7 @@ const BasicTile* MapCache::parseBasicTile(void* loaderptr, const void* nodeptr, 
                         ZoneId zoneId = 0;
                         do {
                             if (!propStream.read<ZoneId>(zoneId)) {
-                                LOG_ERROR("[MapCache] Failed to read tile zone id");
+                                error = "Failed to read tile zone id.";
                                 return nullptr;
                             }
 
@@ -932,7 +958,7 @@ const BasicTile* MapCache::parseBasicTile(void* loaderptr, const void* nodeptr, 
                         } while (zoneId != 0);
                     }
                 } else {
-                    LOG_ERROR("[MapCache] Failed to read tile flags");
+                    error = "Failed to read tile flags.";
                     return nullptr;
                 }
                 break;
@@ -940,19 +966,20 @@ const BasicTile* MapCache::parseBasicTile(void* loaderptr, const void* nodeptr, 
             case OTBM_AttrTypes_t::ITEM: {
                 // Inline item
                 BasicItem item;
-                if (parseBasicItemFromStream(propStream, item)) {
-                     const ItemType& it = Item::items[item.id];
-                     if (it.isGroundTile()) {
-                         tile.ground = MapCache::tryGetItemFromCache(std::move(item));
-                     } else {
-                         tile.items.push_back(MapCache::tryGetItemFromCache(std::move(item)));
-                     }
+                if (!parseBasicItemFromStream(propStream, item, error)) {
+                    return nullptr;
+                }
+                const ItemType& it = Item::items[item.id];
+                if (it.isGroundTile()) {
+                    tile.ground = MapCache::tryGetItemFromCache(std::move(item));
+                } else {
+                    tile.items.push_back(MapCache::tryGetItemFromCache(std::move(item)));
                 }
                 break; 
             }
             default:
-                LOG_WARN(fmt::format("[MapCache] Unknown tile attribute: {}", attribute));
-                break;
+                error = fmt::format("Unknown tile attribute {}.", attribute);
+                return nullptr;
         }
     }
     
@@ -960,21 +987,25 @@ const BasicTile* MapCache::parseBasicTile(void* loaderptr, const void* nodeptr, 
     for (auto& itemNode : tileNode.children) {
         const auto childNodeType = static_cast<OTBM_NodeTypes_t>(itemNode.type);
         if (childNodeType == OTBM_NodeTypes_t::ITEM) {
-            auto item = parseBasicItem(loaderptr, &itemNode);
-            if (item) {
-                const ItemType& it = Item::items[item->id];
-                if (it.isGroundTile() && tile.ground == nullptr) {
-                    tile.ground = item;
-                } else {
-                    tile.items.push_back(item);
-                }
+            auto item = parseBasicItem(loaderptr, &itemNode, error);
+            if (!item) {
+                return nullptr;
+            }
+            const ItemType& it = Item::items[item->id];
+            if (it.isGroundTile() && tile.ground == nullptr) {
+                tile.ground = item;
+            } else {
+                tile.items.push_back(item);
             }
         } else if (childNodeType == OTBM_NodeTypes_t::TILE_ZONE) {
             std::string errorType;
             if (!IOMap::parseTileZoneNode(loader, itemNode, tile.zoneIds, errorType)) {
-                LOG_ERROR(fmt::format("[MapCache] {}", errorType));
+                error = std::move(errorType);
                 return nullptr;
             }
+        } else {
+            error = fmt::format("Unknown tile child node type {}.", itemNode.type);
+            return nullptr;
         }
     }
 
@@ -1106,4 +1137,4 @@ std::unique_ptr<Tile> createTileFromBasic(const BasicTile* basicTile,
     return tile;
 }
 
-} // namespace MapCacheUtils
+}

--- a/src/mapcache.h
+++ b/src/mapcache.h
@@ -225,7 +225,7 @@ public:
     using Digest = std::array<uint8_t, 32>;
     struct Fingerprint {
         Digest map{};
-        Digest itemsOtb{};
+        Digest itemSource{};
         Digest itemsXml{};
 
         bool operator==(const Fingerprint&) const = default;
@@ -271,8 +271,9 @@ public:
     /**
      * Map Parsing Helpers (used by IOMap)
      */
-    static std::shared_ptr<BasicItem> parseBasicItem(void* loaderptr, const void* nodeptr);
-    static const BasicTile* parseBasicTile(void* loaderptr, const void* nodeptr, uint8_t& xOffset, uint8_t& yOffset);
+    static std::shared_ptr<BasicItem> parseBasicItem(void* loaderptr, const void* nodeptr, std::string& error);
+    static const BasicTile* parseBasicTile(void* loaderptr, const void* nodeptr, uint8_t& xOffset, uint8_t& yOffset,
+                                           std::string& error);
     /**
      * Get cache statistics for debugging
      */

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -525,7 +525,7 @@ bool mainLoader(const std::shared_ptr<ServiceManager>& services, StartupRuntimeS
 	// load item data
 	LOG_INFO(">> Loading items... ");
 	if (!Item::items.loadFromConfiguredSource()) {
-		startupProgress().fail(Item::items.getLastError());
+		startupErrorMessage(Item::items.getLastError());
 		return false;
 	}
 	startupProgress().update(3, 6, Item::items.isLoadedFromDat() ? "items DAT" : "items OTB");

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -524,16 +524,14 @@ bool mainLoader(const std::shared_ptr<ServiceManager>& services, StartupRuntimeS
 
 	// load item data
 	LOG_INFO(">> Loading items... ");
-	if (!Item::items.loadFromOtb("data/items/items.otb")) {
-		startupErrorMessage("Unable to load items (OTB)!");
+	if (!Item::items.loadFromConfiguredSource()) {
+		startupErrorMessage(Item::items.getLastError());
 		return false;
 	}
-	startupProgress().update(3, 6, "items OTB");
-	LOG_INFO(fmt::format(">> OTB v{:d}.{:d}.{:d}", Item::items.majorVersion, Item::items.minorVersion,
-	                         Item::items.buildNumber));
+	startupProgress().update(3, 6, Item::items.isLoadedFromDat() ? "items DAT" : "items OTB");
 
 	if (!Item::items.loadFromXml()) {
-		startupErrorMessage("Unable to load items (XML)!");
+		startupErrorMessage(Item::items.getLastError());
 		return false;
 	}
 	startupProgress().update(4, 6, "items XML");

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -525,7 +525,7 @@ bool mainLoader(const std::shared_ptr<ServiceManager>& services, StartupRuntimeS
 	// load item data
 	LOG_INFO(">> Loading items... ");
 	if (!Item::items.loadFromConfiguredSource()) {
-		startupErrorMessage(Item::items.getLastError());
+		startupProgress().fail(Item::items.getLastError());
 		return false;
 	}
 	startupProgress().update(3, 6, Item::items.isLoadedFromDat() ? "items DAT" : "items OTB");

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -128,6 +128,7 @@ bool Scripts::loadScripts(const std::string& folderName, bool isLib, bool reload
 	                                   startupProgress().isCurrentStage(StartupStage::MONSTER_SCRIPTS) ||
 	                                   startupProgress().isCurrentStage(StartupStage::LUA_SCRIPTS);
 	const bool showCurrentFile = reportStartupProgress && startupProgress().detailedLogs();
+	bool success = true;
 	if (reportStartupProgress && processedCount != 0) {
 		startupProgress().update(processedCount, candidateCount,
 		                         showCurrentFile ? "disabled/already loaded scripts" : "scripts");
@@ -137,6 +138,7 @@ bool Scripts::loadScripts(const std::string& folderName, bool isLib, bool reload
 		if (scriptInterface.loadFile(scriptFile) == -1) {
 			LOG_ERROR(fmt::format("> {} [error]", path.filename().string()));
 			LOG_ERROR(fmt::format("^ {}", scriptInterface.getLastLuaError()));
+			success = false;
 			++processedCount;
 			if (reportStartupProgress) {
 				startupProgress().update(processedCount, candidateCount,
@@ -182,5 +184,5 @@ bool Scripts::loadScripts(const std::string& folderName, bool isLib, bool reload
 		}
 	}
 
-	return true;
+	return success;
 }

--- a/src/tests/dat_test_fixture.h
+++ b/src/tests/dat_test_fixture.h
@@ -36,23 +36,36 @@ inline void appendU32(std::vector<uint8_t>& bytes, uint32_t value)
 	bytes.push_back(static_cast<uint8_t>(value >> 24));
 }
 
-inline void appendThing(std::vector<uint8_t>& bytes, size_t spriteIdBytes, bool unmoveable = false)
+inline void appendThing(std::vector<uint8_t>& bytes, size_t spriteIdBytes, bool unmoveable = false,
+                        uint8_t animationPhases = 1, bool enhancedAnimations = false)
 {
 	if (unmoveable) {
 		bytes.push_back(13); // IsUnmoveable
 	}
-	bytes.push_back(255);                             // LastFlag
-	bytes.insert(bytes.end(), {1, 1, 1, 1, 1, 1, 1}); // width, height, layers, patterns, frames
-	if (spriteIdBytes == sizeof(uint16_t)) {
-		appendU16(bytes, 1);
-	} else {
-		appendU32(bytes, 1);
+	bytes.push_back(255); // LastFlag
+	bytes.insert(bytes.end(), {1, 1, 1, 1, 1, 1}); // width, height, layers, patterns
+	bytes.push_back(animationPhases);
+	if (enhancedAnimations && animationPhases > 1) {
+		bytes.push_back(0); // async
+		appendU32(bytes, 0); // loop count
+		bytes.push_back(0); // start phase
+		for (uint8_t phase = 0; phase < animationPhases; ++phase) {
+			appendU32(bytes, 100);
+			appendU32(bytes, 100);
+		}
+	}
+	for (uint8_t phase = 0; phase < animationPhases; ++phase) {
+		if (spriteIdBytes == sizeof(uint16_t)) {
+			appendU16(bytes, 1);
+		} else {
+			appendU32(bytes, 1);
+		}
 	}
 }
 
 inline std::vector<uint8_t> makeDat(uint16_t itemCount = FIRST_DAT_ITEM_ID,
                                     size_t spriteIdBytes = sizeof(uint16_t), bool firstItemUnmoveable = false,
-                                    VisualCounts visualCounts = {})
+                                    VisualCounts visualCounts = {}, bool enhancedAnimations = false)
 {
 	if (itemCount < FIRST_DAT_ITEM_ID) {
 		throw std::invalid_argument("DAT test fixture itemCount must be at least 100");
@@ -73,9 +86,16 @@ inline std::vector<uint8_t> makeDat(uint16_t itemCount = FIRST_DAT_ITEM_ID,
 	appendU16(bytes, visualCounts.distanceEffects);
 
 	for (uint32_t id = FIRST_DAT_ITEM_ID; id <= itemCount; ++id) {
-		appendThing(bytes, spriteIdBytes, firstItemUnmoveable && id == FIRST_DAT_ITEM_ID);
+		appendThing(bytes, spriteIdBytes, firstItemUnmoveable && id == FIRST_DAT_ITEM_ID,
+		            enhancedAnimations && id == FIRST_DAT_ITEM_ID ? 2 : 1, enhancedAnimations);
 	}
-	for (size_t index = 0; index < visualCount; ++index) {
+	for (uint16_t id = 0; id < visualCounts.outfits; ++id) {
+		appendThing(bytes, spriteIdBytes);
+	}
+	for (uint16_t id = 0; id < visualCounts.effects; ++id) {
+		appendThing(bytes, spriteIdBytes);
+	}
+	for (uint16_t id = 0; id < visualCounts.distanceEffects; ++id) {
 		appendThing(bytes, spriteIdBytes);
 	}
 	return bytes;

--- a/src/tests/dat_test_fixture.h
+++ b/src/tests/dat_test_fixture.h
@@ -1,0 +1,96 @@
+#ifndef FS_DAT_TEST_FIXTURE_H
+#define FS_DAT_TEST_FIXTURE_H
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace tfs::tests::dat {
+
+constexpr uint32_t TIBIA_860_DAT_SIGNATURE = 0x4C2C7993;
+constexpr uint16_t FIRST_DAT_ITEM_ID = 100;
+
+inline void appendU16(std::vector<uint8_t>& bytes, uint16_t value)
+{
+	bytes.push_back(static_cast<uint8_t>(value));
+	bytes.push_back(static_cast<uint8_t>(value >> 8));
+}
+
+inline void appendU32(std::vector<uint8_t>& bytes, uint32_t value)
+{
+	bytes.push_back(static_cast<uint8_t>(value));
+	bytes.push_back(static_cast<uint8_t>(value >> 8));
+	bytes.push_back(static_cast<uint8_t>(value >> 16));
+	bytes.push_back(static_cast<uint8_t>(value >> 24));
+}
+
+inline std::vector<uint8_t> makeDat(uint16_t itemCount = FIRST_DAT_ITEM_ID,
+                                    size_t spriteIdBytes = sizeof(uint16_t), bool firstItemUnmoveable = false)
+{
+	if (itemCount < FIRST_DAT_ITEM_ID) {
+		throw std::invalid_argument("DAT test fixture itemCount must be at least 100");
+	}
+	if (spriteIdBytes != sizeof(uint16_t) && spriteIdBytes != sizeof(uint32_t)) {
+		throw std::invalid_argument("DAT test fixture sprite IDs must be uint16 or uint32");
+	}
+
+	const size_t recordCount = static_cast<size_t>(itemCount) - FIRST_DAT_ITEM_ID + 1;
+	std::vector<uint8_t> bytes;
+	bytes.reserve(12 + recordCount * (8 + spriteIdBytes) + (firstItemUnmoveable ? 1 : 0));
+	appendU32(bytes, TIBIA_860_DAT_SIGNATURE);
+	appendU16(bytes, itemCount);
+	appendU16(bytes, 0); // outfits
+	appendU16(bytes, 0); // effects
+	appendU16(bytes, 0); // distance effects
+
+	for (uint32_t id = FIRST_DAT_ITEM_ID; id <= itemCount; ++id) {
+		if (firstItemUnmoveable && id == FIRST_DAT_ITEM_ID) {
+			bytes.push_back(13); // IsUnmoveable
+		}
+		bytes.push_back(255);                             // LastFlag
+		bytes.insert(bytes.end(), {1, 1, 1, 1, 1, 1, 1}); // width, height, layers, patterns, frames
+		if (spriteIdBytes == sizeof(uint16_t)) {
+			appendU16(bytes, 1);
+		} else {
+			appendU32(bytes, 1);
+		}
+	}
+	return bytes;
+}
+
+class TempDatFile
+{
+public:
+	TempDatFile(std::string_view name, const std::vector<uint8_t>& bytes) :
+	    path(std::filesystem::temp_directory_path() /
+	         (std::string{name} + "_" +
+	          std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".dat"))
+	{
+		std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+		stream.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+		if (!stream) {
+			throw std::runtime_error("Unable to create temporary DAT test fixture");
+		}
+	}
+
+	~TempDatFile()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+
+	TempDatFile(const TempDatFile&) = delete;
+	TempDatFile& operator=(const TempDatFile&) = delete;
+
+	std::filesystem::path path;
+};
+
+} // namespace tfs::tests::dat
+
+#endif // FS_DAT_TEST_FIXTURE_H

--- a/src/tests/dat_test_fixture.h
+++ b/src/tests/dat_test_fixture.h
@@ -16,6 +16,12 @@ namespace tfs::tests::dat {
 constexpr uint32_t TIBIA_860_DAT_SIGNATURE = 0x4C2C7993;
 constexpr uint16_t FIRST_DAT_ITEM_ID = 100;
 
+struct VisualCounts {
+	uint16_t outfits = 0;
+	uint16_t effects = 0;
+	uint16_t distanceEffects = 0;
+};
+
 inline void appendU16(std::vector<uint8_t>& bytes, uint16_t value)
 {
 	bytes.push_back(static_cast<uint8_t>(value));
@@ -30,8 +36,23 @@ inline void appendU32(std::vector<uint8_t>& bytes, uint32_t value)
 	bytes.push_back(static_cast<uint8_t>(value >> 24));
 }
 
+inline void appendThing(std::vector<uint8_t>& bytes, size_t spriteIdBytes, bool unmoveable = false)
+{
+	if (unmoveable) {
+		bytes.push_back(13); // IsUnmoveable
+	}
+	bytes.push_back(255);                             // LastFlag
+	bytes.insert(bytes.end(), {1, 1, 1, 1, 1, 1, 1}); // width, height, layers, patterns, frames
+	if (spriteIdBytes == sizeof(uint16_t)) {
+		appendU16(bytes, 1);
+	} else {
+		appendU32(bytes, 1);
+	}
+}
+
 inline std::vector<uint8_t> makeDat(uint16_t itemCount = FIRST_DAT_ITEM_ID,
-                                    size_t spriteIdBytes = sizeof(uint16_t), bool firstItemUnmoveable = false)
+                                    size_t spriteIdBytes = sizeof(uint16_t), bool firstItemUnmoveable = false,
+                                    VisualCounts visualCounts = {})
 {
 	if (itemCount < FIRST_DAT_ITEM_ID) {
 		throw std::invalid_argument("DAT test fixture itemCount must be at least 100");
@@ -41,25 +62,21 @@ inline std::vector<uint8_t> makeDat(uint16_t itemCount = FIRST_DAT_ITEM_ID,
 	}
 
 	const size_t recordCount = static_cast<size_t>(itemCount) - FIRST_DAT_ITEM_ID + 1;
+	const size_t visualCount =
+	    static_cast<size_t>(visualCounts.outfits) + visualCounts.effects + visualCounts.distanceEffects;
 	std::vector<uint8_t> bytes;
-	bytes.reserve(12 + recordCount * (8 + spriteIdBytes) + (firstItemUnmoveable ? 1 : 0));
+	bytes.reserve(12 + (recordCount + visualCount) * (8 + spriteIdBytes) + (firstItemUnmoveable ? 1 : 0));
 	appendU32(bytes, TIBIA_860_DAT_SIGNATURE);
 	appendU16(bytes, itemCount);
-	appendU16(bytes, 0); // outfits
-	appendU16(bytes, 0); // effects
-	appendU16(bytes, 0); // distance effects
+	appendU16(bytes, visualCounts.outfits);
+	appendU16(bytes, visualCounts.effects);
+	appendU16(bytes, visualCounts.distanceEffects);
 
 	for (uint32_t id = FIRST_DAT_ITEM_ID; id <= itemCount; ++id) {
-		if (firstItemUnmoveable && id == FIRST_DAT_ITEM_ID) {
-			bytes.push_back(13); // IsUnmoveable
-		}
-		bytes.push_back(255);                             // LastFlag
-		bytes.insert(bytes.end(), {1, 1, 1, 1, 1, 1, 1}); // width, height, layers, patterns, frames
-		if (spriteIdBytes == sizeof(uint16_t)) {
-			appendU16(bytes, 1);
-		} else {
-			appendU32(bytes, 1);
-		}
+		appendThing(bytes, spriteIdBytes, firstItemUnmoveable && id == FIRST_DAT_ITEM_ID);
+	}
+	for (size_t index = 0; index < visualCount; ++index) {
+		appendThing(bytes, spriteIdBytes);
 	}
 	return bytes;
 }

--- a/src/tests/test_item_source_integration.cpp
+++ b/src/tests/test_item_source_integration.cpp
@@ -184,6 +184,7 @@ TEST_CASE(successful_reload_switches_between_otb_and_dat)
 	CurrentPathGuard currentPath(root);
 	TempDatFile dat("tfs_item_source_switch", makeDat(52947));
 
+	CHECK(ConfigManager::setString(ConfigManager::CONFIG_FILE, (root / "config.lua.dist").string()));
 	CHECK(ConfigManager::load());
 	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, false);
 	CHECK(ScriptingManager::getInstance().loadPreItems());

--- a/src/tests/test_item_source_integration.cpp
+++ b/src/tests/test_item_source_integration.cpp
@@ -1,0 +1,214 @@
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../iomap.h"
+#include "../item.h"
+#include "../logger.h"
+#include "../map.h"
+#include "../scriptmanager.h"
+#include "dat_test_fixture.h"
+#include "test_support.h"
+
+#include <chrono>
+#include <filesystem>
+
+namespace {
+
+using tfs::tests::dat::makeDat;
+using tfs::tests::dat::TempDatFile;
+
+std::filesystem::path sourceRoot()
+{
+	return std::filesystem::weakly_canonical(std::filesystem::path{__FILE__}).parent_path().parent_path().parent_path();
+}
+
+class CurrentPathGuard
+{
+public:
+	explicit CurrentPathGuard(const std::filesystem::path& path) : previous(std::filesystem::current_path())
+	{
+		std::filesystem::current_path(path);
+	}
+
+	~CurrentPathGuard() { std::filesystem::current_path(previous); }
+
+private:
+	std::filesystem::path previous;
+};
+
+class TempDirectory
+{
+public:
+	TempDirectory() :
+	    path(std::filesystem::temp_directory_path() /
+	         ("tfs_dat_without_otb_" +
+	          std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())))
+	{
+		std::filesystem::create_directory(path);
+	}
+
+	~TempDirectory()
+	{
+		std::error_code error;
+		std::filesystem::remove_all(path, error);
+	}
+
+	std::filesystem::path path;
+};
+
+void loadRealXml(Items& items)
+{
+	if (!items.loadFromXml(false, false)) {
+		throw std::runtime_error(items.getLastError());
+	}
+	CHECK(items.isValidItemId(100));
+	CHECK(items.isValidItemId(52947));
+	CHECK(items.isValidItemId(65000));
+	CHECK(items.isValidItemId(65001));
+	CHECK(!items[65000].stackable);
+	CHECK(items[65001].stackable);
+}
+
+void loadRealMap(const std::filesystem::path& root)
+{
+	Map map;
+	IOMap loader;
+	if (!loader.loadMap(&map, root / "data/world/world.otbm", false)) {
+		throw std::runtime_error(std::string{loader.getLastErrorString()});
+	}
+	CHECK(map.getWidth() != 0);
+	CHECK(map.getHeight() != 0);
+}
+
+} // namespace
+
+TEST_CASE(real_otb_source_loads_xml_and_map)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+
+	Item::items.clear();
+	CHECK(Item::items.loadFromOtb((root / "data/items/items.otb").string()));
+	loadRealXml(Item::items);
+	loadRealMap(root);
+	Item::items.clear();
+}
+
+TEST_CASE(generated_dat_source_loads_real_xml_without_otb)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+	TempDatFile dat("tfs_item_source_real_xml", makeDat(52947));
+
+	Item::items.clear();
+	CHECK(Item::items.loadFromDat(dat.path.string()));
+	loadRealXml(Item::items);
+	Item::items.clear();
+}
+
+TEST_CASE(configured_otb_source_ignores_the_dat_path)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, false);
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, "data/items/does-not-exist.dat");
+	Items items;
+	CHECK(items.loadFromConfiguredSource());
+	CHECK(items.getLoadedSource() == Items::Source::OTB);
+}
+
+TEST_CASE(configured_dat_source_and_missing_file_failure_are_explicit)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+	TempDatFile dat("tfs_item_source_configured", makeDat());
+
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, true);
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, dat.path.string());
+	Items items;
+	CHECK(items.loadFromConfiguredSource());
+	CHECK(items.getLoadedSource() == Items::Source::DAT);
+
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, "data/items/does-not-exist.dat");
+	Items missing;
+	CHECK(!missing.loadFromConfiguredSource());
+	CHECK(missing.getLastError().find("does-not-exist.dat") != std::string::npos);
+	CHECK(missing.getLastError().find("Tibia.dat") != std::string::npos);
+	CHECK(missing.getLastError().find("assets.dat") != std::string::npos);
+}
+
+TEST_CASE(configured_dat_source_does_not_require_otb)
+{
+	const auto root = sourceRoot();
+	TempDirectory isolated;
+	CurrentPathGuard currentPath(isolated.path);
+	TempDatFile dat("tfs_item_source_without_otb", makeDat());
+
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, true);
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, dat.path.string());
+	Items items;
+	CHECK(items.loadFromConfiguredSource());
+	CHECK(items.getLoadedSource() == Items::Source::DAT);
+	CHECK(!std::filesystem::exists(isolated.path / "data/items/items.otb"));
+}
+
+TEST_CASE(truncated_dat_reload_preserves_the_previous_item_state)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+	TempDatFile dat("tfs_item_source_reload", makeDat(52947));
+
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, true);
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, dat.path.string());
+	Items items;
+	CHECK(items.loadFromConfiguredSource());
+	loadRealXml(items);
+	const std::string originalName = items[100].name;
+	const std::string originalPath{items.getLoadedSourcePath()};
+
+	auto truncatedBytes = makeDat(52947);
+	truncatedBytes.resize(64);
+	TempDatFile truncated("tfs_item_source_reload_truncated", truncatedBytes);
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, truncated.path.string());
+	CHECK(!items.reload());
+	CHECK(items.getLoadedSource() == Items::Source::DAT);
+	CHECK(items.getLoadedSourcePath() == originalPath);
+	CHECK(items[100].name == originalName);
+	CHECK(items.isValidItemId(52947));
+}
+
+TEST_CASE(successful_reload_switches_between_otb_and_dat)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+	TempDatFile dat("tfs_item_source_switch", makeDat(52947));
+
+	CHECK(ConfigManager::load());
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, false);
+	CHECK(ScriptingManager::getInstance().loadPreItems());
+	Item::items.clear();
+	CHECK(Item::items.loadFromConfiguredSource());
+	CHECK(Item::items.loadFromXml());
+	CHECK(ScriptingManager::getInstance().loadScriptSystems());
+
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, true);
+	ConfigManager::setString(ConfigManager::ASSETS_DAT_PATH, dat.path.string());
+	CHECK(Item::items.reload());
+	CHECK(Item::items.getLoadedSource() == Items::Source::DAT);
+
+	ConfigManager::setBoolean(ConfigManager::USE_ASSETS_DAT, false);
+	CHECK(Item::items.reload());
+	CHECK(Item::items.getLoadedSource() == Items::Source::OTB);
+	Item::items.clear();
+}
+
+int main()
+{
+	if (!initLogger(LogLevel::ERRORR)) {
+		return EXIT_FAILURE;
+	}
+	const int result = ::tfs::tests::run();
+	shutdownLogger();
+	return result;
+}

--- a/src/tests/test_items_dat.cpp
+++ b/src/tests/test_items_dat.cpp
@@ -1,0 +1,116 @@
+#include "../otpch.h"
+
+#include "../items.h"
+#include "dat_test_fixture.h"
+#include "test_support.h"
+
+#include <filesystem>
+
+namespace {
+
+using tfs::tests::dat::makeDat;
+using tfs::tests::dat::TempDatFile;
+
+std::filesystem::path sourceRoot()
+{
+	return std::filesystem::weakly_canonical(std::filesystem::path{__FILE__}).parent_path().parent_path().parent_path();
+}
+
+class CurrentPathGuard
+{
+public:
+	explicit CurrentPathGuard(const std::filesystem::path& path) : previous(std::filesystem::current_path())
+	{
+		std::filesystem::current_path(path);
+	}
+
+	~CurrentPathGuard() { std::filesystem::current_path(previous); }
+
+private:
+	std::filesystem::path previous;
+};
+
+} // namespace
+
+TEST_CASE(loads_uint16_sprite_ids)
+{
+	TempDatFile file("tfs_items_dat_u16", makeDat(100, sizeof(uint16_t)));
+	Items items;
+	CHECK(items.loadFromDat(file.path.string()));
+	CHECK(items.isLoadedFromDat());
+	CHECK(items.getDatItemCount() == 100);
+	CHECK(items.isValidItemId(100));
+	CHECK(items[100].moveable);
+	CHECK(items.isValidItemId(ITEM_BROWSEFIELD));
+}
+
+TEST_CASE(loads_uint32_sprite_ids_only_after_full_uint16_probe_fails)
+{
+	TempDatFile file("tfs_items_dat_u32", makeDat(100, sizeof(uint32_t)));
+	Items items;
+	CHECK(items.loadFromDat(file.path.string()));
+	CHECK(items.isValidItemId(100));
+}
+
+TEST_CASE(dat_unmoveable_applies_only_to_the_parsed_item)
+{
+	TempDatFile file("tfs_items_dat_unmoveable", makeDat(100, sizeof(uint16_t), true));
+	Items items;
+	CHECK(items.loadFromDat(file.path.string()));
+	CHECK(!items[100].moveable);
+	CHECK(!items[99].moveable);
+	CHECK(!items[101].moveable);
+}
+
+TEST_CASE(xml_stackable_override_applies_in_dat_mode)
+{
+	const auto root = sourceRoot();
+	CurrentPathGuard currentPath(root);
+	TempDatFile file("tfs_items_dat_xml", makeDat(52947));
+
+	Items items;
+	CHECK(items.loadFromDat(file.path.string()));
+	CHECK(items.loadFromXml(false, false));
+	CHECK(!items[65000].stackable);
+	CHECK(items[65001].stackable);
+}
+
+TEST_CASE(rejects_truncated_dat)
+{
+	auto bytes = makeDat(100, sizeof(uint32_t));
+	bytes.pop_back();
+	TempDatFile file("tfs_items_dat_truncated", bytes);
+	Items items;
+	CHECK(!items.loadFromDat(file.path.string()));
+	CHECK(items.getLastError().find("offset") != std::string::npos);
+}
+
+TEST_CASE(rejects_unknown_dat_flag)
+{
+	auto bytes = makeDat();
+	bytes[12] = 34;
+	TempDatFile file("tfs_items_dat_unknown_flag", bytes);
+	Items items;
+	CHECK(!items.loadFromDat(file.path.string()));
+	CHECK(items.getLastError().find("unknown flag 34") != std::string::npos);
+}
+
+TEST_CASE(rejects_bad_dat_signature_and_count)
+{
+	auto badSignature = makeDat();
+	badSignature[0] = 0;
+	TempDatFile signatureFile("tfs_items_dat_bad_signature", badSignature);
+	Items signatureItems;
+	CHECK(!signatureItems.loadFromDat(signatureFile.path.string()));
+	CHECK(signatureItems.getLastError().find("signature") != std::string::npos);
+
+	auto badCount = makeDat();
+	badCount[4] = 99;
+	badCount[5] = 0;
+	TempDatFile countFile("tfs_items_dat_bad_count", badCount);
+	Items countItems;
+	CHECK(!countItems.loadFromDat(countFile.path.string()));
+	CHECK(countItems.getLastError().find("itemCount") != std::string::npos);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_items_dat.cpp
+++ b/src/tests/test_items_dat.cpp
@@ -10,6 +10,7 @@ namespace {
 
 using tfs::tests::dat::makeDat;
 using tfs::tests::dat::TempDatFile;
+using tfs::tests::dat::VisualCounts;
 
 std::filesystem::path sourceRoot()
 {
@@ -50,6 +51,35 @@ TEST_CASE(loads_uint32_sprite_ids_only_after_full_uint16_probe_fails)
 	Items items;
 	CHECK(items.loadFromDat(file.path.string()));
 	CHECK(items.isValidItemId(100));
+}
+
+TEST_CASE(validates_and_discards_declared_visual_sections)
+{
+	TempDatFile file("tfs_items_dat_visual_sections",
+	                 makeDat(100, sizeof(uint32_t), false, VisualCounts{1, 1, 1}));
+	Items items;
+	CHECK(items.loadFromDat(file.path.string()));
+	CHECK(items.getDatItemCount() == 100);
+	CHECK(!items.isValidItemId(101));
+}
+
+TEST_CASE(rejects_corrupt_visual_section)
+{
+	const size_t visualOffset = makeDat().size();
+	auto bytes = makeDat(100, sizeof(uint16_t), false, VisualCounts{1, 0, 0});
+	bytes[visualOffset] = 34;
+	TempDatFile file("tfs_items_dat_corrupt_visual", bytes);
+	Items items;
+	CHECK(!items.loadFromDat(file.path.string()));
+}
+
+TEST_CASE(rejects_bytes_after_declared_dat_sections)
+{
+	auto bytes = makeDat(100, sizeof(uint16_t), false, VisualCounts{1, 1, 1});
+	bytes.push_back(0);
+	TempDatFile file("tfs_items_dat_trailing_bytes", bytes);
+	Items items;
+	CHECK(!items.loadFromDat(file.path.string()));
 }
 
 TEST_CASE(dat_unmoveable_applies_only_to_the_parsed_item)

--- a/src/tests/test_items_dat.cpp
+++ b/src/tests/test_items_dat.cpp
@@ -53,7 +53,7 @@ TEST_CASE(loads_uint32_sprite_ids_only_after_full_uint16_probe_fails)
 	CHECK(items.isValidItemId(100));
 }
 
-TEST_CASE(validates_and_discards_declared_visual_sections)
+TEST_CASE(ignores_declared_visual_sections)
 {
 	TempDatFile file("tfs_items_dat_visual_sections",
 	                 makeDat(100, sizeof(uint32_t), false, VisualCounts{1, 1, 1}));
@@ -63,23 +63,32 @@ TEST_CASE(validates_and_discards_declared_visual_sections)
 	CHECK(!items.isValidItemId(101));
 }
 
-TEST_CASE(rejects_corrupt_visual_section)
+TEST_CASE(loads_astra_extended_animation_layout)
+{
+	TempDatFile file("tfs_items_dat_astra", makeDat(100, sizeof(uint32_t), false, {}, true));
+	Items items;
+	CHECK(items.loadFromDat(file.path.string()));
+	CHECK(items.getDatItemCount() == 100);
+	CHECK(items[100].isAnimation);
+}
+
+TEST_CASE(ignores_visual_section_contents)
 {
 	const size_t visualOffset = makeDat().size();
 	auto bytes = makeDat(100, sizeof(uint16_t), false, VisualCounts{1, 0, 0});
 	bytes[visualOffset] = 34;
 	TempDatFile file("tfs_items_dat_corrupt_visual", bytes);
 	Items items;
-	CHECK(!items.loadFromDat(file.path.string()));
+	CHECK(items.loadFromDat(file.path.string()));
 }
 
-TEST_CASE(rejects_bytes_after_declared_dat_sections)
+TEST_CASE(ignores_bytes_after_item_section)
 {
 	auto bytes = makeDat(100, sizeof(uint16_t), false, VisualCounts{1, 1, 1});
 	bytes.push_back(0);
 	TempDatFile file("tfs_items_dat_trailing_bytes", bytes);
 	Items items;
-	CHECK(!items.loadFromDat(file.path.string()));
+	CHECK(items.loadFromDat(file.path.string()));
 }
 
 TEST_CASE(dat_unmoveable_applies_only_to_the_parsed_item)


### PR DESCRIPTION
## What changed

- adds the optional `useAssetsDat` / `assetsDatPath` configuration, defaulting to the existing `items.otb` behavior
- adds a bounded Tibia 8.60 DAT item parser with uint16/uint32 sprite-ID probing and explicit diagnostics
- keeps `items.xml` overlays, custom item systems, map loading, map-cache compatibility, and transactional reload working with the selected source
- rejects missing, truncated, corrupt, or incompatible DAT files without silently falling back to OTB
- preserves `items.otb` and ignores `data/items/assets.dat` in Git; no client binary is bundled
- adds self-contained parser and integration tests that generate temporary DAT fixtures

## Installing assets.dat

1. Find `Tibia.dat` in a Tibia 8.60 client installation.
2. **Copy** it into the server's `data/items` directory; keep the original client file unchanged.
3. Rename the copied file to `assets.dat`.
4. Set:

```lua
useAssetsDat = true
assetsDatPath = "data/items/assets.dat"
```

With `useAssetsDat = false`, the server continues loading `data/items/items.otb` and does not require or inspect `assets.dat`.

## Why

The previous DAT experiment replaced the normal OTB path and could silently change the item-ID model. This implementation makes the source an explicit administrator choice, validates map/source compatibility, and fails startup or reload with an actionable error instead of changing sources automatically.

## Validation

- runtime smoke test completed server startup and map loading with a real Tibia 8.60 DAT
- earlier implementation validation passed 29/29 Release tests and the focused ASan DAT tests
- final staged diff passes `git diff --check`
- `data/items/items.xml` parses as valid XML
- final packaging changes (instructional error text and self-contained fixtures) were not recompiled, per maintainer request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading item data from a configured `.dat` file or the existing OTB source.
  * Added configuration options for enabling `.dat` loading and specifying its path.
  * Item data can now be switched and reloaded between supported sources.

* **Bug Fixes**
  * Improved startup and map-loading errors with clearer source and item details.
  * Failed item-data reloads now preserve the previously loaded state.
  * Script loading now correctly reports failures.

* **Validation**
  * Added stricter validation for item data, mappings, map caches, and malformed `.dat` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional Tibia 8.60 assets.dat item source while retaining OTB as the default.
- Adds bounded DAT parsing, source configuration, diagnostics, and generated parser fixtures.
- Makes item-source reload transactional across item definitions and dependent registries.
- Adds source-aware map and persistent-cache validation.
- Tightens items.xml range validation and corrects several reversed ranges.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because item, full, and SIGHUP reloads leave data/items Lua callbacks stale while reporting success.

Items::reload deliberately omits the data/items script directory, and none of its item-only, full-reload, or SIGHUP callers reload that directory afterward, so runtime callbacks can remain out of sync with successfully reloaded item definitions.

**Files Needing Attention:** src/items.cpp, src/game.cpp, src/signals.cpp

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/items.cpp | Adds DAT parsing and transactional source reloads; the previously reported stale data/items script behavior remains. |
| src/iomap.cpp | Adds source-aware map compatibility checks and clearer item parsing diagnostics. |
| src/mapcache.cpp | Incorporates the selected item source into cache validation and propagates detailed cache parsing errors. |
| src/script.cpp | Propagates script-file loading failures from the loader. |
| src/tests/test_items_dat.cpp | Adds self-contained coverage for valid and malformed DAT parsing. |
| src/tests/test_item_source_integration.cpp | Adds integration coverage for source selection, XML overlays, and reload behavior. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(startup): report item source errors"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/96414a423f290e8d1329aba82deef527e9db5f30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47331078)</sub>

<!-- /greptile_comment -->