### PR TITLE
fix: enforce lower bound on SpecialSkills_t in Lua bindings

### DIFF
--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -834,7 +834,7 @@ int luaPlayerGetSpecialSkill(lua_State* L)
 	// player:getSpecialSkill(specialSkillType)
 	SpecialSkills_t specialSkillType = getInteger<SpecialSkills_t>(L, 2);
 	const Player* player = getUserdata<const Player>(L, 1);
-	if (player && specialSkillType <= SPECIALSKILL_LAST) {
+	if (player && specialSkillType >= SPECIALSKILL_FIRST && specialSkillType <= SPECIALSKILL_LAST) {
 		lua_pushinteger(L, player->getSpecialSkill(specialSkillType));
 	} else {
 		lua_pushnil(L);
@@ -852,7 +852,7 @@ int luaPlayerAddSpecialSkill(lua_State* L)
 	}
 
 	SpecialSkills_t specialSkillType = getInteger<SpecialSkills_t>(L, 2);
-	if (specialSkillType > SPECIALSKILL_LAST) {
+	if (specialSkillType < SPECIALSKILL_FIRST || specialSkillType > SPECIALSKILL_LAST) {
 		lua_pushnil(L);
 		return 1;
 	}


### PR DESCRIPTION
## Bug

`player:getSpecialSkill()` and `player:addSpecialSkill()` in `src/luaplayer.cpp` only validated the **upper** bound of the skill type argument:

```cpp
if (player && specialSkillType <= SPECIALSKILL_LAST) { ... }
...
if (specialSkillType > SPECIALSKILL_LAST) { lua_pushnil(L); return 1; }
```

`getInteger<SpecialSkills_t>()` (in `src/luascript.h`) performs no range validation of its own for enum types, so a script calling:

```lua
player:addSpecialSkill(-1, someAmount)
```

passes the existing check (`-1 > SPECIALSKILL_LAST` is false) and reaches:

```cpp
void setVarSpecialSkill(SpecialSkills_t skill, int32_t modifier) { varSpecialSkills[skill] += modifier; }
```

with `skill == -1`.

`Player::varSpecialSkills` is declared as `int32_t varSpecialSkills[SPECIALSKILL_LAST + 1]`, and in the current member layout (`src/player.h`) the field immediately preceding it is `manaMax`. Indexing with `-1` writes one `int32_t` before the start of the array, landing exactly on `manaMax` and silently corrupting it — reachable from any Lua script with access to these calls (e.g. talkactions, spells, custom actions).

## Fix

Add the missing lower-bound check (`specialSkillType >= SPECIALSKILL_FIRST`) to both `luaPlayerGetSpecialSkill` and `luaPlayerAddSpecialSkill`, matching the existing bounds-checking style used elsewhere in the file.

## Testing

Built a standalone repro mirroring the real `Player` member layout (`manaMax` immediately followed by `varSpecialSkills[SPECIALSKILL_LAST + 1]`) with a canary value in `manaMax`'s slot:

- Before the fix: `addSpecialSkill(-1, N)` reliably overwrote the canary.
- After the fix: out-of-range calls (negative and `> SPECIALSKILL_LAST`) are rejected via `lua_pushnil`, and in-range calls still update the correct skill with no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for special skill types.
  - Invalid values below the supported range are now rejected consistently when retrieving or adding special skills.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->