### PR TITLE
fix: use-after-free of ProtocolAdmin in dispatcher tasks during shutdown

### DIFF
--- a/src/protocoladmin.cpp
+++ b/src/protocoladmin.cpp
@@ -266,19 +266,20 @@ void ProtocolAdmin::parsePacket(NetworkMessage& msg)
 				}
 
 				case CMD_PAY_HOUSES: {
-					g_dispatcher.addTask([this]() { adminCommandPayHouses(); });
+					g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->adminCommandPayHouses(); });
 					break;
 				}
 
 				case CMD_RELOAD_SCRIPTS: {
 					int8_t reload = msg.getByte();
-					g_dispatcher.addTask([this, reload]() { adminCommandReload(reload); });
+					g_dispatcher.addTask([thisPtr = getThis(), reload]() { thisPtr->adminCommandReload(reload); });
 					break;
 				}
 
 				case CMD_KICK: {
 					std::string param = std::string(msg.getString());
-					g_dispatcher.addTask([this, param = std::move(param)]() { adminCommandKickPlayer(param); });
+					g_dispatcher.addTask(
+					    [thisPtr = getThis(), param = std::move(param)]() { thisPtr->adminCommandKickPlayer(param); });
 					break;
 				}
 

--- a/src/protocoladmin.h
+++ b/src/protocoladmin.h
@@ -7,6 +7,8 @@
 #include "protocol.h"
 
 class NetworkMessage;
+class ProtocolAdmin;
+using ProtocolAdmin_ptr = std::shared_ptr<ProtocolAdmin>;
 
 class ProtocolAdmin : public Protocol
 {
@@ -22,6 +24,8 @@ class ProtocolAdmin : public Protocol
 			lastCommand = 0;
 			startTime = std::time(nullptr);
 		}
+
+		ProtocolAdmin_ptr getThis() { return std::static_pointer_cast<ProtocolAdmin>(shared_from_this()); }
 
 		enum {protocolId = 0xFE};
 		// enum {isSingleSocket = false}; // Protocol base class handles this? Check if needed.


### PR DESCRIPTION
## Bug

`ProtocolAdmin::parsePacket()` (`src/protocoladmin.cpp`) schedules admin-command handlers on the global dispatcher by capturing a raw `this`:

```cpp
case CMD_PAY_HOUSES: {
    g_dispatcher.addTask([this]() { adminCommandPayHouses(); });
    break;
}
case CMD_RELOAD_SCRIPTS: {
    int8_t reload = msg.getByte();
    g_dispatcher.addTask([this, reload]() { adminCommandReload(reload); });
    break;
}
case CMD_KICK: {
    std::string param = std::string(msg.getString());
    g_dispatcher.addTask([this, param = std::move(param)]() { adminCommandKickPlayer(param); });
    break;
}
```

`ProtocolAdmin` only stays alive through `shared_ptr` ownership held by its `Connection`. Tracing the shutdown path:

- `ServiceManager::stop()` schedules `die()` (which calls `ConnectionManager::releaseAllProtocols()`) via a 3-second `death_timer`.
- `otserv.cpp`'s shutdown sequence calls `g_dispatcher.shutdown()` only *after* `serviceManager->stop()` / `serviceThread.join()` have already completed.

So the dispatcher is still fully running while connections/protocols are being released. Any admin task already queued at that point holds a raw `this` that can outlive the `ProtocolAdmin` object once its owning `Connection`/protocol chain is torn down — a real use-after-free during shutdown, not a hypothetical one. The existing in-code comment claiming "the dispatcher is already shut down" at that point does not match the actual call order.

## Fix

Add a `getThis()` helper to `ProtocolAdmin`, matching the pattern already used by `ProtocolGame`:

```cpp
ProtocolAdmin_ptr getThis() { return std::static_pointer_cast<ProtocolAdmin>(shared_from_this()); }
```

and capture a `shared_ptr` (`thisPtr = getThis()`) in the three `addTask` lambdas instead of raw `this`, keeping the object alive for as long as the queued task exists.

## Testing

Verified with a standalone repro: an object heap-allocated via `shared_ptr` with a custom deleter (poisoning its memory on free) demonstrates a dangling-pointer call reading poisoned memory when captured by raw pointer, and confirms the issue no longer occurs once the capture is switched to a `shared_ptr` obtained through `getThis()`.