### PR TITLE
fix: iterator invalidation in Monster::searchTarget fallback selection

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1248,10 +1248,19 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	}
 
 	// lets just pick the first target in the list
+	// snapshot targetList first: selectTarget() can call removeTarget(), which erases
+	// from targetList, so iterating targetList directly here would invalidate the loop
+	std::vector<std::shared_ptr<Creature>> fallbackList;
+	fallbackList.reserve(targetList.size());
+	for (const auto& weakRef : targetList) {
+		if (auto creature = weakRef.lock()) {
+			fallbackList.push_back(std::move(creature));
+		}
+	}
+
 	if (preferPlayers) {
-		for (const auto& weakRef : targetList) {
-			auto target = weakRef.lock();
-			if (!target || target->isRemoved() || !target->getTile()) {
+		for (const auto& target : fallbackList) {
+			if (target->isRemoved() || !target->getTile()) {
 				continue;
 			}
 
@@ -1262,9 +1271,8 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 		}
 	}
 
-	for (const auto& weakRef : targetList) {
-		auto target = weakRef.lock();
-		if (!target || target->isRemoved() || !target->getTile()) {
+	for (const auto& target : fallbackList) {
+		if (target->isRemoved() || !target->getTile()) {
 			continue;
 		}
 


### PR DESCRIPTION
## Bug

The final fallback block of `Monster::searchTarget()` (`src/monster.cpp`) iterated `targetList` (`std::vector<std::weak_ptr<Creature>>`) directly with a range-for loop while calling `selectTarget()` on each candidate:

```cpp
for (const auto& weakRef : targetList) {
    auto target = weakRef.lock();
    if (!target || target->isRemoved() || !target->getTile()) { continue; }
    ...
    if (... && selectTarget(target.get())) {
        return true;
    }
}
```

`selectTarget()` can call `removeTarget()`, which does `std::erase_if(targetList, ...)` — mutating `targetList` while it is still being range-for iterated in this same block. This is reachable whenever `MONSTER_FACTION_SYSTEM` is enabled and a faction-disallowed creature is present in `targetList`, and it invalidates the loop's iterators mid-iteration (undefined behavior).

Note that an earlier part of the same function already snapshots into a separate `resultList` before iterating, for exactly this reason — but `resultList`'s filtering is narrower (only attack-range-usable creatures), so it isn't a drop-in replacement for this fallback block.

## Fix

Snapshot `targetList` into a local `fallbackList` of locked `shared_ptr<Creature>` before running the fallback selection loops (`preferPlayers` pass and the general pass), and iterate that snapshot instead of `targetList` directly.

## Testing

Verified by compiling this function's control flow with GCC's libstdc++ debug-mode STL (`-D_GLIBCXX_DEBUG`), which aborts with an iterator-invalidation diagnostic on the original code when `removeTarget()` is triggered mid-iteration, and runs clean after the fix.