### PR TITLE
fix(creature): block cross-floor follow paths

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -531,15 +531,16 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 	}
 
 	if (auto fc = followCreature.lock(); creature == fc.get() || (creature == this && fc)) {
-		if (hasFollowPath) {
-			requestFollowPathUpdate();
-		}
-
 		auto masterCreature = master.lock();
 		const bool followsLiveMaster = masterCreature && masterCreature == fc && !masterCreature->isRemoved() &&
 		                               !masterCreature->isDead();
 		if (!followsLiveMaster && (newPos.z != oldPos.z || !canSee(fc->getPosition()))) {
+			clearFollowPath();
 			onCreatureDisappear(fc.get(), false);
+		} else if (getPosition().z != fc->getPosition().z) {
+			clearFollowPath();
+		} else if (hasFollowPath) {
+			requestFollowPathUpdate();
 		}
 	}
 
@@ -1076,20 +1077,35 @@ void Creature::getPathSearchParams(const Creature*, FindPathParams& fpp) const
 	}
 }
 
+void Creature::clearFollowPath()
+{
+	stopEventWalk();
+	if (!listWalkDir.empty()) {
+		listWalkDir.clear();
+		onWalkAborted();
+	}
+	hasFollowPath = false;
+	forceUpdateFollowPath = false;
+}
+
 void Creature::goToFollowCreature()
 {
 	PerformanceScope performanceScope(PerformanceMetric::CreatureGoToFollow);
 	if (auto fc = followCreature.lock()) {
-		FindPathParams fpp;
-		getPathSearchParams(fc.get(), fpp);
+		if (getPosition().z != fc->getPosition().z) {
+			clearFollowPath();
+		} else {
+			FindPathParams fpp;
+			getPathSearchParams(fc.get(), fpp);
 
-		listWalkDir.clear();
+			listWalkDir.clear();
 
-		if (getPathTo(fc->getPosition(), listWalkDir, fpp)) {
-			hasFollowPath = true;
-			startAutoWalk(listWalkDir);
-		} else
-			hasFollowPath = false;
+			if (getPathTo(fc->getPosition(), listWalkDir, fpp)) {
+				hasFollowPath = true;
+				startAutoWalk(listWalkDir);
+			} else
+				hasFollowPath = false;
+		}
 	}
 
 	auto follow = followCreature.lock();
@@ -1098,7 +1114,17 @@ void Creature::goToFollowCreature()
 
 void Creature::requestFollowPathUpdate()
 {
-	if (isUpdatingPath || followCreature.expired()) {
+	auto follow = followCreature.lock();
+	if (!follow) {
+		return;
+	}
+
+	if (getPosition().z != follow->getPosition().z) {
+		clearFollowPath();
+		return;
+	}
+
+	if (isUpdatingPath) {
 		return;
 	}
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -502,6 +502,7 @@ protected:
 	virtual uint64_t getLostExperience() const { return 0; }
 	virtual void dropLoot(Container*, Creature*) {}
 	virtual uint16_t getLookCorpse() const { return 0; }
+	void clearFollowPath();
 	virtual void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const;
 	virtual void death(Creature*) {}
 	virtual bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified,

--- a/src/tests/test_monster_target_state.cpp
+++ b/src/tests/test_monster_target_state.cpp
@@ -35,6 +35,22 @@ public:
 		}
 	}
 	void markDead() { health = 0; }
+	void seedFollowPath(Direction direction)
+	{
+		stopEventWalk();
+		listWalkDir = {direction};
+		hasFollowPath = true;
+		forceUpdateFollowPath = false;
+	}
+	void runFollowPathUpdate()
+	{
+		isUpdatingPath = false;
+		goToFollowCreature();
+	}
+	bool hasPhysicalFollowPath() const { return hasFollowPath; }
+	bool hasPendingFollowPathUpdate() const { return isUpdatingPath; }
+	bool hasScheduledWalk() const { return eventWalk != 0; }
+	size_t getFollowPathSize() const { return listWalkDir.size(); }
 
 private:
 	inline static uint32_t nextId = 0x50000000;
@@ -304,6 +320,114 @@ TEST_CASE(summon_preserves_master_follow_across_floor_change)
 
 	CHECK(summon->getMaster() == master);
 	CHECK(summon->getFollowCreatureShared() == master);
+}
+
+TEST_CASE(summon_does_not_pathfind_to_master_on_different_floor)
+{
+	WorldFixture world;
+	auto summon = std::make_shared<TestCreature>();
+	auto master = std::make_shared<TestCreature>();
+	const Position summonPosition{700, 500, 7};
+	const Position oldMasterPosition{701, 500, 7};
+	const Position newMasterPosition{701, 500, 8};
+	world.place(summon, summonPosition);
+	world.place(master, oldMasterPosition);
+	CHECK(summon->setMaster(master.get()));
+	CHECK(summon->setFollowCreature(master.get()));
+	summon->runFollowPathUpdate();
+	summon->seedFollowPath(DIRECTION_SOUTH);
+
+	moveCreatureForMonster(master, newMasterPosition);
+
+	CHECK(summon->getMaster() == master);
+	CHECK(summon->getFollowCreatureShared() == master);
+	CHECK(!summon->hasPhysicalFollowPath());
+	CHECK(summon->getFollowPathSize() == 0);
+	CHECK(!summon->hasScheduledWalk());
+
+	summon->runFollowPathUpdate();
+	CHECK(!summon->hasPhysicalFollowPath());
+	CHECK(summon->getFollowPathSize() == 0);
+	CHECK(!summon->hasScheduledWalk());
+}
+
+TEST_CASE(summon_does_not_move_when_master_moves_on_other_floor)
+{
+	WorldFixture world;
+	auto summon = std::make_shared<TestCreature>();
+	auto master = std::make_shared<TestCreature>();
+	const Position summonPosition{720, 500, 7};
+	world.place(summon, summonPosition);
+	world.place(master, Position{721, 500, 7});
+	CHECK(summon->setMaster(master.get()));
+	CHECK(summon->setFollowCreature(master.get()));
+	summon->runFollowPathUpdate();
+	summon->seedFollowPath(DIRECTION_SOUTH);
+
+	for (const Position& masterPosition : {Position{721, 500, 8}, Position{722, 500, 8}, Position{723, 500, 8}}) {
+		moveCreatureForMonster(master, masterPosition);
+		summon->onThink(2000);
+		CHECK(!summon->hasPendingFollowPathUpdate());
+		summon->onWalk();
+		CHECK(summon->getPosition() == summonPosition);
+		CHECK(summon->getFollowPathSize() == 0);
+	}
+}
+
+TEST_CASE(summon_resumes_follow_when_master_returns_to_same_floor)
+{
+	WorldFixture world;
+	auto summon = std::make_shared<TestCreature>();
+	auto master = std::make_shared<TestCreature>();
+	const Position summonPosition{740, 500, 7};
+	const Position oldMasterPosition{741, 500, 7};
+	const Position otherFloorPosition{744, 500, 8};
+	const Position returnedMasterPosition{744, 500, 7};
+	for (uint16_t x = summonPosition.x; x <= returnedMasterPosition.x; ++x) {
+		ensureTile(Position{x, summonPosition.y, summonPosition.z});
+	}
+	world.place(summon, summonPosition);
+	world.place(master, oldMasterPosition);
+	CHECK(summon->setMaster(master.get()));
+	CHECK(summon->setFollowCreature(master.get()));
+	summon->runFollowPathUpdate();
+
+	moveCreatureForMonster(master, otherFloorPosition);
+	summon->onThink(2000);
+	CHECK(!summon->hasPendingFollowPathUpdate());
+	CHECK(!summon->hasPhysicalFollowPath());
+
+	moveCreatureForMonster(master, returnedMasterPosition);
+	summon->onThink(2000);
+	CHECK(summon->hasPendingFollowPathUpdate());
+	summon->runFollowPathUpdate();
+
+	CHECK(summon->getFollowCreatureShared() == master);
+	CHECK(summon->hasPhysicalFollowPath());
+	CHECK(summon->getFollowPathSize() > 0);
+	summon->onWalk();
+	CHECK(summon->getPosition() != summonPosition);
+}
+
+TEST_CASE(no_duplicate_follow_update_tasks_across_floors)
+{
+	WorldFixture world;
+	auto summon = std::make_shared<TestCreature>();
+	auto master = std::make_shared<TestCreature>();
+	world.place(summon, Position{760, 500, 7});
+	world.place(master, Position{761, 500, 7});
+	CHECK(summon->setMaster(master.get()));
+	CHECK(summon->setFollowCreature(master.get()));
+	summon->runFollowPathUpdate();
+
+	moveCreatureForMonster(master, Position{761, 500, 8});
+	for (uint8_t i = 0; i < 5; ++i) {
+		summon->requestFollowPathUpdate();
+		summon->onThink(2000);
+		CHECK(!summon->hasPendingFollowPathUpdate());
+		CHECK(!summon->hasPhysicalFollowPath());
+		CHECK(summon->getFollowPathSize() == 0);
+	}
 }
 
 TEST_CASE(monster_does_not_duplicate_known_target)

--- a/src/tests/test_monster_target_state.cpp
+++ b/src/tests/test_monster_target_state.cpp
@@ -99,6 +99,15 @@ void ensureTile(const Position& position)
 	}
 }
 
+void ensureArea(const Position& center, int32_t rangeX, int32_t rangeY)
+{
+	for (int32_t x = -rangeX; x <= rangeX; ++x) {
+		for (int32_t y = -rangeY; y <= rangeY; ++y) {
+			ensureTile(Position{static_cast<uint16_t>(center.x + x), static_cast<uint16_t>(center.y + y), center.z});
+		}
+	}
+}
+
 void addStairHeight(Tile* tile)
 {
 	static const uint16_t heightItemId = [] {
@@ -468,9 +477,10 @@ TEST_CASE(monster_cleans_target_that_changes_floor)
 	WorldFixture world;
 	auto monster = makeMonster();
 	auto target = makeMonster(true);
+	const Position monsterPosition{599, 500, 7};
 	const Position oldPosition{600, 500, 7};
 	const Position newPosition{600, 500, 6};
-	world.place(monster, Position{599, 500, 7});
+	world.place(monster, monsterPosition);
 	world.place(target, oldPosition);
 	selectTarget(monster, target);
 	CHECK(monster->canSee(oldPosition));
@@ -486,6 +496,9 @@ TEST_CASE(monster_cleans_target_that_changes_floor)
 	CHECK(!monster->getAttackedCreatureShared());
 	CHECK(!monster->getFollowCreatureShared());
 	CHECK(monster->getIdleStatus());
+	g_game.updateCreatureWalk(monster->getID());
+	monster->onWalk();
+	CHECK(monster->getPosition() == monsterPosition);
 
 	moveCreatureForMonster(target, oldPosition);
 	CHECK(hasTarget(monster, target.get()));
@@ -698,6 +711,120 @@ TEST_CASE(moving_monster_discovers_new_stationary_target)
 	CHECK(monster->canSee(stationaryTarget->getPosition()));
 	CHECK(hasTarget(monster, followedTarget.get()));
 	CHECK(hasTarget(monster, stationaryTarget.get()));
+}
+
+TEST_CASE(monster_follows_player_in_all_cardinal_directions)
+{
+	struct ChaseCase
+	{
+		int32_t dx;
+		int32_t dy;
+		Direction direction;
+	};
+	const std::array<ChaseCase, 4> cases = {{
+	    {1, 0, DIRECTION_EAST},
+	    {-1, 0, DIRECTION_WEST},
+	    {0, 1, DIRECTION_SOUTH},
+	    {0, -1, DIRECTION_NORTH},
+	}};
+
+	for (size_t index = 0; index < cases.size(); ++index) {
+		WorldFixture world;
+		const ChaseCase& chase = cases[index];
+		const Position monsterPosition{static_cast<uint16_t>(1000 + index * 30), 700, 7};
+		const Position playerPosition{static_cast<uint16_t>(monsterPosition.x + chase.dx * 4),
+		                              static_cast<uint16_t>(monsterPosition.y + chase.dy * 4), 7};
+		const Position movedPlayerPosition{static_cast<uint16_t>(playerPosition.x + chase.dx),
+		                                   static_cast<uint16_t>(playerPosition.y + chase.dy), 7};
+		ensureArea(monsterPosition, 6, 6);
+		auto monster = makeMonster();
+		auto player = makePlayer();
+		world.place(monster, monsterPosition);
+		world.place(player, playerPosition);
+		selectTarget(monster, player);
+		g_game.updateCreatureWalk(monster->getID());
+
+		moveCreatureForMonster(player, movedPlayerPosition);
+		g_game.updateCreatureWalk(monster->getID());
+
+		Direction direction = DIRECTION_NONE;
+		uint32_t flags = 0;
+		CHECK(monster->getNextStep(direction, flags));
+		CHECK(direction == chase.direction);
+		CHECK(monster->getAttackedCreatureShared() == player);
+		CHECK(monster->getFollowCreatureShared() == player);
+	}
+}
+
+TEST_CASE(moving_monster_discovers_targets_at_all_view_edges)
+{
+	struct EdgeCase
+	{
+		int32_t moveX;
+		int32_t moveY;
+		int32_t targetX;
+		int32_t targetY;
+	};
+	const std::array<EdgeCase, 4> cases = {{
+	    {1, 0, Map::maxClientViewportX + 2, 0},
+	    {-1, 0, -(Map::maxClientViewportX + 2), 0},
+	    {0, 1, 0, Map::maxClientViewportY + 2},
+	    {0, -1, 0, -(Map::maxClientViewportY + 2)},
+	}};
+
+	for (size_t index = 0; index < cases.size(); ++index) {
+		WorldFixture world;
+		const EdgeCase& edge = cases[index];
+		const Position oldPosition{static_cast<uint16_t>(1200 + index * 40), 700, 7};
+		const Position newPosition{static_cast<uint16_t>(oldPosition.x + edge.moveX),
+		                           static_cast<uint16_t>(oldPosition.y + edge.moveY), 7};
+		const Position edgeTargetPosition{static_cast<uint16_t>(oldPosition.x + edge.targetX),
+		                                  static_cast<uint16_t>(oldPosition.y + edge.targetY), 7};
+		auto monster = makeMonster();
+		auto followedTarget = makeMonster(true);
+		auto edgeTarget = makeMonster(true);
+		world.place(monster, oldPosition);
+		world.place(followedTarget,
+		            Position{static_cast<uint16_t>(oldPosition.x + 1), static_cast<uint16_t>(oldPosition.y + 1), 7});
+		world.place(edgeTarget, edgeTargetPosition);
+		selectTarget(monster, followedTarget);
+		CHECK(!monster->canSee(edgeTargetPosition));
+
+		moveCreatureForMonster(monster, newPosition);
+
+		CHECK(monster->canSee(edgeTargetPosition));
+		CHECK(hasTarget(monster, followedTarget.get()));
+		CHECK(hasTarget(monster, edgeTarget.get()));
+	}
+}
+
+TEST_CASE(non_master_follow_clears_cross_floor_path_and_recovers)
+{
+	WorldFixture world;
+	auto follower = std::make_shared<TestCreature>();
+	auto target = std::make_shared<TestCreature>();
+	const Position followerPosition{1400, 700, 7};
+	const Position oldTargetPosition{1401, 700, 7};
+	const Position otherFloorPosition{1401, 700, 8};
+	world.place(follower, followerPosition);
+	world.place(target, oldTargetPosition);
+	CHECK(follower->setFollowCreature(target.get()));
+	follower->seedFollowPath(DIRECTION_EAST);
+
+	moveCreatureForMonster(target, otherFloorPosition);
+
+	CHECK(!follower->getFollowCreatureShared());
+	CHECK(!follower->hasPhysicalFollowPath());
+	CHECK(follower->getFollowPathSize() == 0);
+	g_game.updateCreatureWalk(follower->getID());
+	follower->onWalk();
+	CHECK(follower->getPosition() == followerPosition);
+	CHECK(!follower->setFollowCreature(target.get()));
+
+	moveCreatureForMonster(target, oldTargetPosition);
+	CHECK(follower->setFollowCreature(target.get()));
+	follower->runFollowPathUpdate();
+	CHECK(follower->getFollowCreatureShared() == target);
 }
 
 TFS_TEST_MAIN()


### PR DESCRIPTION
## Problema

O PR #177 passou a preservar corretamente `followCreature` quando summon/familiar segue seu mestre vivo entre andares. Porém, o caminho físico antigo continuava ativo e novas atualizações ainda podiam chamar `getPathTo()` com mestre e summon em valores de Z diferentes.

Como o pathfinding trabalha no piso atual e compara principalmente X/Y, o summon tentava alinhar-se às coordenadas do mestre no andar antigo.

O commit `f063e6a9` introduziu essa regressão ao preservar o vínculo lógico sem bloquear o pathfinding cross-floor. O commit `7d57803a` altera somente a iteração de fallback de `Monster::searchTarget()` e não participa do problema.

## Correção

- preserva `master` e `followCreature` para mestre vivo;
- cancela evento de caminhada e limpa somente estado físico do caminho quando os valores de Z diferem;
- impede `requestFollowPathUpdate()` de enfileirar novos cálculos cross-floor;
- protege `goToFollowCreature()` contra tarefas antigas já enfileiradas;
- retoma follow normalmente quando mestre e summon voltam ao mesmo Z;
- mantém limpeza normal de alvos cross-floor para monstros comuns.

## Testes

Adicionados casos para caminho antigo, movimento repetido do mestre em outro andar, retomada no mesmo andar e ausência de updates duplicados. A suíte `test_monster_target_state` concluiu os 20 testes com retorno 0 antes do teardown do CRT; no Windows, o binário de teste ainda apresenta uma falha de destruição estática após `main`. O build completo Release x64 concluiu sem erros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature-following behavior when targets become invalid or move between floors.
  * Prevented creatures from attempting to pathfind toward targets on different floors.
  * Ensured follow paths and pending movement updates are properly cleared and resumed when appropriate.

* **Tests**
  * Added coverage for summon and master following across floor transitions.
  * Verified that repeated follow updates do not create duplicate movement tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents creatures from retaining or scheduling physical follow paths across floors while preserving a living summon’s logical link to its master.
- Adds a shared helper that cancels walking and clears physical follow-path state.
- Guards movement notifications, queued path execution, and path-update requests against cross-floor pathfinding.
- Adds regression coverage for cross-floor cancellation, same-floor resumption, repeated updates, and ordinary target cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/creature.cpp | Centralizes physical follow-path cleanup and blocks path requests or execution while follower and target are on different floors. |
| src/creature.h | Declares the new protected follow-path cleanup helper. |
| src/tests/test_monster_target_state.cpp | Adds regression tests for cross-floor path cancellation, resumption, duplicate-update prevention, and related movement behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Follow target moves] --> B{Follower and target on same floor?}
    B -- No --> C[Cancel scheduled walk]
    C --> D[Clear physical path state]
    D --> E[Preserve logical follow only for living master]
    B -- Yes --> F[Request follow-path update]
    F --> G[Queued update rechecks floor]
    G --> H[Compute and start path]
    E --> I{Return to same floor?}
    I -- Yes --> F
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(creature): cover follow regressions"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/bd17a36def8f99f74e201a51c53a49b975a393a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48054290)</sub>

<!-- /greptile_comment -->