### PR TITLE
Fix ghost item after full container removal

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2218,7 +2218,7 @@ void Player::sendRemoveContainerItem(const Container* container, uint16_t slot)
 
 		const uint32_t capacity = container->capacity();
 		const Item* lastItem = capacity > 0 ?
-		                           container->getItemByIndex(firstIndex + static_cast<uint16_t>(capacity - 1)) :
+		                           container->getItemByIndex(firstIndex + static_cast<uint16_t>(capacity)) :
 		                           nullptr;
 		client->sendRemoveContainerItem(it->first, std::max<uint16_t>(slot, firstIndex), lastItem);
 		++it;


### PR DESCRIPTION
## Summary

Fixes the ghost item that appears after moving an item out of a full container, corpse, or backpack.

## Root cause

The container removal notification is sent before the item is erased from the server-side list. The replacement lookup used `firstIndex + capacity - 1`, which points to the last item already visible on the current page. That item was sent again in opcode `0x72`, making the client display it twice even though the server moved only one real item.

## Fix

Use `firstIndex + capacity`, the first item outside the visible page. A full container without overflow now sends no replacement item, while paginated containers receive the correct item from the next slot.

This preserves atomic server-side movement, container pagination, browse fields, corpse loot, and quickloot behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects paginated container-removal notifications by selecting the first item beyond the visible page as the replacement, avoiding duplicate ghost items when the current page is full.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the corrected container pagination logic.

The replacement lookup now targets the item immediately beyond the visible page; partially filled and final pages correctly produce no replacement when that index is out of bounds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/player.cpp | Changes the replacement lookup to use the exclusive end of the visible container page, consistent with the pagination window. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(container): prevent ghost item on re..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/0016986ad5497e9a5652ed922516e4823ddfae49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48071785)</sub>

<!-- /greptile_comment -->