### PR TITLE
fix(boss): normalize participant reward rate

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2727,9 +2727,9 @@ void Monster::death(Creature*)
 			if (healingDone > 0) {
 				contrubutionScore += healingDone;
 			}
-			double expectedScore =
-			    ((contrubutionScore / totalScore) * ConfigManager::getFloat(ConfigManager::REWARD_BASE_RATE));
-			double lootRate = std::min(expectedScore, 1.0);
+			double expectedScore = static_cast<double>(totalScore) / contributors;
+			double lootRate = std::min(
+			    (contrubutionScore / expectedScore) * ConfigManager::getFloat(ConfigManager::REWARD_BASE_RATE), 1.0);
 			auto player = g_game.getPlayerByGUID(playerId);
 			auto rewardItem = Item::CreateItem(ITEM_REWARD_CONTAINER);
 			if (!rewardItem) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -28,6 +28,21 @@ int32_t Monster::despawnRadius;
 
 uint32_t Monster::monsterAutoID = 0x40000000;
 
+double reward_boss::calculateLootRate(double contributionScore, int32_t totalScore, int32_t contributors,
+                                      double baseRate)
+{
+	if (totalScore <= 0 || contributors <= 0) {
+		return 0.0;
+	}
+
+	const double expectedScore = static_cast<double>(totalScore) / contributors;
+	if (expectedScore <= 0.0) {
+		return 0.0;
+	}
+
+	return std::min((contributionScore / expectedScore) * baseRate, 1.0);
+}
+
 std::unique_ptr<Monster> Monster::createMonster(const std::string& name)
 {
 	auto mType = g_monsters.getSharedMonsterType(name);
@@ -2727,9 +2742,9 @@ void Monster::death(Creature*)
 			if (healingDone > 0) {
 				contrubutionScore += healingDone;
 			}
-			double expectedScore = static_cast<double>(totalScore) / contributors;
-			double lootRate = std::min(
-			    (contrubutionScore / expectedScore) * ConfigManager::getFloat(ConfigManager::REWARD_BASE_RATE), 1.0);
+			const double lootRate = reward_boss::calculateLootRate(
+			    contrubutionScore, totalScore, contributors,
+			    ConfigManager::getFloat(ConfigManager::REWARD_BASE_RATE));
 			auto player = g_game.getPlayerByGUID(playerId);
 			auto rewardItem = Item::CreateItem(ITEM_REWARD_CONTAINER);
 			if (!rewardItem) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -11,6 +11,11 @@ class Creature;
 class Game;
 class Spawn;
 
+namespace reward_boss {
+	[[nodiscard]] double calculateLootRate(double contributionScore, int32_t totalScore, int32_t contributors,
+	                                       double baseRate);
+}
+
 using CreatureWeakHashSet = std::set<std::weak_ptr<Creature>, std::owner_less<std::weak_ptr<Creature>>>;
 using CreatureWeakList = std::vector<std::weak_ptr<Creature>>;
 

--- a/src/tests/test_monster_reward.cpp
+++ b/src/tests/test_monster_reward.cpp
@@ -1,0 +1,22 @@
+#include "../otpch.h"
+
+#include "../monster.h"
+
+#include "test_support.h"
+
+TEST_CASE(reward_boss_zero_aggregate_has_zero_loot_rate)
+{
+	const double lootRate = reward_boss::calculateLootRate(0.0, 0, 4, 1.0);
+
+	CHECK(std::isfinite(lootRate));
+	CHECK(lootRate == 0.0);
+}
+
+TEST_CASE(reward_boss_positive_scores_keep_proportional_rate)
+{
+	CHECK(reward_boss::calculateLootRate(25.0, 100, 4, 1.0) == 1.0);
+	CHECK(reward_boss::calculateLootRate(10.0, 100, 4, 1.0) == 0.4);
+	CHECK(reward_boss::calculateLootRate(50.0, 100, 4, 1.0) == 1.0);
+}
+
+TFS_TEST_MAIN()


### PR DESCRIPTION
## Summary

Normalize reward-boss contribution scores against the expected score per participant.

## Root cause

The reward calculation divided each player's contribution by the total score while the configured contract expects comparison against `totalScore / contributors`. As the group grew, every player's loot rate was unintentionally reduced. With four equally contributing players, each received only 25% of the intended rate, so several participants could finish without a reward.

## Impact

Players who meet the expected participation share now retain the configured base loot rate regardless of group size. Contribution weighting, unique loot selection, reward chest delivery, party behavior, and normal monster loot remain unchanged.

Fixes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boss loot distribution by calculating rewards more accurately based on each player’s contribution relative to the average contribution.
  * Ensured individual loot rates are capped at the maximum allowed rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalize reward-boss loot rates against the average contribution per participant.
- Adds a guarded helper that calculates and caps the normalized loot rate.
- Uses the normalized rate when generating participant rewards.
- Adds unit coverage for zero aggregate scores and proportional rates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/monster.cpp | Introduces the guarded average-contribution calculation and applies it to reward-boss loot generation. |
| src/monster.h | Declares the reward-boss loot-rate helper used by production code and tests. |
| src/tests/test_monster_reward.cpp | Covers zero-score handling, proportional normalization, and the maximum-rate cap. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(boss): guard zero reward scores"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/ff2d85bb604dd445415a3475be0e7a005afa1d6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48679432)</sub>

<!-- /greptile_comment -->