### PR TITLE
Fix Fatal on area attacks

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -87,6 +87,34 @@ bool rollMonsterCritical(const std::shared_ptr<Monster>& monster, const CombatDa
 	return chance > 0 && skill > 0 && uniform_random(1, 10000) <= chance;
 }
 
+bool rollFatalHit(const Player* player, const CombatDamage& damage)
+{
+	if (!player || damage.fatal || damage.primary.type == COMBAT_HEALING ||
+	    damage.primary.type == COMBAT_MANADRAIN || damage.origin == ORIGIN_CONDITION) {
+		return false;
+	}
+
+	const Item* weapon = player->getWeapon();
+	if (!weapon || weapon->getTier() == 0) {
+		return false;
+	}
+
+	double fatalChance = weapon->getFatalChance();
+	const Item* boots = player->getInventoryItem(CONST_SLOT_FEET);
+	if (boots && boots->getTier() > 0) {
+		const double ampChance = boots->getMomentumChance() * 0.02;
+		fatalChance *= 1.0 + ampChance;
+	}
+	return fatalChance > 0 && (normal_random(1, 10000) / 100.0) < fatalChance;
+}
+
+void applyFatalDamage(CombatDamage& damage)
+{
+	damage.primary.value += std::round(damage.primary.value * 0.5);
+	damage.secondary.value += std::round(damage.secondary.value * 0.5);
+	damage.fatal = true;
+}
+
 } // namespace
 
 static int32_t getEffectiveMagicLevel(const Player* player, CombatType_t combatType)
@@ -1238,23 +1266,8 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 				}
 			}
 
-			if (!damage.fatal && damage.primary.type != COMBAT_HEALING && damage.origin != ORIGIN_CONDITION) {
-				Item* weapon = casterPlayer->getWeapon();
-				if (weapon && weapon->getTier() > 0) {
-					double fatalChance = weapon->getFatalChance();
-					Item* boots = casterPlayer->getInventoryItem(CONST_SLOT_FEET);
-					if (boots && boots->getTier() > 0) {
-						double ampChance = boots->getMomentumChance() * 0.02;
-						fatalChance *= (1.0 + ampChance);
-					}
-					if (fatalChance > 0 && (normal_random(1, 10000) / 100.0) < fatalChance) {
-						int32_t fatalPrimary = std::round(damage.primary.value * 0.5);
-						int32_t fatalSecondary = std::round(damage.secondary.value * 0.5);
-						damage.primary.value += fatalPrimary;
-						damage.secondary.value += fatalSecondary;
-						damage.fatal = true;
-					}
-				}
+			if (rollFatalHit(casterPlayer, damage)) {
+				applyFatalDamage(damage);
 			}
 		} else if (auto casterMonster = lockMonster(caster)) {
 			int32_t skill = 0;
@@ -1536,6 +1549,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		}
 	}
 	finishPhase(PerformanceMetric::CombatAreaPrepareDamage, &AreaCombatMetricsSample::prepareDamageNanoseconds);
+	const bool fatalHit = rollFatalHit(casterPlayer, damage);
 
 	int32_t maxX = 0;
 	int32_t maxY = 0;
@@ -1675,6 +1689,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 			if (fullyBlocked) {
 				continue;
 			}
+			if (fatalHit) {
+				applyFatalDamage(damageCopy);
+			}
 			if (params.resetDamageMultiplier >= 0.0f) {
 				damageCopy.spellResetMultiplier = params.resetDamageMultiplier;
 			}
@@ -1694,6 +1711,12 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		if (success) {
 			if (metrics) {
 				++metrics->appliedTargets;
+			}
+			if (damageCopy.fatal) {
+				SpectatorVec fatalSpectators;
+				g_game.map.getSpectators(fatalSpectators, creature->getPosition(), true, true);
+				InstanceUtils::sendMagicEffectToInstance(
+				    fatalSpectators, creature->getPosition(), CONST_ME_FATAL, creature->getInstanceID());
 			}
 			if (casterPlayer && wpEnabled && damageCopy.primary.type != COMBAT_HEALING && damageCopy.primary.type != COMBAT_MANADRAIN) {
 				casterPlayer->weaponProficiency().applyOn(WeaponProficiencyHealth_t::LIFE, WeaponProficiencyGain_t::HIT);


### PR DESCRIPTION
## Summary

- Reuse the existing Fatal roll and damage application for direct and area combat.
- Apply one Fatal roll per area attack to every valid, non-blocked target hit by spells or runes.
- Send the Fatal effect on each affected target.

## Root cause

Fatal was implemented only in `Combat::doTargetCombat`, so `Combat::doAreaCombat` never rolled or applied the Forge bonus. This made direct attacks and single-target runes work while area spells such as Exori did not.

## Behavior

Direct attacks keep their existing chance and 50% bonus. Area attacks now follow Crystal's behavior: one roll is shared by all targets of the same attack, while fully blocked targets are skipped. Condition/DoT ticks remain excluded, matching Crystal's combat extension flow and the existing critical-hit rule.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds shared Fatal-hit helpers and extends Fatal damage and visual effects to valid, non-blocked targets in area combat.
- Reuses the same Fatal eligibility and 50% damage calculation for direct and area attacks.
- Rolls Fatal once per area attack and applies the result independently to each eligible target.
- Skips fully blocked targets and emits the Fatal effect after successful damage application.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the area-combat Fatal flow preserving direct-combat eligibility, modifier ordering, blocking, and successful-application behavior.

The refactor preserves the existing direct-target behavior, while area attacks apply the shared roll only to non-fully-blocked targets and emit effects only after combat application succeeds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/combat.cpp | Extracts the existing direct-target Fatal logic into helpers and consistently applies one shared Fatal roll to each eligible, successfully hit area target. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Prepare area damage] --> B[Roll Fatal once]
    B --> C[Copy damage for target]
    C --> D[Apply target-specific modifiers]
    D --> E[Resolve blocking]
    E -->|Fully blocked| F[Skip target]
    E -->|Damage remains| G{Fatal roll succeeded?}
    G -->|Yes| H[Add 50% Fatal damage]
    G -->|No| I[Keep normal damage]
    H --> J[Apply combat damage]
    I --> J
    J -->|Success and Fatal| K[Send Fatal effect]
    J -->|Otherwise| L[Continue area processing]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(combat): apply Fatal to area attacks"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/cdf0b87afecad0f3def92901d47e9715857bf667) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48685822)</sub>

<!-- /greptile_comment -->