### PR TITLE
Fix invalid floor transitions

### DIFF
--- a/data/scripts/actions/others/teleport.lua
+++ b/data/scripts/actions/others/teleport.lua
@@ -8,8 +8,19 @@ function action.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		fromPosition.z = fromPosition.z + 1
 	end
 
-	if player:isPzLocked() and Tile(fromPosition):hasFlag(TILESTATE_PROTECTIONZONE) then
+	local destinationTile = Tile(fromPosition)
+	if not destinationTile then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		return true
+	end
+
+	if player:isPzLocked() and destinationTile:hasFlag(TILESTATE_PROTECTIONZONE) then
 		player:sendCancelMessage(RETURNVALUE_PLAYERISPZLOCKED)
+		return true
+	end
+
+	if destinationTile:queryAdd(player) ~= RETURNVALUE_NOERROR then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		return true
 	end
 


### PR DESCRIPTION
## Summary

- Reject missing floor destinations before teleporting.
- Validate the destination with `Tile:queryAdd(player)`.
- Preserve the existing PZ-lock cancellation behavior.

## Root cause

`Creature:teleportTo()` delegates to `Game::internalTeleport()`, which checks creature destinations with `FLAG_NOLIMIT`. The floor-change action previously passed its calculated destination directly to that path, allowing blocked or otherwise invalid tiles to bypass normal movement rules.

Valid stairs and holes keep their existing behavior, while invalid or occupied destinations now cancel the action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved teleport destination validation.
  * Teleportation now correctly stops when the destination is unavailable, protected, or unable to accept the player.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->