### PR TITLE
feat(lua): add createTown(id, name, templePosition) for maps without towns

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1680,6 +1680,9 @@ void LuaScriptInterface::registerFunctions()
 	// cleanMap()
 	lua_register(luaState, "cleanMap", LuaScriptInterface::luaCleanMap);
 
+	// createTown(id, name, templePosition)
+	lua_register(luaState, "createTown", LuaScriptInterface::luaCreateTown);
+
 	// debugPrint(text)
 	lua_register(luaState, "debugPrint", LuaScriptInterface::luaDebugPrint);
 
@@ -4030,6 +4033,22 @@ int LuaScriptInterface::luaCleanMap(lua_State* L)
 {
 	// cleanMap()
 	lua_pushinteger(L, g_game.map.clean());
+	return 1;
+}
+
+int LuaScriptInterface::luaCreateTown(lua_State* L)
+{
+	// createTown(id, name, templePosition)
+	uint32_t townId = Lua::getNumber<uint32_t>(L, 1);
+	if (g_game.map.towns.getTown(townId)) {
+		Lua::pushBoolean(L, false);
+		return 1;
+	}
+
+	auto town = std::make_shared<Town>(townId);
+	town->setName(Lua::getString(L, 2));
+	town->setTemplePos(Lua::getPosition(L, 3));
+	Lua::pushBoolean(L, g_game.map.towns.addTown(townId, std::move(town)));
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -511,6 +511,7 @@ private:
 
 	static int luaSaveServer(lua_State* L);
 	static int luaCleanMap(lua_State* L);
+	static int luaCreateTown(lua_State* L);
 
 	static int luaIsInWar(lua_State* L);
 


### PR DESCRIPTION
## What

Adds a `createTown(id, name, templePosition)` Lua global that registers a town at runtime — creates a `Town`, sets its name + temple position, and adds it to `g_game.map.towns` (no-op if the id already exists). Registered next to `cleanMap`.

## Why

Some maps ship **without OTBM town definitions** — e.g. "tracked" / real maps where the tracker didn't capture towns. Without at least one town, `IOLoginData::loadPlayer` fails and **no character can log in**:

```
[WARNING] <name> has Town ID 3 which doesn't exist; using Town ID 1
[ERROR]   Town ID 1 doesn't exist
[ERROR]   Failed to load player: ... (Login Error: "Your character could not be loaded.")
```

Today towns can only be added by the OTBM loader (`Towns::addTown`), so there's no way to recover such a map short of opening it in RME and adding town markers. This global lets a `startup` script define the temples so login works.

## Usage

```lua
local ev = GlobalEvent("Towns")
function ev.onStartup()
    createTown(1, "Thais", Position(32369, 32241, 7))
    createTown(2, "Carlin", Position(32360, 31782, 7))
    return true
end
ev:register()
```

## Testing

Loaded a tracked 8.60 map that has no towns:
- **Before:** every login logged `Town ID ... doesn't exist` and the client showed *"Your character could not be loaded."*
- **After:** a `startup` script calling `createTown(...)` creates the temples; characters log in at the town temple normally. `createTown` returns `true` on success, `false` if the id already exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lua scripting support for creating towns with a unique ID, name, and temple location.
  * Newly created towns are added to the game map automatically.
  * Scripts receive a success or failure result when attempting to register a town.
  * Duplicate town IDs are rejected to prevent conflicting town records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->