### PR TITLE
fix(lua): "decayto" attribute key silently writes the decay state

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1160,8 +1160,6 @@ itemAttrTypes stringToItemAttribute(std::string_view str)
 		return ITEM_ATTRIBUTE_FLUIDTYPE;
 	} else if (str == "doorid") {
 		return ITEM_ATTRIBUTE_DOORID;
-	} else if (str == "decayto") {
-		return ITEM_ATTRIBUTE_DECAYSTATE;
 	} else if (str == "wrapid") {
 		return ITEM_ATTRIBUTE_WRAPID;
 	} else if (str == "storeitem") {


### PR DESCRIPTION
`stringToItemAttribute()` maps two different keys onto the same attribute:

```cpp
} else if (str == "decaystate") {
    return ITEM_ATTRIBUTE_DECAYSTATE;   // correct
...
} else if (str == "decayto") {
    return ITEM_ATTRIBUTE_DECAYSTATE;   // no ITEM_ATTRIBUTE_DECAYTO exists
}
```

There is no `ITEM_ATTRIBUTE_DECAYTO` anywhere in `itemAttrTypes` (`enums.h:60`), so this branch has no correct reading — it is a copy-paste of the line above it.

From Lua, on any of the four call sites that resolve attribute names by string:

- `item:setAttribute("decayto", 1234)` writes 1234 into the decay-state field, whose valid range is `ItemDecayState_t` 0–3
- `item:getAttribute("decayto")` returns the decay state
- `item:removeAttribute("decayto")` calls `g_game.stopDecay()` and clears the decay state

## Checked before changing anything

The `decayto` key in `items.xml` — 48 entries — is a **different parser entirely**. It goes through `ITEM_PARSE_DECAYTO` (`items.cpp:67`) into `ItemType::decayTo` (`items.h:414`), which is an item-type property rather than a per-item attribute. That path is untouched and those 48 entries keep working exactly as before.

No `.lua` file in `data/` uses `"decayto"` as an item attribute key, so nothing in the datapack depends on the old behaviour.

## Change

The bogus branch is removed, which is a two line deletion. Unknown keys already fall through to `ITEM_ATTRIBUTE_NONE`, and every get/set/has/remove wrapper handles that as a clean no-op — so a script that used the key now does nothing instead of corrupting decay state.

If a real `decayto` item attribute is wanted later, that is a separate change: it needs an enum value, serialisation in `Item::readAttr`/`serializeAttr`, and a decision about how it interacts with `ItemType::decayTo`.

## Note

Not compiled — no working build environment for this project on hand (the toolchain needs the patched Lua 5.5 and I am on macOS). This one is a pure deletion of two lines inside an if/else chain, so the risk is about as low as it gets, but please let CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
