### PR TITLE
perf: cache item value packets

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -4,6 +4,7 @@
 #include "otpch.h"
 
 #include "items.h"
+#include "protocolgame.h"
 
 #include "movement.h"
 #include "pugicast.h"
@@ -494,6 +495,7 @@ void Items::clear()
 
 bool Items::reload()
 {
+	ProtocolGame::invalidateItemValuesCache();
 	clear();
 	loadFromOtb("data/items/items.otb");
 
@@ -506,6 +508,7 @@ bool Items::reload()
 
 	g_scripts->loadScripts("items", false, true);
 	g_weapons->loadDefaults();
+	ProtocolGame::rebuildItemValuesCache();
 	return true;
 }
 

--- a/src/luaitemtype.cpp
+++ b/src/luaitemtype.cpp
@@ -7,6 +7,7 @@
 #include "item.h"
 #include "items.h"
 #include "luascript.h"
+#include "protocolgame.h"
 #include "tools.h"
 
 namespace {
@@ -457,7 +458,10 @@ int luaItemTypeSetBuyPrice(lua_State* L)
 		const uint32_t safePrice = price > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())
 		                         ? std::numeric_limits<uint32_t>::max()
 		                         : static_cast<uint32_t>(price);
-		mutableItemType.buyPrice = std::max(mutableItemType.buyPrice, safePrice);
+		if (safePrice > mutableItemType.buyPrice) {
+			mutableItemType.buyPrice = safePrice;
+			ProtocolGame::invalidateItemValuesCache();
+		}
 	}
 	pushBoolean(L, true);
 	return 1;
@@ -478,7 +482,10 @@ int luaItemTypeSetSellPrice(lua_State* L)
 		const uint32_t safePrice = price > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())
 		                         ? std::numeric_limits<uint32_t>::max()
 		                         : static_cast<uint32_t>(price);
-		mutableItemType.sellPrice = std::max(mutableItemType.sellPrice, safePrice);
+		if (safePrice > mutableItemType.sellPrice) {
+			mutableItemType.sellPrice = safePrice;
+			ProtocolGame::invalidateItemValuesCache();
+		}
 	}
 	pushBoolean(L, true);
 	return 1;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -8,6 +8,7 @@
 #include "configmanager.h"
 #include "game.h"
 #include "logger.h"
+#include "protocolgame.h"
 #include "pugicast.h"
 #include "startup_progress.h"
 
@@ -33,11 +34,23 @@ namespace {
 void registerItemShopPrice(const ShopInfo& item)
 {
 	ItemType& itemType = Item::items.getItemType(item.itemId);
+	bool changed = false;
 	if (item.buyPrice > 0) {
-		itemType.buyPrice = std::max(itemType.buyPrice, static_cast<uint32_t>(item.buyPrice));
+		const auto buyPrice = static_cast<uint32_t>(item.buyPrice);
+		if (buyPrice > itemType.buyPrice) {
+			itemType.buyPrice = buyPrice;
+			changed = true;
+		}
 	}
 	if (item.sellPrice > 0) {
-		itemType.sellPrice = std::max(itemType.sellPrice, static_cast<uint32_t>(item.sellPrice));
+		const auto sellPrice = static_cast<uint32_t>(item.sellPrice);
+		if (sellPrice > itemType.sellPrice) {
+			itemType.sellPrice = sellPrice;
+			changed = true;
+		}
+	}
+	if (changed) {
+		ProtocolGame::invalidateItemValuesCache();
 	}
 }
 } // namespace
@@ -335,6 +348,8 @@ void reload()
 			npcRef->reload();
 		}
 	}
+
+	ProtocolGame::rebuildItemValuesCache();
 }
 
 void addNpcType(const std::string& name, const std::shared_ptr<NpcType>& npcType)

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -15,6 +15,7 @@
 #include "logger.h"
 #include "mapcache.h"
 #include "outputmessage.h"
+#include "protocolgame.h"
 #include "protocollogin.h"
 #include "protocoladmin.h"
 #include "protocolstatus.h"
@@ -647,6 +648,7 @@ bool mainLoader(const std::shared_ptr<ServiceManager>& services, StartupRuntimeS
 	LOG_INFO(">> Initializing gamestate");
 	startupProgress().begin(StartupStage::GAME_INITIALIZATION, "groups and chat");
 	g_game.setGameState(GAME_STATE_INIT);
+	ProtocolGame::rebuildItemValuesCache();
 	startupProgress().complete("game state initialized");
 	g_logger().info(">> Map-to-GAME_STATE_INIT total: {:.3f} s.",
 	                std::chrono::duration<double>(std::chrono::steady_clock::now() - mapStartupStart).count());

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -83,6 +83,18 @@ constexpr uint8_t HELPER_OPCODE_SMART_FOLLOW = 212;
 constexpr uint32_t STORAGE_ASTRA_HELPER_CAVEBOT = 99997;
 constexpr uint32_t STORAGE_ASTRA_HELPER_SMART_FOLLOW = 99998;
 constexpr auto STORE_OUTFIT_OFFERS_PATH = "data/store/gamestore.xml";
+constexpr uint8_t ITEM_VALUES_OPCODE = 0xC6;
+constexpr size_t ITEM_VALUE_WIRE_SIZE = sizeof(uint16_t) + sizeof(uint32_t);
+constexpr size_t ITEM_VALUES_PACKET_HEADER_SIZE = sizeof(uint8_t) + sizeof(uint16_t);
+constexpr size_t MAX_ITEM_VALUES_PER_PACKET =
+    (NetworkMessage::MAX_PROTOCOL_BODY_LENGTH - ITEM_VALUES_PACKET_HEADER_SIZE) / ITEM_VALUE_WIRE_SIZE;
+
+struct ItemValuesCache {
+	std::vector<NetworkMessage> packets;
+	bool valid = false;
+};
+
+ItemValuesCache itemValuesCache;
 
 std::string anonymizeIPv4ForFile(uint32_t ip)
 {
@@ -2891,12 +2903,17 @@ void ProtocolGame::sendItemValues()
 		return;
 	}
 
-	constexpr uint8_t OPCODE_ITEM_VALUES = 0xC6;
-	constexpr size_t ITEM_VALUE_WIRE_SIZE = sizeof(uint16_t) + sizeof(uint32_t);
-	constexpr size_t PACKET_HEADER_SIZE = sizeof(uint8_t) + sizeof(uint16_t);
-	constexpr size_t MAX_ITEM_VALUES_PER_PACKET =
-	    (NetworkMessage::MAX_PROTOCOL_BODY_LENGTH - PACKET_HEADER_SIZE) / ITEM_VALUE_WIRE_SIZE;
+	if (!itemValuesCache.valid) {
+		rebuildItemValuesCache();
+	}
 
+	for (const auto& packet : itemValuesCache.packets) {
+		writeToOutputBuffer(packet);
+	}
+}
+
+void ProtocolGame::rebuildItemValuesCache()
+{
 	std::vector<std::pair<uint16_t, uint32_t>> entries;
 	entries.reserve(Item::items.size());
 	for (size_t id = 0, size = Item::items.size(); id < size; ++id) {
@@ -2910,21 +2927,26 @@ void ProtocolGame::sendItemValues()
 		}
 	}
 
-	if (entries.empty()) {
-		return;
-	}
-
+	std::vector<NetworkMessage> packets;
+	packets.reserve((entries.size() + MAX_ITEM_VALUES_PER_PACKET - 1) / MAX_ITEM_VALUES_PER_PACKET);
 	for (size_t offset = 0; offset < entries.size(); offset += MAX_ITEM_VALUES_PER_PACKET) {
 		const size_t chunkSize = std::min(MAX_ITEM_VALUES_PER_PACKET, entries.size() - offset);
-		NetworkMessage msg;
-		msg.addByte(OPCODE_ITEM_VALUES);
+		NetworkMessage& msg = packets.emplace_back();
+		msg.addByte(ITEM_VALUES_OPCODE);
 		msg.add<uint16_t>(static_cast<uint16_t>(chunkSize));
 		for (size_t index = offset; index < offset + chunkSize; ++index) {
 			msg.add<uint16_t>(entries[index].first);
 			msg.add<uint32_t>(entries[index].second);
 		}
-		writeToOutputBuffer(msg);
 	}
+
+	itemValuesCache.packets = std::move(packets);
+	itemValuesCache.valid = true;
+}
+
+void ProtocolGame::invalidateItemValuesCache()
+{
+	itemValuesCache.valid = false;
 }
 
 void ProtocolGame::sendImpactTracker(uint8_t analyzerType, uint32_t amount, CombatType_t combatType,

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -95,6 +96,7 @@ struct ItemValuesCache {
 };
 
 ItemValuesCache itemValuesCache;
+std::mutex itemValuesCacheMutex;
 
 std::string anonymizeIPv4ForFile(uint32_t ip)
 {
@@ -2903,17 +2905,28 @@ void ProtocolGame::sendItemValues()
 		return;
 	}
 
-	if (!itemValuesCache.valid) {
+	std::vector<NetworkMessage> packets;
+	for (;;) {
+		{
+			std::lock_guard<std::mutex> lock(itemValuesCacheMutex);
+			if (itemValuesCache.valid) {
+				packets = itemValuesCache.packets;
+				break;
+			}
+		}
+
 		rebuildItemValuesCache();
 	}
 
-	for (const auto& packet : itemValuesCache.packets) {
+	for (const auto& packet : packets) {
 		writeToOutputBuffer(packet);
 	}
 }
 
 void ProtocolGame::rebuildItemValuesCache()
 {
+	std::lock_guard<std::mutex> lock(itemValuesCacheMutex);
+
 	std::vector<std::pair<uint16_t, uint32_t>> entries;
 	entries.reserve(Item::items.size());
 	for (size_t id = 0, size = Item::items.size(); id < size; ++id) {
@@ -2946,6 +2959,7 @@ void ProtocolGame::rebuildItemValuesCache()
 
 void ProtocolGame::invalidateItemValuesCache()
 {
+	std::lock_guard<std::mutex> lock(itemValuesCacheMutex);
 	itemValuesCache.valid = false;
 }
 

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -77,6 +77,8 @@ public:
 	uint16_t getVersion() const { return version; }
 	bool canSendAstraItemState() const;
 	bool shouldSendAstraQuiverCountU16() const;
+	static void rebuildItemValuesCache();
+	static void invalidateItemValuesCache();
 
 	static uint32_t spectatorId;
 	static std::set<std::string> spectatorNames;


### PR DESCRIPTION
Caches serialized item-value packets after game initialization and reuses them for Astra client logins and reconnects. The cache is invalidated and rebuilt when item or NPC prices change. Validation: git diff --check and runtime server test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved delivery of item values by reusing prepared data, reducing repeated processing.
  * Item value information is now refreshed efficiently when items, NPCs, or shop prices change.

* **Bug Fixes**
  * Item value data now stays synchronized with updated buy and sell prices.
  * Item values are rebuilt correctly during game initialization and reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->