### PR TITLE
fix(threading): remove shared mutable state from every random number path

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1291,9 +1291,12 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 void ProtocolGame::onConnect()
 {
 	auto output = OutputMessagePool::getOutputMessage();
-	static std::random_device rd;
-	static std::ranlux24 generator(rd());
-	static std::uniform_int_distribution<uint16_t> randNumber(0x00, 0xFF);
+	// thread_local: onConnect() runs on the io_context threads, and the server
+	// spawns several of them for parallel I/O, so incoming connections are handled
+	// concurrently. A shared engine and distribution here were raced on every
+	// simultaneous connect, which is also how the login challenge is drawn.
+	static thread_local std::ranlux24 generator(std::random_device{}());
+	static thread_local std::uniform_int_distribution<uint16_t> randNumber(0x00, 0xFF);
 
 	// Skip checksum
 	output->skipBytes(sizeof(uint32_t));

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -300,8 +300,16 @@ IntegerVector vectorAtoi(const std::vector<std::string_view>& stringVector)
 
 std::mt19937& getRandomGenerator()
 {
-	static std::random_device rd;
-	static std::mt19937 generator(rd());
+	// thread_local, not a plain static. std::mt19937::operator() mutates the
+	// engine's internal state, so a shared instance is a data race the moment two
+	// threads draw at once - and they do. Player loading runs on a thread pool
+	// worker (ProtocolGame::connect -> IOLoginData::loadPlayerById), where
+	// Item::CreateItem reaches normal_random() through setDefaultDuration() and
+	// setID(), while the dispatcher thread is drawing from combat, monster and
+	// weapon code at the same time.
+	//
+	// Each thread now owns its stream, seeded independently on first use.
+	static thread_local std::mt19937 generator(std::random_device{}());
 	return generator;
 }
 
@@ -371,7 +379,9 @@ void replaceString(std::string& source, std::string_view search, std::string_vie
 
 int32_t uniform_random(int32_t minNumber, int32_t maxNumber)
 {
-	static std::uniform_int_distribution<int32_t> uniformRand;
+	// thread_local for the same reason as the engine: a distribution object is
+	// allowed to carry state across calls, so sharing one across threads is a race.
+	static thread_local std::uniform_int_distribution<int32_t> uniformRand;
 	if (minNumber == maxNumber) {
 		return minNumber;
 	} else if (minNumber > maxNumber) {
@@ -382,7 +392,10 @@ int32_t uniform_random(int32_t minNumber, int32_t maxNumber)
 
 int32_t normal_random(int32_t minNumber, int32_t maxNumber)
 {
-	static std::normal_distribution<float> normalRand(0.5f, 0.25f);
+	// std::normal_distribution is the clearest case: it generates values in pairs
+	// and caches the second one inside the object, so concurrent calls both race
+	// on that cache and hand back values from the wrong draw.
+	static thread_local std::normal_distribution<float> normalRand(0.5f, 0.25f);
 
 	float v;
 	do {
@@ -395,7 +408,7 @@ int32_t normal_random(int32_t minNumber, int32_t maxNumber)
 
 bool boolean_random(double probability /* = 0.5*/)
 {
-	static std::bernoulli_distribution booleanRand;
+	static thread_local std::bernoulli_distribution booleanRand;
 	return booleanRand(getRandomGenerator(), std::bernoulli_distribution::param_type(probability));
 }
 
@@ -1534,9 +1547,14 @@ SpellGroup_t stringToSpellGroup(std::string_view value)
 	return SPELLGROUP_NONE;
 }
 
-const std::vector<Direction>& getShuffleDirections()
+std::vector<Direction> getShuffleDirections()
 {
-	static std::vector<Direction> dirList{DIRECTION_NORTH, DIRECTION_WEST, DIRECTION_EAST, DIRECTION_SOUTH};
+	// Returned by value. This used to shuffle one shared static vector and hand
+	// out a const reference to it, which was both a data race across threads and,
+	// on a single thread, a buffer every caller aliased: a nested call reshuffled
+	// the same storage while an outer range-for was still walking it. Four
+	// elements make the copy free in practice.
+	std::vector<Direction> dirList{DIRECTION_NORTH, DIRECTION_WEST, DIRECTION_EAST, DIRECTION_SOUTH};
 	std::shuffle(dirList.begin(), dirList.end(), getRandomGenerator());
 	return dirList;
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -119,7 +119,7 @@ int64_t OTSYS_NANOTIME();
 
 SpellGroup_t stringToSpellGroup(std::string_view value);
 
-const std::vector<Direction>& getShuffleDirections();
+std::vector<Direction> getShuffleDirections();
 
 std::string getVocationShortName(uint8_t vocationId);
 


### PR DESCRIPTION
The engine, the distributions and the shuffle buffer were all shared across
threads with no synchronisation. Every one of them mutates on use, so these are
data races - undefined behaviour, and in practice correlated or duplicated
values.

The races are reachable today, not theoretical. Two independent paths:

1. ProtocolGame::connect detaches player loading onto a thread pool worker
   (g_threadPool.detach_task -> IOLoginData::loadPlayerById). That path reaches
   the generator through loadItems() -> Item::CreateItem() -> Item::Item() ->
   setDefaultDuration() -> normal_random(), and through Item::setID(). The
   dispatcher thread draws continuously from combat, monster and weapon code at
   the same time.

2. ProtocolGame::onConnect() runs on the io_context threads, and server.cpp
   spawns several of them for parallel I/O, so simultaneous connections raced on
   the generator that draws the login challenge.

Everything is now thread_local, seeded per thread on first use:

  tools.cpp        getRandomGenerator()  std::mt19937
                   uniform_random()      std::uniform_int_distribution
                   normal_random()       std::normal_distribution
                   boolean_random()      std::bernoulli_distribution
  protocolgame.cpp onConnect()           std::ranlux24 + distribution

std::normal_distribution is the clearest case of the three distributions: it
generates values in pairs and caches the second inside the object, so concurrent
callers both race on that cache and receive values from the wrong draw.

thread_local rather than a mutex on purpose - uniform_random() sits in some of
the hottest code in the server, and a lock there would cost more than the bug.

getShuffleDirections() had the same problem plus one of its own: it shuffled a
shared static vector and returned a const reference to it, so every caller
aliased the same buffer. Even on one thread, a nested call reshuffled the storage
an outer range-for was still walking. It now returns by value; with four elements
the copy is free in practice.

---
First of the small PRs from the review, in the order you asked for. Rebased onto current main; CI on my copy is green (build with `-Werror`, 29/29 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for login challenge generation and randomized direction handling.
  * Prevented potential race conditions during concurrent operations.
  * Ensured shuffled direction data is safely isolated for each operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->