### PR TITLE
fix(lua): null check in creature:removeCondition before dereferencing

### DIFF
--- a/src/luacreature.cpp
+++ b/src/luacreature.cpp
@@ -858,6 +858,14 @@ int luaCreatureRemoveCondition(lua_State* L)
 
 	if (isUserdata(L, 2)) {
 		const Condition* const condition = getUserdata<Condition>(L, 2);
+		// isUserdata() only says argument 2 is some userdata, not that it is a
+		// Condition. getUserdata() type-checks and returns nullptr on a mismatch,
+		// so passing any other userdata here reached this dereference.
+		if (!condition) {
+			lua_pushnil(L);
+			return 1;
+		}
+
 		const ConditionType_t conditionType = condition->getType();
 		const ConditionId_t conditionId = condition->getId();
 		const uint32_t subId = condition->getSubId();


### PR DESCRIPTION
luaCreatureRemoveCondition takes two overloads, and picks between them with
isUserdata(L, 2). That only answers "is argument 2 some userdata" - it does not
say the userdata is a Condition.

getUserdata<Condition>() does type-check (via isType<T>) and returns nullptr on
a mismatch, so any other userdata passed here - an Item, a Player, anything -
produced a nullptr that was dereferenced on the very next line:

    const Condition* const condition = getUserdata<Condition>(L, 2);
    const ConditionType_t conditionType = condition->getType();

That is a datapack typo taking the whole server down, not a Lua error.

The function already returns nil on failure elsewhere, so it now does the same
here.

Found while sweeping all 40 lua*.cpp binding files for userdata dereferenced
without a null check. This was the only real instance; everything else guards
correctly, usually as `if (a && b)` or an early `if (!a || !b)` return.

---
Second of the small PRs. Independent of #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)