### PR TITLE
Add perspective-aware PvP square indicators

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -410,7 +410,11 @@ const uint8_t fluidMap[] = {
 
 enum SquareColor_t : uint8_t
 {
+	SQ_COLOR_BLACK = 0,
+	SQ_COLOR_BROWN = 114,
+	SQ_COLOR_ORANGE = 198,
 	SQ_COLOR_YELLOW = 210,
+	SQ_COLOR_NONE = 255,
 };
 
 enum TextColor_t : uint8_t

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8022,7 +8022,7 @@ void Game::updateCreatureSquare(const Creature* creature)
 	const uint32_t creatureInstance = creature->getInstanceID();
 	for (const auto& spectator : spectators.players()) {
 		Player* player = static_cast<Player*>(spectator.get());
-		if (!player->compareInstance(creatureInstance)) {
+		if (!player->compareInstance(creatureInstance) || !player->canSeeCreature(creature)) {
 			continue;
 		}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8011,6 +8011,25 @@ void Game::updateCreatureSkull(const Creature* creature)
 	}
 }
 
+void Game::updateCreatureSquare(const Creature* creature)
+{
+	if (!creature || getWorldType() != WORLD_TYPE_PVP) {
+		return;
+	}
+
+	SpectatorVec spectators;
+	map.getSpectators(spectators, creature->getPosition(), true, true);
+	const uint32_t creatureInstance = creature->getInstanceID();
+	for (const auto& spectator : spectators.players()) {
+		Player* player = static_cast<Player*>(spectator.get());
+		if (!player->compareInstance(creatureInstance)) {
+			continue;
+		}
+
+		player->sendCreatureSquare(creature, player->getCreatureSquare(creature));
+	}
+}
+
 void Game::updatePlayerShield(Player* player)
 {
 	SpectatorVec spectators;

--- a/src/game.h
+++ b/src/game.h
@@ -498,6 +498,7 @@ public:
 	void internalCreatureChangeVisible(Creature* creature, bool visible);
 	void changeLight(const Creature* creature);
 	void updateCreatureSkull(const Creature* creature);
+	void updateCreatureSquare(const Creature* creature);
 	void updatePlayerShield(Player* player);
 	void updateCreatureWalkthrough(const Creature* creature);
 	void updateCreatureEmblem(Creature* creature);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2941,6 +2941,13 @@ void Player::onThink(uint32_t interval)
 {
 	Creature::onThink(interval);
 
+	// O protocolo 8.6 exibe o opcode 0x86 como um quadrado temporário.
+	// Renova a marca enquanto houver uma relação de PvP ativa para que o
+	// efeito permaneça visível também no cliente padrão.
+	if (isInPvpSituation()) {
+		g_game.updateCreatureSquare(this);
+	}
+
 	if (client && getIP() == 0) {
 		if (hasCondition(CONDITION_INFIGHT)) {
 			ghostModeStartTime = 0;
@@ -3605,6 +3612,7 @@ void Player::death(Creature* lastHitCreature)
 			pzLocked = false;
 			onIdleStatus();
 			clearAttacked();
+			clearAttackedBy();
 
 			if (getSkull() != SKULL_RED && getSkull() != SKULL_BLACK) {
 				setSkull(SKULL_NONE);
@@ -3619,6 +3627,7 @@ void Player::death(Creature* lastHitCreature)
 		setFollowCreature(nullptr);
 		stopWalk();
 		clearAttacked();
+		clearAttackedBy();
 	};
 
 	int32_t storedTotalReduceSkillLoss = totalReduceSkillLoss;
@@ -5233,6 +5242,7 @@ void Player::onEndCondition(ConditionType_t type)
 		onIdleStatus();
 		pzLocked = false;
 		clearAttacked();
+		clearAttackedBy();
 
 		updateSkullAfterPzLockEnded();
 	}
@@ -5786,7 +5796,16 @@ void Player::addAttacked(const Player* attacked)
 		return;
 	}
 
-	attackedSet.insert(attacked->guid);
+	if (!attackedSet.insert(attacked->guid).second) {
+		return;
+	}
+
+	if (auto attackedPlayer = g_game.getPlayerByGUID(attacked->guid)) {
+		attackedPlayer->attackedBySet.insert(guid);
+		g_game.updateCreatureSquare(attackedPlayer.get());
+	}
+
+	g_game.updateCreatureSquare(this);
 }
 
 void Player::removeAttacked(const Player* attacked)
@@ -5798,10 +5817,126 @@ void Player::removeAttacked(const Player* attacked)
 	auto it = attackedSet.find(attacked->guid);
 	if (it != attackedSet.end()) {
 		attackedSet.erase(it);
+
+		if (auto attackedPlayer = g_game.getPlayerByGUID(attacked->guid)) {
+			attackedPlayer->removeAttackedBy(this);
+			g_game.updateCreatureSquare(attackedPlayer.get());
+		}
+
+		g_game.updateCreatureSquare(this);
 	}
 }
 
-void Player::clearAttacked() { attackedSet.clear(); }
+void Player::clearAttacked()
+{
+	if (attackedSet.empty()) {
+		return;
+	}
+
+	const auto attackedPlayers = attackedSet;
+	attackedSet.clear();
+
+	for (uint32_t attackedGuid : attackedPlayers) {
+		auto attackedPlayer = g_game.getPlayerByGUID(attackedGuid);
+		if (!attackedPlayer) {
+			continue;
+		}
+
+		attackedPlayer->removeAttackedBy(this);
+		g_game.updateCreatureSquare(attackedPlayer.get());
+	}
+
+	g_game.updateCreatureSquare(this);
+}
+
+bool Player::hasAttackedBy(const Player* attacker) const
+{
+	return attacker && attackedBySet.contains(attacker->guid);
+}
+
+void Player::removeAttackedBy(const Player* attacker)
+{
+	if (attacker) {
+		attackedBySet.erase(attacker->guid);
+	}
+}
+
+void Player::clearAttackedBy()
+{
+	if (attackedBySet.empty()) {
+		return;
+	}
+
+	const auto attackers = attackedBySet;
+	attackedBySet.clear();
+
+	for (uint32_t attackerGuid : attackers) {
+		auto attacker = g_game.getPlayerByGUID(attackerGuid);
+		if (!attacker) {
+			continue;
+		}
+
+		attacker->attackedSet.erase(guid);
+		g_game.updateCreatureSquare(attacker.get());
+	}
+
+	g_game.updateCreatureSquare(this);
+}
+
+bool Player::hasPvpActivity(const Player* player, bool guildAndParty) const
+{
+	if (!player) {
+		return false;
+	}
+
+	if (hasAttacked(player) || hasAttackedBy(player)) {
+		return true;
+	}
+
+	if (!guildAndParty) {
+		return false;
+	}
+
+	auto hasRelatedParticipant = [this](const std::unordered_set<uint32_t>& participants) {
+		for (uint32_t participantGuid : participants) {
+			auto participant = g_game.getPlayerByGUID(participantGuid);
+			if (participant && (isPartner(participant.get()) || isGuildMate(participant.get()))) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	return hasRelatedParticipant(player->attackedSet) || hasRelatedParticipant(player->attackedBySet);
+}
+
+bool Player::isInPvpSituation() const { return !attackedSet.empty() || !attackedBySet.empty(); }
+
+SquareColor_t Player::getCreatureSquare(const Creature* creature) const
+{
+	if (g_game.getWorldType() != WORLD_TYPE_PVP || !creature) {
+		return SQ_COLOR_NONE;
+	}
+
+	const Player* targetPlayer = creature->getPlayer();
+	if (!targetPlayer) {
+		return SQ_COLOR_NONE;
+	}
+
+	if (targetPlayer == this) {
+		return isInPvpSituation() ? SQ_COLOR_YELLOW : SQ_COLOR_NONE;
+	}
+
+	if (hasPvpActivity(targetPlayer, false)) {
+		return SQ_COLOR_YELLOW;
+	}
+
+	if (targetPlayer->isInPvpSituation()) {
+		return hasPvpActivity(targetPlayer, true) ? SQ_COLOR_ORANGE : SQ_COLOR_BROWN;
+	}
+
+	return SQ_COLOR_NONE;
+}
 
 void Player::updateSkullAfterPzLockEnded()
 {

--- a/src/player.h
+++ b/src/player.h
@@ -921,6 +921,12 @@ public:
 	void addAttacked(const Player* attacked);
 	void removeAttacked(const Player* attacked);
 	void clearAttacked();
+	bool hasAttackedBy(const Player* attacker) const;
+	void removeAttackedBy(const Player* attacker);
+	void clearAttackedBy();
+	bool hasPvpActivity(const Player* player, bool guildAndParty) const;
+	bool isInPvpSituation() const;
+	SquareColor_t getCreatureSquare(const Creature* creature) const;
 
 	void addUnjustifiedDead(const Player* attacked);
 	void sendCreatureSkull(const Creature* creature) const
@@ -1651,6 +1657,7 @@ private:
 	void internalAddThing(uint32_t index, Thing* thing) override;
 
 	std::unordered_set<uint32_t> attackedSet;
+	std::unordered_set<uint32_t> attackedBySet;
 	std::unordered_set<uint32_t> VIPList;
 	std::unordered_set<uint32_t> modifiedStorageKeys;
 	std::unordered_set<uint32_t> removedStorageKeys;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3984,6 +3984,7 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 			auto [known, removedKnown] = isKnownCreature(creature->getID());
 			AddCreature(msg, creature, known, removedKnown);
 			writeToOutputBuffer(msg);
+			sendCreatureSquare(creature, player->getCreatureSquare(creature));
 		}
 
 		if (magicEffect != CONST_ME_NONE) {
@@ -4008,6 +4009,11 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	writeToOutputBuffer(msg);
 
 	sendMapDescription(pos);
+	for (const auto& visiblePlayer : g_game.getPlayers()) {
+		if (visiblePlayer->getInstanceID() == player->getInstanceID() && canSee(visiblePlayer->getPosition())) {
+			sendCreatureSquare(visiblePlayer.get(), player->getCreatureSquare(visiblePlayer.get()));
+		}
+	}
 	sendZoneWeather(pos, true);
 
 	if (magicEffect != CONST_ME_NONE) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4010,7 +4010,8 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 
 	sendMapDescription(pos);
 	for (const auto& visiblePlayer : g_game.getPlayers()) {
-		if (visiblePlayer->getInstanceID() == player->getInstanceID() && canSee(visiblePlayer->getPosition())) {
+		if (visiblePlayer->getInstanceID() == player->getInstanceID() && canSee(visiblePlayer->getPosition()) &&
+		    player->canSeeCreature(visiblePlayer.get())) {
 			sendCreatureSquare(visiblePlayer.get(), player->getCreatureSquare(visiblePlayer.get()));
 		}
 	}


### PR DESCRIPTION
## Summary

Adds perspective-aware PvP square indicators for protocol 8.60 without changing combat rules or gameplay behavior.

## What changed

- adds brown, orange, black and no-square color constants alongside the existing yellow square
- tracks both outgoing (`attackedSet`) and incoming (`attackedBySet`) PvP relations
- computes the visible square independently for each spectator
- sends square updates to nearby players in the same instance
- restores active square state when a creature enters the viewport or the initial map is sent
- clears both sides of the tracked PvP relation when infight ends or the player dies
- periodically refreshes active marks because opcode `0x86` is rendered as a temporary square by 8.60 clients

## Visual behavior

- **Yellow:** the spectator has a direct PvP relation with the displayed player
- **Orange:** the displayed player is fighting someone related to the spectator through party or guild
- **Brown:** the displayed player is in PvP and the spectator is an unrelated observer
- **None:** no applicable PvP relation

The result is calculated per spectator, so different clients may see different colors for the same player.

## Scope

This PR is visual only. It does not change damage, secure mode, skull rules, unjustified kills, protection levels or other PvP gameplay mechanics.

No OTC changes are included. The implementation uses the standard 8.60 `sendCreatureSquare` packet and was verified in both BlackOTCHD and the classic Tibia 8.60 client.

## Validation

- patch applies cleanly to current `main`
- `git diff --check` passes
- source compiled successfully in the project owner's TFS environment
- runtime behavior tested successfully with two players in BlackOTCHD
- runtime behavior tested successfully with two players in the classic Tibia 8.60 client


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added colored creature indicators for PvP activity, including self, active opponents, related participants, and uninvolved players.
  * Indicators now update during combat and refresh as PvP relationships change.
  * Creature indicators are displayed consistently when entering the map and when visible creatures appear.
  * PvP activity tracking now includes relevant party and guild relationships.
* **Bug Fixes**
  * Improved synchronization of attacker status when combat ends, players die, or attackers are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->