### PR TITLE
cleanup(cast): take spectator chat text by view, and guard the empty case

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -5349,7 +5349,7 @@ void ProtocolGame::parseSpectatorSay(NetworkMessage& msg)
 	spectatorSay(text, channelId);
 }
 
-void ProtocolGame::spectatorSay(const std::string text, uint16_t channelId)
+void ProtocolGame::spectatorSay(std::string_view text, uint16_t channelId)
 {
 	if (channelId != CHANNEL_CAST || !player || !player->client) {
 		return;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -341,7 +341,7 @@ private:
 	//cast
 	void spectatorTurn(uint8_t direction);
 	void parseSpectatorSay(NetworkMessage& msg);
-	void spectatorSay(const std::string text, uint16_t channelId);
+	void spectatorSay(std::string_view text, uint16_t channelId);
 	void sendCastChannel();
 	void syncOpenContainers();
 	void parseSwitchCast(uint8_t direction); // 0 = previous, 1 = next

--- a/src/protocolspectator.cpp
+++ b/src/protocolspectator.cpp
@@ -58,7 +58,10 @@ bool ProtocolSpectator::isBanned(uint32_t ip) const
 
 void ProtocolSpectator::spectatorSay(ProtocolGame_ptr spectator, std::string_view text)
 {
-    if (text[0] == '/') {
+    // text is a view, so operator[] on an empty one is out of bounds rather than
+    // returning '\0' the way std::string does. A spectator can send an empty
+    // message, so the emptiness check has to come first.
+    if (!text.empty() && text[0] == '/') {
         auto sv = explodeString(text.substr(1, text.length()), " ", 1);
         // Convert string_view elements to std::string for manipulation
         std::string cmd = sv.empty() ? "" : std::string(sv[0]);


### PR DESCRIPTION
ProtocolGame::spectatorSay took `const std::string` by value. The const blocks
the move, so every spectator chat message was copied in full for nothing - and
the only thing the function does with it is forward it to
ProtocolSpectator::spectatorSay, which already takes a std::string_view.

The parameter is now std::string_view, matching the callee. The single caller
passes a local std::string that outlives the call, so there is no lifetime
change.

While confirming that, a real defect in the same path: ProtocolSpectator::
spectatorSay opens with `text[0] == '/'`. On std::string_view, operator[] with
an empty view is out of bounds - unlike std::string, which is defined to return
'\0'. The text comes straight from msg.getString() with only a length > 255
check, so a spectator sending an empty message reaches it. In practice the view
pointed into a std::string and read its null terminator, which is why nothing
ever crashed, but it was undefined behaviour.

The check now tests emptiness first. An empty message falls through to the
normal chat path instead of being parsed as a command.

---
Verified on CI in my copy: Build (Linux) with -Werror, 29/29 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spectator chat handling for empty messages, preventing errors when no text is provided.
  * Preserved existing command and channel-message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->