### PR TITLE
fix(data): define the BESTY_RACE_* constants the monster files reference

### DIFF
--- a/data/lib/core/constants.lua
+++ b/data/lib/core/constants.lua
@@ -18,3 +18,31 @@ RESPAWNPERIOD_NIGHT = 2
 RARITY_BANE = 1
 RARITY_ARCHFOE = 2
 RARITY_NEMESIS = 3
+
+-- Bestiary class ordering keys.
+-- custom_bestiary.lua uses these only as a sort key (classRace), so the values
+-- just have to be distinct and stable; the grouping itself comes from the
+-- separate `class` string on each monster. Ordered alphabetically because the
+-- scripts carry no other ordering intent - adjust freely if you want a
+-- different order in the bestiary list.
+BESTY_RACE_AMPHIBIC = 1
+BESTY_RACE_AQUATIC = 2
+BESTY_RACE_BIRD = 3
+BESTY_RACE_CONSTRUCT = 4
+BESTY_RACE_DEMON = 5
+BESTY_RACE_DRAGON = 6
+BESTY_RACE_ELEMENTAL = 7
+BESTY_RACE_EXTRA_DIMENSIONAL = 8
+BESTY_RACE_FEY = 9
+BESTY_RACE_GIANT = 10
+BESTY_RACE_HUMAN = 11
+BESTY_RACE_HUMANOID = 12
+BESTY_RACE_INKBORN = 13
+BESTY_RACE_LYCANTHROPE = 14
+BESTY_RACE_MAGICAL = 15
+BESTY_RACE_MAMMAL = 16
+BESTY_RACE_PLANT = 17
+BESTY_RACE_REPTILE = 18
+BESTY_RACE_SLIME = 19
+BESTY_RACE_UNDEAD = 20
+BESTY_RACE_VERMIN = 21


### PR DESCRIPTION
780 monster files set `race = BESTY_RACE_UNDEAD` and friends inside their
`monster.Bestiary` table, but none of those 21 constants exists - not in the
engine, not anywhere in data/. They came in with scripts ported from a 13.x
codebase.

Worth stating the actual effect precisely, because it is smaller than it first
looks. The bestiary grouping is *not* broken: that comes from the separate
`class = "Undead"` string, which is present and correct in 782 files. The nil
lands here instead:

    local raceOrder = tonumber(entry.race) or 0     custom_bestiary.lua:191
    if not CustomBestiary.classRace[className] or raceOrder < ...

so `race` is used only as the sort key that orders bestiary classes, and every
class currently gets 0. The list falls back to insertion order rather than any
intended one. `or 0` keeps it silent.

The constants are now defined in lib/core/constants.lua, which core.lua loads
before anything reads them. Values are sequential and alphabetical: since they
are only ever compared against each other for ordering, they need to be distinct
and stable, nothing more. The scripts carry no other ordering intent that I could
find, so alphabetical seemed the least invented choice - reorder freely if you
want the bestiary to read differently.

An alternative would be dropping the redundant `race` field from all 780 files,
since `class` already carries the same information. That is a bigger and more
opinionated diff, so I went with the smaller one.

---
Verified on CI in my copy: Lua syntax check and Docker build both pass. Every touched file re-checked with luac 5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)