### PR TITLE
fix(login): stop silently substituting a different character

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -160,17 +160,15 @@ IOLoginData::GameworldAuthenticationResult IOLoginData::gameworldAuthentication(
 			return {AuthenticationResult::Success, fallbackAccountId, accountManagerId};
         }
 
-        // Pick the first character from this account if specific character was not found/matched
-        DBResult_ptr firstCharRes = db.storeQuery(fmt::format(
-            "SELECT `id`, `name` FROM `players` WHERE `account_id` = {:d} AND `deletion` = 0 ORDER BY `name` ASC LIMIT 1",
-            fallbackAccountId));
-        if (!firstCharRes) {
-			return {failedQueryAuthenticationResult(db)};
-        }
-
-        uint32_t fallbackCharacterId = firstCharRes->getNumber<uint32_t>("id");
-        std::string fallbackCharacterName = std::string{firstCharRes->getString("name")};
-        return {AuthenticationResult::Success, fallbackAccountId, fallbackCharacterId};
+        // The credentials are good but the requested character did not resolve: it
+        // does not exist, was deleted, was renamed, or belongs to another account.
+        // Report the account as authenticated with no character rather than
+        // substituting one, so the player is told instead of silently landing on a
+        // different character of theirs.
+        //
+        // Still a Success, not a Rejected - the password was correct, and counting
+        // it would burn a login attempt on a mistyped character name.
+        return {AuthenticationResult::Success, fallbackAccountId, 0};
     }
 
     if (transformToSHA1(password) != result->getString("password")) {


### PR DESCRIPTION
When the exact (account, character) query matches nothing,
gameworldAuthentication() falls back to validating the account on its own and
then returns the account's first character by alphabetical order.

To be clear about the security question: this is not a breach. The password is
verified either way, and the fallback only ever picks from the authenticated
account's own characters. But a player whose chosen character was just deleted,
renamed, or simply mistyped is put into a different character of theirs with no
indication that anything happened. On an account with a mule sorted ahead of the
main, that produces a bug report nobody can reproduce.

It now returns Success with characterId 0 - the credentials were good, there is
just nothing to log in as. ProtocolGame already handles that: preloadPlayer()
finds no player with guid 0 and the client is told "Your character could not be
loaded.", which is accurate. No caller change is needed.

Deliberately Success rather than Rejected, so a mistyped character name does not
burn an attempt against the brute force limiter.

Also drops fallbackCharacterName, which was read from the query and never used.
It escaped -Wunused-variable only because std::string has a non-trivial
destructor, which is how it survived in a build that is otherwise warning-clean.

Sent as its own behavioural PR, as requested - it changes what players see, so it
should be judged separately from the pure bug fixes.

---
This one changes what players see, so it is separate from the pure fixes as you asked. The resulting iologindata.cpp is byte-identical (ignoring comments) to the version running green in my copy at 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)