### PR TITLE
feat(combat): add equipment bonuses

### DIFF
--- a/data/lib/core/item.lua
+++ b/data/lib/core/item.lua
@@ -370,6 +370,24 @@ do
 			if atkSpeed ~= 0 then descriptions[#descriptions + 1] = fmt("AS:%0.2f/turn", 2000 / atkSpeed) end
 		end
 
+		-- equipment combat bonuses
+		do
+			local attackSpeedPercent = itemType:getAttackSpeedPercent()
+			if attackSpeedPercent > 0 then
+				descriptions[#descriptions + 1] = fmt("Attack Speed: +%d%%", attackSpeedPercent)
+			end
+
+			local damagePercent = itemType:getDamagePercent()
+			if damagePercent > 0 then
+				descriptions[#descriptions + 1] = fmt("Damage Increase: +%d%%", damagePercent)
+			end
+
+			local damageReductionPercent = itemType:getDamageReductionPercent()
+			if damageReductionPercent > 0 then
+				descriptions[#descriptions + 1] = fmt("Damage Reduction: +%d%%", damageReductionPercent)
+			end
+		end
+
 		-- defense attributes
 		do
 			local showDef = table.contains(showDefWeaponTypes, weaponType)

--- a/src/enums.h
+++ b/src/enums.h
@@ -780,6 +780,8 @@ struct CombatDamage
 	bool fatal = false;
 	bool dodge = false;
 	bool preyApplied = false;
+	bool equipmentDamageBonusApplied = false;
+	bool equipmentDamageReductionApplied = false;
 	int32_t criticalDamage = 0;
 	int32_t criticalChance = 0;
 	int32_t perfectShotDamage = 0;

--- a/src/enums.h
+++ b/src/enums.h
@@ -774,12 +774,14 @@ struct CombatDamage
 	} primary = {}, secondary = {};
 
 	CombatOrigin origin = ORIGIN_NONE;
+	CombatOrigin initialOrigin = ORIGIN_NONE;
 	BlockType_t blockType = BLOCK_NONE;
 	bool critical = false;
 	bool leeched = false;
 	bool fatal = false;
 	bool dodge = false;
 	bool preyApplied = false;
+	bool initialOriginCaptured = false;
 	bool equipmentDamageBonusApplied = false;
 	bool equipmentDamageReductionApplied = false;
 	int32_t criticalDamage = 0;

--- a/src/equipment_combat_bonus.h
+++ b/src/equipment_combat_bonus.h
@@ -1,0 +1,48 @@
+#ifndef FS_EQUIPMENT_COMBAT_BONUS_H
+#define FS_EQUIPMENT_COMBAT_BONUS_H
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+namespace EquipmentCombatBonus {
+
+inline uint32_t applyAttackSpeedPercent(uint64_t interval, uint32_t percent)
+{
+	if (percent != 0) {
+		const uint64_t denominator = 100ULL + percent;
+		interval = (interval * 100ULL + denominator - 1) / denominator;
+	}
+
+	return static_cast<uint32_t>(std::clamp<uint64_t>(
+	    interval, 100, std::numeric_limits<uint32_t>::max()));
+}
+
+inline int32_t increaseDamageByPercent(int32_t value, uint32_t percent)
+{
+	if (value <= 0 || percent == 0) {
+		return value;
+	}
+
+	const uint64_t unsignedValue = static_cast<uint32_t>(value);
+	const uint64_t increase = (unsignedValue / 100) * percent + ((unsignedValue % 100) * percent) / 100;
+	const uint64_t result = unsignedValue + increase;
+	return static_cast<int32_t>(std::min<uint64_t>(result, std::numeric_limits<int32_t>::max()));
+}
+
+inline int32_t reduceDamageByPercent(int32_t value, uint32_t percent)
+{
+	if (value <= 0 || percent == 0) {
+		return value;
+	}
+
+	if (percent >= 100) {
+		return 0;
+	}
+
+	return value - static_cast<int32_t>(static_cast<int64_t>(value) * percent / 100);
+}
+
+} // namespace EquipmentCombatBonus
+
+#endif // FS_EQUIPMENT_COMBAT_BONUS_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6737,6 +6737,18 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 		applyPreyCombatBonuses(damage, attackerRef, targetRef);
 
+		if (!damage.equipmentDamageReductionApplied) {
+			damage.equipmentDamageReductionApplied = true;
+			const bool validOrigin = damage.initialOrigin != ORIGIN_CONDITION && damage.initialOrigin != ORIGIN_REFLECT;
+			if (targetPlayer && attacker && attacker != target && validOrigin) {
+				const uint32_t percent = targetPlayer->getEquipmentDamageReductionPercent();
+				damage.primary.value =
+				    EquipmentCombatBonus::reduceDamageByPercent(damage.primary.value, percent);
+				damage.secondary.value =
+				    EquipmentCombatBonus::reduceDamageByPercent(damage.secondary.value, percent);
+			}
+		}
+
 		int32_t healthChange = damage.primary.value + damage.secondary.value;
 		if (healthChange == 0) {
 			return true;
@@ -6830,18 +6842,6 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 					damage.secondary.value = std::max<int32_t>(0, damage.secondary.value + damage.primary.value);
 					damage.primary.value = 0;
 				}
-			}
-		}
-
-		if (!damage.equipmentDamageReductionApplied) {
-			damage.equipmentDamageReductionApplied = true;
-			const bool validOrigin = damage.initialOrigin != ORIGIN_CONDITION && damage.initialOrigin != ORIGIN_REFLECT;
-			if (targetPlayer && attacker && attacker != target && validOrigin) {
-				const uint32_t percent = targetPlayer->getEquipmentDamageReductionPercent();
-				damage.primary.value =
-				    EquipmentCombatBonus::reduceDamageByPercent(damage.primary.value, percent);
-				damage.secondary.value =
-				    EquipmentCombatBonus::reduceDamageByPercent(damage.secondary.value, percent);
 			}
 		}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6510,6 +6510,10 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 	if (!target || target->isDead() || target->isRemoved()) {
 		return false;
 	}
+	if (!damage.initialOriginCaptured) {
+		damage.initialOrigin = damage.origin;
+		damage.initialOriginCaptured = true;
+	}
 
 	if (attacker && !attacker->compareInstance(target->getInstanceID())) {
 		return false;
@@ -6713,7 +6717,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 		if (!damage.equipmentDamageBonusApplied) {
 			damage.equipmentDamageBonusApplied = true;
-			const bool validOrigin = damage.origin != ORIGIN_CONDITION && damage.origin != ORIGIN_REFLECT;
+			const bool validOrigin = damage.initialOrigin != ORIGIN_CONDITION && damage.initialOrigin != ORIGIN_REFLECT;
 			if (attackerPlayer && attacker != target && validOrigin) {
 				const uint32_t percent = attackerPlayer->getEquipmentDamagePercent();
 				damage.primary.value =
@@ -6831,7 +6835,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 
 		if (!damage.equipmentDamageReductionApplied) {
 			damage.equipmentDamageReductionApplied = true;
-			const bool validOrigin = damage.origin != ORIGIN_CONDITION && damage.origin != ORIGIN_REFLECT;
+			const bool validOrigin = damage.initialOrigin != ORIGIN_CONDITION && damage.initialOrigin != ORIGIN_REFLECT;
 			if (targetPlayer && attacker && attacker != target && validOrigin) {
 				const uint32_t percent = targetPlayer->getEquipmentDamageReductionPercent();
 				damage.primary.value =

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13,6 +13,7 @@
 #include "creatureevent.h"
 #include "databasetasks.h"
 #include "enums.h"
+#include "equipment_combat_bonus.h"
 #include "events.h"
 #include "globalevent.h"
 #include "housetile.h"
@@ -6410,29 +6411,6 @@ void Game::combatGetTypeInfo(CombatType_t combatType, Creature* target, TextColo
 	}
 }
 
-static int32_t increaseDamageByPercent(int32_t value, uint16_t percent)
-{
-	if (value <= 0 || percent == 0) {
-		return value;
-	}
-
-	const int64_t result = static_cast<int64_t>(value) + (static_cast<int64_t>(value) * percent / 100);
-	return static_cast<int32_t>(std::min<int64_t>(result, std::numeric_limits<int32_t>::max()));
-}
-
-static int32_t reduceDamageByPercent(int32_t value, uint16_t percent)
-{
-	if (value <= 0 || percent == 0) {
-		return value;
-	}
-
-	if (percent >= 100) {
-		return 0;
-	}
-
-	return value - static_cast<int32_t>(static_cast<int64_t>(value) * percent / 100);
-}
-
 static uint16_t getPreyDamageBoostPercent(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& target)
 {
 	if (!player || !target) {
@@ -6471,16 +6449,16 @@ static void applyPreyCombatBonuses(CombatDamage& damage, const std::shared_ptr<C
 	auto attackerPlayer = std::dynamic_pointer_cast<Player>(attacker);
 	if (attackerPlayer) {
 		const uint16_t boost = getPreyDamageBoostPercent(attackerPlayer, target);
-		damage.primary.value = increaseDamageByPercent(damage.primary.value, boost);
-		damage.secondary.value = increaseDamageByPercent(damage.secondary.value, boost);
+		damage.primary.value = EquipmentCombatBonus::increaseDamageByPercent(damage.primary.value, boost);
+		damage.secondary.value = EquipmentCombatBonus::increaseDamageByPercent(damage.secondary.value, boost);
 		return;
 	}
 
 	auto targetPlayer = std::dynamic_pointer_cast<Player>(target);
 	if (targetPlayer) {
 		const uint16_t reduction = getPreyDamageReductionPercent(targetPlayer, attacker);
-		damage.primary.value = reduceDamageByPercent(damage.primary.value, reduction);
-		damage.secondary.value = reduceDamageByPercent(damage.secondary.value, reduction);
+		damage.primary.value = EquipmentCombatBonus::reduceDamageByPercent(damage.primary.value, reduction);
+		damage.secondary.value = EquipmentCombatBonus::reduceDamageByPercent(damage.secondary.value, reduction);
 	}
 }
 
@@ -6733,6 +6711,18 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 		damage.primary.value = std::abs(damage.primary.value);
 		damage.secondary.value = std::abs(damage.secondary.value);
 
+		if (!damage.equipmentDamageBonusApplied) {
+			damage.equipmentDamageBonusApplied = true;
+			const bool validOrigin = damage.origin != ORIGIN_CONDITION && damage.origin != ORIGIN_REFLECT;
+			if (attackerPlayer && attacker != target && validOrigin) {
+				const uint32_t percent = attackerPlayer->getEquipmentDamagePercent();
+				damage.primary.value =
+				    EquipmentCombatBonus::increaseDamageByPercent(damage.primary.value, percent);
+				damage.secondary.value =
+				    EquipmentCombatBonus::increaseDamageByPercent(damage.secondary.value, percent);
+			}
+		}
+
 		// Reset system: apply damage/defense bonuses (PvE only)
 		applyResetSystemBonuses(damage, attackerPlayer, targetPlayer);
 
@@ -6836,6 +6826,18 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 					damage.secondary.value = std::max<int32_t>(0, damage.secondary.value + damage.primary.value);
 					damage.primary.value = 0;
 				}
+			}
+		}
+
+		if (!damage.equipmentDamageReductionApplied) {
+			damage.equipmentDamageReductionApplied = true;
+			const bool validOrigin = damage.origin != ORIGIN_CONDITION && damage.origin != ORIGIN_REFLECT;
+			if (targetPlayer && attacker && attacker != target && validOrigin) {
+				const uint32_t percent = targetPlayer->getEquipmentDamageReductionPercent();
+				damage.primary.value =
+				    EquipmentCombatBonus::reduceDamageByPercent(damage.primary.value, percent);
+				damage.secondary.value =
+				    EquipmentCombatBonus::reduceDamageByPercent(damage.secondary.value, percent);
 			}
 		}
 

--- a/src/item.h
+++ b/src/item.h
@@ -780,6 +780,9 @@ public:
 		}
 		return items[id].attackSpeed;
 	}
+	uint32_t getAttackSpeedPercent() const { return items[id].attackSpeedPercent; }
+	uint32_t getDamagePercent() const { return items[id].damagePercent; }
+	uint32_t getDamageReductionPercent() const { return items[id].damageReductionPercent; }
 	int32_t getArmor() const
 	{
 		if (hasAttribute(ITEM_ATTRIBUTE_ARMOR)) {

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -37,6 +37,9 @@ const std::unordered_map<std::string, ItemParseAttributes_t> ItemParseAttributes
     {"extradef", ITEM_PARSE_EXTRADEF},
     {"attack", ITEM_PARSE_ATTACK},
     {"attackspeed", ITEM_PARSE_ATTACK_SPEED},
+    {"attackspeedpercent", ITEM_PARSE_ATTACK_SPEED_PERCENT},
+    {"damagepercent", ITEM_PARSE_DAMAGE_PERCENT},
+    {"damagereductionpercent", ITEM_PARSE_DAMAGE_REDUCTION_PERCENT},
     {"classification", ITEM_PARSE_CLASSIFICATION},
     {"upgradeclassification", ITEM_PARSE_CLASSIFICATION},
     {"upgrade_classification", ITEM_PARSE_CLASSIFICATION},
@@ -929,6 +932,26 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 						LOG_WARN(fmt::format("[Warning - Items::parseItemNode] AttackSpeed lower than 100 for item: {}", it.id));
 						it.attackSpeed = 100;
 					}
+					break;
+				}
+
+				case ITEM_PARSE_ATTACK_SPEED_PERCENT: {
+					const int64_t value = pugi::cast<int64_t>(valueAttribute.value());
+					it.attackSpeedPercent = static_cast<uint32_t>(std::clamp<int64_t>(
+					    value, 0, std::numeric_limits<uint32_t>::max()));
+					break;
+				}
+
+				case ITEM_PARSE_DAMAGE_PERCENT: {
+					const int64_t value = pugi::cast<int64_t>(valueAttribute.value());
+					it.damagePercent = static_cast<uint32_t>(std::clamp<int64_t>(
+					    value, 0, std::numeric_limits<uint32_t>::max()));
+					break;
+				}
+
+				case ITEM_PARSE_DAMAGE_REDUCTION_PERCENT: {
+					const int64_t value = pugi::cast<int64_t>(valueAttribute.value());
+					it.damageReductionPercent = static_cast<uint32_t>(std::clamp<int64_t>(value, 0, 100));
 					break;
 				}
 

--- a/src/items.h
+++ b/src/items.h
@@ -59,6 +59,9 @@ enum ItemParseAttributes_t
 	ITEM_PARSE_EXTRADEF,
 	ITEM_PARSE_ATTACK,
 	ITEM_PARSE_ATTACK_SPEED,
+	ITEM_PARSE_ATTACK_SPEED_PERCENT,
+	ITEM_PARSE_DAMAGE_PERCENT,
+	ITEM_PARSE_DAMAGE_REDUCTION_PERCENT,
 	ITEM_PARSE_CLASSIFICATION,
 	ITEM_PARSE_TIER,
 	ITEM_PARSE_ROTATETO,
@@ -398,6 +401,9 @@ public:
 	std::unique_ptr<ConditionDamage> conditionDamage;
 
 	uint32_t attackSpeed = 0;
+	uint32_t attackSpeedPercent = 0;
+	uint32_t damagePercent = 0;
+	uint32_t damageReductionPercent = 0;
 	uint32_t classification = 0;
 	uint32_t tier = 0;
 	uint32_t weight = 0;

--- a/src/luaitemtype.cpp
+++ b/src/luaitemtype.cpp
@@ -564,6 +564,42 @@ int luaItemTypeGetAttackSpeed(lua_State* L)
 	return 1;
 }
 
+int luaItemTypeGetAttackSpeedPercent(lua_State* L)
+{
+	// itemType:getAttackSpeedPercent()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		lua_pushinteger(L, itemType->attackSpeedPercent);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int luaItemTypeGetDamagePercent(lua_State* L)
+{
+	// itemType:getDamagePercent()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		lua_pushinteger(L, itemType->damagePercent);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int luaItemTypeGetDamageReductionPercent(lua_State* L)
+{
+	// itemType:getDamageReductionPercent()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		lua_pushinteger(L, itemType->damageReductionPercent);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int luaItemTypeGetDefense(lua_State* L)
 {
 	// itemType:getDefense()
@@ -1235,6 +1271,9 @@ void LuaScriptInterface::registerItemType()
 
 	registerMethod("ItemType", "getAttack", luaItemTypeGetAttack);
 	registerMethod("ItemType", "getAttackSpeed", luaItemTypeGetAttackSpeed);
+	registerMethod("ItemType", "getAttackSpeedPercent", luaItemTypeGetAttackSpeedPercent);
+	registerMethod("ItemType", "getDamagePercent", luaItemTypeGetDamagePercent);
+	registerMethod("ItemType", "getDamageReductionPercent", luaItemTypeGetDamageReductionPercent);
 	registerMethod("ItemType", "getClassification", luaItemTypeGetClassification);
 	registerMethod("ItemType", "getTier", luaItemTypeGetTier);
 	registerMethod("ItemType", "getDefense", luaItemTypeGetDefense);

--- a/src/mounts.cpp
+++ b/src/mounts.cpp
@@ -296,7 +296,7 @@ bool Mounts::addAttributes(uint32_t playerId, uint16_t mountId)
 	}
 
 	if (mount->attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeed() + mount->attackSpeed);
+		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() + mount->attackSpeed);
 		update = true;
 	}
 
@@ -385,7 +385,7 @@ bool Mounts::removeAttributes(uint32_t playerId, uint16_t mountId)
 	}
 
 	if (mount->attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeed() - mount->attackSpeed);
+		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() - mount->attackSpeed);
 		update = true;
 	}
 

--- a/src/mounts.cpp
+++ b/src/mounts.cpp
@@ -296,7 +296,7 @@ bool Mounts::addAttributes(uint32_t playerId, uint16_t mountId)
 	}
 
 	if (mount->attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() + mount->attackSpeed);
+		player->setAttackSpeed(player->getRawAttackSpeed() + mount->attackSpeed);
 		update = true;
 	}
 
@@ -385,7 +385,7 @@ bool Mounts::removeAttributes(uint32_t playerId, uint16_t mountId)
 	}
 
 	if (mount->attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() - mount->attackSpeed);
+		player->setAttackSpeed(player->getRawAttackSpeed() - mount->attackSpeed);
 		update = true;
 	}
 

--- a/src/outfit.cpp
+++ b/src/outfit.cpp
@@ -289,7 +289,7 @@ bool Outfits::addAttributes(uint32_t playerId, uint32_t outfitId, PlayerSex_t se
 	}
 
 	if (outfit.attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() + outfit.attackSpeed);
+		player->setAttackSpeed(player->getRawAttackSpeed() + outfit.attackSpeed);
 		needsUpdate = true;
 	}
 
@@ -352,7 +352,7 @@ bool Outfits::removeAttributes(uint32_t playerId, uint32_t outfitId, PlayerSex_t
 	}
 
 	if (outfit.attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() - outfit.attackSpeed);
+		player->setAttackSpeed(player->getRawAttackSpeed() - outfit.attackSpeed);
 		needsUpdate = true;
 	}
 

--- a/src/outfit.cpp
+++ b/src/outfit.cpp
@@ -289,7 +289,7 @@ bool Outfits::addAttributes(uint32_t playerId, uint32_t outfitId, PlayerSex_t se
 	}
 
 	if (outfit.attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeed() + outfit.attackSpeed);
+		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() + outfit.attackSpeed);
 		needsUpdate = true;
 	}
 
@@ -352,7 +352,7 @@ bool Outfits::removeAttributes(uint32_t playerId, uint32_t outfitId, PlayerSex_t
 	}
 
 	if (outfit.attackSpeed != 0) {
-		player->setAttackSpeed(player->getAttackSpeed() - outfit.attackSpeed);
+		player->setAttackSpeed(player->getAttackSpeedWithoutEquipmentBonus() - outfit.attackSpeed);
 		needsUpdate = true;
 	}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3457,7 +3457,7 @@ uint32_t Player::getEquipmentDamageReductionPercent() const
 
 uint64_t Player::getAttackSpeedBeforeEquipmentBonus() const
 {
-	uint64_t baseSpeed = attackSpeed > 0 ? attackSpeed : vocation->getAttackSpeed();
+	uint64_t baseSpeed = getRawAttackSpeed();
 	if (resetAttackSpeedBonus > 0 && baseSpeed > static_cast<uint32_t>(resetAttackSpeedBonus)) {
 		baseSpeed -= static_cast<uint32_t>(resetAttackSpeedBonus);
 	}
@@ -3471,9 +3471,9 @@ uint64_t Player::getAttackSpeedBeforeEquipmentBonus() const
 	return baseSpeed;
 }
 
-uint32_t Player::getAttackSpeedWithoutEquipmentBonus() const
+uint32_t Player::getRawAttackSpeed() const
 {
-	return EquipmentCombatBonus::applyAttackSpeedPercent(getAttackSpeedBeforeEquipmentBonus(), 0);
+	return attackSpeed > 0 ? attackSpeed : vocation->getAttackSpeed();
 }
 
 uint32_t Player::getAttackSpeed() const

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -9,6 +9,7 @@
 #include "configmanager.h"
 #include "creatureevent.h"
 #include "database.h"
+#include "equipment_combat_bonus.h"
 #include "events.h"
 #include "familiar.h"
 #include "game.h"
@@ -3410,6 +3411,75 @@ bool Player::hasShield() const
 		return true;
 	}
 	return false;
+}
+
+uint32_t Player::getEquipmentAttackSpeedPercent() const
+{
+	uint64_t total = 0;
+	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+		const auto inventorySlot = static_cast<slots_t>(slot);
+		const Item* item = getInventoryItem(inventorySlot);
+		if (item && isItemAbilityEnabled(inventorySlot)) {
+			total = std::min<uint64_t>(total + item->getAttackSpeedPercent(),
+			                           std::numeric_limits<uint32_t>::max());
+		}
+	}
+	return static_cast<uint32_t>(total);
+}
+
+uint32_t Player::getEquipmentDamagePercent() const
+{
+	uint64_t total = 0;
+	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+		const auto inventorySlot = static_cast<slots_t>(slot);
+		const Item* item = getInventoryItem(inventorySlot);
+		if (item && isItemAbilityEnabled(inventorySlot)) {
+			total = std::min<uint64_t>(total + item->getDamagePercent(),
+			                           std::numeric_limits<uint32_t>::max());
+		}
+	}
+	return static_cast<uint32_t>(total);
+}
+
+uint32_t Player::getEquipmentDamageReductionPercent() const
+{
+	uint32_t total = 0;
+	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+		const auto inventorySlot = static_cast<slots_t>(slot);
+		const Item* item = getInventoryItem(inventorySlot);
+		if (item && isItemAbilityEnabled(inventorySlot)) {
+			total = static_cast<uint32_t>(std::min<uint64_t>(
+			    100, static_cast<uint64_t>(total) + item->getDamageReductionPercent()));
+		}
+	}
+	return total;
+}
+
+uint64_t Player::getAttackSpeedBeforeEquipmentBonus() const
+{
+	uint64_t baseSpeed = attackSpeed > 0 ? attackSpeed : vocation->getAttackSpeed();
+	if (resetAttackSpeedBonus > 0 && baseSpeed > static_cast<uint32_t>(resetAttackSpeedBonus)) {
+		baseSpeed -= static_cast<uint32_t>(resetAttackSpeedBonus);
+	}
+	if (isDualWielding()) {
+		const auto rate = getInteger(ConfigManager::DUAL_WIELDING_SPEED_RATE);
+		if (rate > 0) {
+			const auto rateValue = static_cast<uint64_t>(rate);
+			baseSpeed = (baseSpeed * 100 + rateValue - 1) / rateValue;
+		}
+	}
+	return baseSpeed;
+}
+
+uint32_t Player::getAttackSpeedWithoutEquipmentBonus() const
+{
+	return EquipmentCombatBonus::applyAttackSpeedPercent(getAttackSpeedBeforeEquipmentBonus(), 0);
+}
+
+uint32_t Player::getAttackSpeed() const
+{
+	return EquipmentCombatBonus::applyAttackSpeedPercent(getAttackSpeedBeforeEquipmentBonus(),
+	                                                     getEquipmentAttackSpeedPercent());
 }
 
 BlockType_t Player::blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,

--- a/src/player.h
+++ b/src/player.h
@@ -782,25 +782,11 @@ public:
 	void setSecureMode(bool mode) { secureMode = mode; }
 
 	void setAttackSpeed(uint32_t speed) { attackSpeed = speed; }
-	uint32_t getAttackSpeed() const
-	{
-		uint32_t baseSpeed = attackSpeed > 0 ? attackSpeed : vocation->getAttackSpeed();
-		if (resetAttackSpeedBonus > 0 && baseSpeed > static_cast<uint32_t>(resetAttackSpeedBonus)) {
-			baseSpeed -= static_cast<uint32_t>(resetAttackSpeedBonus);
-		}
-		if (isDualWielding()) {
-			const auto rate = getInteger(ConfigManager::DUAL_WIELDING_SPEED_RATE);
-			if (rate > 0) {
-				const auto rateValue = static_cast<uint64_t>(rate);
-				baseSpeed = static_cast<uint32_t>(
-				    (static_cast<uint64_t>(baseSpeed) * 100 + rateValue - 1) / rateValue);
-			}
-		}
-		if (baseSpeed < 100) {
-			baseSpeed = 100;
-		}
-		return baseSpeed;
-	}
+	uint32_t getAttackSpeed() const;
+	uint32_t getAttackSpeedWithoutEquipmentBonus() const;
+	uint32_t getEquipmentAttackSpeedPercent() const;
+	uint32_t getEquipmentDamagePercent() const;
+	uint32_t getEquipmentDamageReductionPercent() const;
 
 	// combat functions
 	bool setAttackedCreature(Creature* creature) override;
@@ -1619,6 +1605,7 @@ private:
 	void reloadEquipmentStats();
 	void applyEquipmentStats();
 	void flushAstraPlayerInventorySnapshot();
+	uint64_t getAttackSpeedBeforeEquipmentBonus() const;
 
 	void setNextWalkActionTask(std::unique_ptr<SchedulerTask> task);
 	void setNextWalkTask(std::unique_ptr<SchedulerTask> task);

--- a/src/player.h
+++ b/src/player.h
@@ -783,7 +783,7 @@ public:
 
 	void setAttackSpeed(uint32_t speed) { attackSpeed = speed; }
 	uint32_t getAttackSpeed() const;
-	uint32_t getAttackSpeedWithoutEquipmentBonus() const;
+	uint32_t getRawAttackSpeed() const;
 	uint32_t getEquipmentAttackSpeedPercent() const;
 	uint32_t getEquipmentDamagePercent() const;
 	uint32_t getEquipmentDamageReductionPercent() const;

--- a/src/tests/test_equipment_combat_bonus.cpp
+++ b/src/tests/test_equipment_combat_bonus.cpp
@@ -1,0 +1,61 @@
+#include "../otpch.h"
+
+#include "../equipment_combat_bonus.h"
+#include "../item.h"
+
+#include "test_support.h"
+
+namespace {
+
+void ensureItemTypesLoaded()
+{
+	if (Item::items.size() != 0) {
+		return;
+	}
+
+	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+	                       "data/items/items.otb";
+	CHECK(Item::items.loadFromOtb(itemsPath.string()));
+}
+
+} // namespace
+
+TEST_CASE(equipment_combat_bonus_math_is_additive_and_clamped)
+{
+	CHECK(EquipmentCombatBonus::applyAttackSpeedPercent(2000, 5) == 1905);
+	CHECK(EquipmentCombatBonus::applyAttackSpeedPercent(2000, 15) == 1740);
+	CHECK(EquipmentCombatBonus::applyAttackSpeedPercent(100, 500) == 100);
+
+	CHECK(EquipmentCombatBonus::increaseDamageByPercent(100, 10) == 110);
+	CHECK(EquipmentCombatBonus::increaseDamageByPercent(100, 25) == 125);
+	CHECK(EquipmentCombatBonus::increaseDamageByPercent(-100, 25) == -100);
+
+	CHECK(EquipmentCombatBonus::reduceDamageByPercent(100, 8) == 92);
+	CHECK(EquipmentCombatBonus::reduceDamageByPercent(100, 100) == 0);
+	CHECK(EquipmentCombatBonus::reduceDamageByPercent(100, 150) == 0);
+	CHECK(EquipmentCombatBonus::reduceDamageByPercent(-100, 8) == -100);
+}
+
+TEST_CASE(equipment_combat_bonus_xml_attributes_are_parsed)
+{
+	ensureItemTypesLoaded();
+	constexpr uint16_t testItemId = 2160;
+
+	pugi::xml_document document;
+	const auto result = document.load_string(R"xml(
+		<item name="equipment combat bonus test">
+			<attribute key="attackspeedpercent" value="5" />
+			<attribute key="damagepercent" value="10" />
+			<attribute key="damagereductionpercent" value="108" />
+		</item>
+	)xml");
+	CHECK(result);
+
+	Item::items.parseItemNode(document.child("item"), testItemId);
+	const ItemType& itemType = Item::items[testItemId];
+	CHECK(itemType.attackSpeedPercent == 5);
+	CHECK(itemType.damagePercent == 10);
+	CHECK(itemType.damageReductionPercent == 100);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_equipment_combat_bonus.cpp
+++ b/src/tests/test_equipment_combat_bonus.cpp
@@ -2,6 +2,7 @@
 
 #include "../equipment_combat_bonus.h"
 #include "../item.h"
+#include "../player.h"
 
 #include "test_support.h"
 
@@ -34,6 +35,24 @@ TEST_CASE(equipment_combat_bonus_math_is_additive_and_clamped)
 	CHECK(EquipmentCombatBonus::reduceDamageByPercent(100, 100) == 0);
 	CHECK(EquipmentCombatBonus::reduceDamageByPercent(100, 150) == 0);
 	CHECK(EquipmentCombatBonus::reduceDamageByPercent(-100, 8) == -100);
+}
+
+TEST_CASE(attack_speed_modifiers_update_the_raw_interval_symmetrically)
+{
+	Player player(nullptr);
+	player.setAttackSpeed(2000);
+	player.setResetAttackSpeedBonus(200);
+
+	CHECK(player.getRawAttackSpeed() == 2000);
+	CHECK(player.getAttackSpeed() == 1800);
+
+	player.setAttackSpeed(player.getRawAttackSpeed() + 100);
+	CHECK(player.getRawAttackSpeed() == 2100);
+	CHECK(player.getAttackSpeed() == 1900);
+
+	player.setAttackSpeed(player.getRawAttackSpeed() - 100);
+	CHECK(player.getRawAttackSpeed() == 2000);
+	CHECK(player.getAttackSpeed() == 1800);
 }
 
 TEST_CASE(equipment_combat_bonus_xml_attributes_are_parsed)

--- a/src/tests/test_equipment_combat_bonus.cpp
+++ b/src/tests/test_equipment_combat_bonus.cpp
@@ -1,6 +1,8 @@
 #include "../otpch.h"
 
+#include "../condition.h"
 #include "../equipment_combat_bonus.h"
+#include "../game.h"
 #include "../item.h"
 #include "../player.h"
 
@@ -75,6 +77,50 @@ TEST_CASE(equipment_combat_bonus_xml_attributes_are_parsed)
 	CHECK(itemType.attackSpeedPercent == 5);
 	CHECK(itemType.damagePercent == 10);
 	CHECK(itemType.damageReductionPercent == 100);
+}
+
+TEST_CASE(equipment_damage_reduction_precedes_full_mana_shield_absorption)
+{
+	ensureItemTypesLoaded();
+	constexpr uint16_t testItemId = 2161;
+	pugi::xml_document document;
+	const auto result = document.load_string(R"xml(
+		<item name="mana shield equipment reduction test">
+			<attribute key="damagereductionpercent" value="20" />
+		</item>
+	)xml");
+	CHECK(result);
+	Item::items.parseItemNode(document.child("item"), testItemId);
+
+	auto equipment = Item::CreateItem(testItemId);
+	CHECK(equipment);
+
+	auto attacker = std::make_shared<Player>(nullptr);
+	auto target = std::make_shared<Player>(nullptr);
+	auto group = std::make_shared<Group>();
+	attacker->setGroup(group);
+	target->setGroup(group);
+	target->setMaxHealth(100);
+	target->setHealth(100);
+	target->setMaxMana(200);
+	target->setMana(200);
+	static_cast<Cylinder*>(target.get())->internalAddThing(CONST_SLOT_RING, equipment.get());
+	target->setItemAbility(CONST_SLOT_RING, true);
+	CHECK(target->getEquipmentDamageReductionPercent() == 20);
+	CHECK(target->addCondition(
+	    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_MANASHIELD, -1, 0)));
+
+	CombatDamage damage;
+	damage.primary.type = COMBAT_PHYSICALDAMAGE;
+	damage.primary.value = -100;
+	damage.origin = ORIGIN_SPELL;
+
+	CHECK(g_game.combatChangeHealth(attacker, target, damage));
+	CHECK(target->getMana() == 120);
+	CHECK(target->getHealth() == 100);
+	CHECK(damage.primary.value == 0);
+	CHECK(damage.secondary.value == 0);
+	CHECK(damage.equipmentDamageReductionApplied);
 }
 
 TFS_TEST_MAIN()


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added item-based attack-speed, damage, and damage-reduction bonuses.
  * Added support for configuring and exposing these attributes in item definitions and Lua.
  * Applied equipment bonuses consistently to combat and attack-speed calculations.
  * Updated item descriptions to display applicable bonuses.
  * Ensured mount and outfit speed adjustments use a baseline excluding equipment bonuses.

* **Bug Fixes**
  * Prevented duplicate application and excluded inappropriate damage types.
  * Added safeguards for invalid values and percentage limits.

* **Tests**
  * Added coverage for calculations, clamping, and item attribute parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->