### PR TITLE
Fix PvP square packet refresh

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8013,7 +8013,7 @@ void Game::updateCreatureSkull(const Creature* creature)
 
 void Game::updateCreatureSquare(const Creature* creature)
 {
-	if (!creature || getWorldType() != WORLD_TYPE_PVP) {
+	if (!creature || !creature->getPlayer() || getWorldType() != WORLD_TYPE_PVP) {
 		return;
 	}
 
@@ -8026,7 +8026,10 @@ void Game::updateCreatureSquare(const Creature* creature)
 			continue;
 		}
 
-		player->sendCreatureSquare(creature, player->getCreatureSquare(creature));
+		const SquareColor_t color = player->getCreatureSquare(creature);
+		if (color != SQ_COLOR_NONE) {
+			player->sendCreatureSquare(creature, color);
+		}
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2942,10 +2942,15 @@ void Player::onThink(uint32_t interval)
 	Creature::onThink(interval);
 
 	// O protocolo 8.6 exibe o opcode 0x86 como um quadrado temporário.
-	// Renova a marca enquanto houver uma relação de PvP ativa para que o
-	// efeito permaneça visível também no cliente padrão.
+	// Limita a renovação para evitar uma enxurrada de pacotes em todo onThink.
 	if (isInPvpSituation()) {
-		g_game.updateCreatureSquare(this);
+		pvpSquareRefreshTicks += interval;
+		if (pvpSquareRefreshTicks >= 1000) {
+			pvpSquareRefreshTicks = 0;
+			g_game.updateCreatureSquare(this);
+		}
+	} else {
+		pvpSquareRefreshTicks = 0;
 	}
 
 	if (client && getIP() == 0) {

--- a/src/player.h
+++ b/src/player.h
@@ -1658,6 +1658,7 @@ private:
 
 	std::unordered_set<uint32_t> attackedSet;
 	std::unordered_set<uint32_t> attackedBySet;
+	uint32_t pvpSquareRefreshTicks = 0;
 	std::unordered_set<uint32_t> VIPList;
 	std::unordered_set<uint32_t> modifiedStorageKeys;
 	std::unordered_set<uint32_t> removedStorageKeys;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3049,7 +3049,9 @@ void ProtocolGame::sendCreatureSkull(const Creature* creature)
 
 void ProtocolGame::sendCreatureSquare(const Creature* creature, SquareColor_t color)
 {
-	if (!canSee(creature)) {
+	// Opcode 0x86 is only valid for visible players with an actual PvP color.
+	// Sending it for monsters or SQ_COLOR_NONE can desynchronize 8.6 clients.
+	if (!creature || !creature->getPlayer() || color == SQ_COLOR_NONE || !canSee(creature)) {
 		return;
 	}
 


### PR DESCRIPTION
﻿# Summary

- send PvP square packets only for player creatures with a valid square color
- throttle the periodic PvP square refresh to once per second
- reset the refresh timer when the player leaves the PvP situation
- keep visibility checks before sending opcode 0x86

# Root cause

PR #227 refreshed opcode 0x86 from `Player::onThink` and allowed refresh paths to reach monsters or `SQ_COLOR_NONE`. On 8.6 clients this can desynchronize combat updates and interfere with weapon damage display.

# Impact

The perspective-aware PvP squares remain visual-only while avoiding invalid or excessive square packets.

# Validation

- `git diff --check` passed
- all changes are limited to `src/game.cpp`, `src/player.cpp`, `src/player.h`, and `src/protocolgame.cpp`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PvP status square updates for better accuracy and reduced unnecessary refreshes.
  * PvP indicators now appear only for visible players with an applicable color.
  * Prevented indicators from being sent for monsters, unseen creatures, or colorless states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->