### PR TITLE
fix(stress): move-only pipeline test crashes the server it runs on

### DIFF
--- a/src/stress_test.cpp
+++ b/src/stress_test.cpp
@@ -257,23 +257,18 @@ bool testUniqueIdentifiers()
 
 bool testMoveOnlyPipeline()
 {
+	TaskReactor reactor;
+	startReactor(reactor);
 	const int COUNT = std::min(1000, getCountFor(ConfigManager::STRESS_TEST_MOVE_ONLY_COUNT));
 	std::atomic<int> sum{0};
 
 	for (int i = 0; i < COUNT; ++i) {
 		auto value = std::make_unique<int>(i + 1);
-		g_scheduler.addEvent(0, [value = std::move(value), &sum] {
+		reactor.schedule(0, [value = std::move(value), &sum] {
 			sum.fetch_add(*value, std::memory_order_relaxed);
 		});
 	}
-
-	while (true) {
-		g_reactor.runOnce();
-		if (sum.load() == COUNT * (COUNT + 1) / 2) {
-			break;
-		}
-		std::this_thread::yield();
-	}
+	reactor.runOnce();
 
 	STRESS_CHECK(sum.load() == COUNT * (COUNT + 1) / 2, "pipeline sum should match");
 	return true;


### PR DESCRIPTION
`/stress_reactor` kills the server. Not a failed assertion — heap corruption and `SIGABRT`.

I found this by running the suite on a live server, which is how I noticed it never finishes.

### What happens

```
[PASS] unique identifiers (8 ms)
double free or corruption (fasttop)
[CRITICAL] Signal received: SIGABRT
[CRITICAL] Signal received: SIGSEGV, reason=unknown memory fault, faultAddress=0x0000000000000000
```

Reproduced twice. The second run had **every other subtest disabled** so that move-only ran first — same crash, before it even printed the test name. The container was gone afterwards; `docker ps` showed nothing.

### Cause

`testMoveOnlyPipeline` is the only one of the twenty tests that drives the **live** `g_reactor`. The other nineteen all do this:

```cpp
TaskReactor reactor;
startReactor(reactor);
```

It did this instead:

```cpp
g_scheduler.addEvent(0, ...);
while (true) {
    g_reactor.runOnce();
    ...
}
```

`runStressTests()` ends with `g_threadPool.detach_task(...)`, so the body runs on a pool worker. That worker's `runOnce()` loop therefore runs concurrently with the dispatcher thread's own `runOnce()`, both draining the same queue. Two threads pop and destroy the same task, and the allocator aborts.

### Consequence beyond the crash

It aborts at test 10 of 20, so **the ten tests after it have never run**: `send with expiration`, `runLoop burst`, `reentrancy`, `shutdown pending`, `cancel external`, `exception resilience`, `inspection`, `mixed delays`, `leak check`, `shutdown send`. Half the suite is unexercised, and the summary line never prints, which is why a passing-looking log still ends early.

Also worth saying plainly: this is reachable on any live server. The talkaction is gated to group access and `accountType(6)`, so it is not a player-facing hole, but a god character typing `/stress_reactor` takes the server down.

### Fix

Use a local reactor, matching the other nineteen. The move-only semantics under test are unchanged — the `unique_ptr` capture stays, which is the point of the test.

### Verification

The crash is verified empirically, twice, as above. The fix follows the exact shape of `testScheduleBulk` two functions up. I have not yet run the fixed binary — CI compiles it here, and I will confirm on the same server that the suite now gets past test 10 and reports a summary.

One loose end I left alone: `#include "scheduler.h"` is now unused in this file, since `g_scheduler` and `g_reactor` no longer appear in it. I did not remove it to keep the diff to the bug, but happy to.
