### PR TITLE
fix(reactor): shutdown can be missed, leaving the run loop blocked forever

### DIFF
--- a/src/reactor.cpp
+++ b/src/reactor.cpp
@@ -221,7 +221,13 @@ void TaskReactor::runOnce()
 
 void TaskReactor::shutdown() noexcept
 {
-	threadState.store(THREAD_STATE_TERMINATED, std::memory_order_release);
+	// The state has to change under the mutex. waitForWork() evaluates its predicate
+	// holding the lock and only then blocks; a store from outside can land in that
+	// window, and notify_all() reaches nobody because the waiter is not registered yet.
+	{
+		std::scoped_lock lock(mutex);
+		threadState.store(THREAD_STATE_TERMINATED, std::memory_order_release);
+	}
 	conditionVariable.notify_all();
 }
 

--- a/src/tests/test_reactor.cpp
+++ b/src/tests/test_reactor.cpp
@@ -184,9 +184,13 @@ TEST_CASE(test_reactor_shutdown_wakes_run_loop)
 	TaskReactor reactor;
 	startReactor(reactor);
 	std::atomic_bool enteredLoop = false;
+	std::atomic_bool loopExited = false;
 
 	reactor.send([&enteredLoop] { enteredLoop.store(true, std::memory_order_release); });
-	std::jthread reactorThread([&reactor] { reactor.runLoop(); });
+	std::jthread reactorThread([&reactor, &loopExited] {
+		reactor.runLoop();
+		loopExited.store(true, std::memory_order_release);
+	});
 
 	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
 	while (!enteredLoop.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
@@ -195,7 +199,22 @@ TEST_CASE(test_reactor_shutdown_wakes_run_loop)
 
 	CHECK(enteredLoop.load(std::memory_order_acquire));
 	reactor.shutdown();
+
+	// join() has no deadline of its own, so a missed wakeup hangs the whole suite
+	// instead of failing it. Bound the wait; if it expires, notify once more — by
+	// then the loop is definitely registered on the condition variable — so the
+	// test can report the failure rather than block ctest until CI times out.
+	const auto exitDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+	while (!loopExited.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < exitDeadline) {
+		std::this_thread::yield();
+	}
+	const bool exitedInTime = loopExited.load(std::memory_order_acquire);
+	if (!exitedInTime) {
+		reactor.shutdown();
+	}
+
 	reactorThread.join();
+	CHECK(exitedInTime);
 	CHECK(reactor.getState() == THREAD_STATE_TERMINATED);
 }
 


### PR DESCRIPTION
`shutdown()` is the only one of the five `conditionVariable.notify*` sites in `reactor.cpp` that changes predicate state **without holding the mutex**.

The other four all look like this:

```cpp
{
    std::scoped_lock lock(mutex);
    sendInbox.push_back(std::move(task));
}
conditionVariable.notify_one();
```

`shutdown()` looked like this:

```cpp
threadState.store(THREAD_STATE_TERMINATED, std::memory_order_release);
conditionVariable.notify_all();
```

### The race

`waitForWork()` takes the lock, evaluates `wakePredicate()`, and only then blocks:

```cpp
std::unique_lock lock(mutex);
if (!wakePredicate()) {
    conditionVariable.wait(lock, wakePredicate);
}
```

The predicate does check `threadState`, so this is not the naive lost-wakeup. The window is narrower: the waiter has evaluated the predicate as `RUNNING` but has not yet released the lock and registered on the condition variable. A `shutdown()` that does not take the mutex can land exactly there. `notify_all()` then reaches no waiter, and the loop blocks with no further notification coming — nothing else will ever run.

### How I found it

Not by reading. `test_reactor` normally finishes in 0.01 s and the whole suite in under 7 s. On one CI run it hung in `test_reactor_shutdown_wakes_run_loop` for **18 minutes** until the 30-minute job timeout killed it:

```
Start 23: test_reactor
...
Terminate orphan process: pid (13713) (ctest)
```

The same commit passed on another runner, `test_reactor` in 0.01 s, 29/29 green. So it is intermittent, which fits a race whose window is a few instructions wide.

The test itself hides it: the wait for `enteredLoop` has a 1-second deadline, but `reactorThread.join()` has none. A missed wakeup does not fail the test, it hangs it.

In production the consequence is the reactor thread failing to observe shutdown, so the server hangs on exit rather than terminating.

### This is the only place in the engine that does it

I checked every condition variable in `src/`. The two sibling subsystems both get it right, which is why I am confident this is a slip rather than an intentional choice:

```cpp
// thread_pool.cpp
{
    std::scoped_lock lock(queueMutex);
    if (stopped.exchange(true)) { return; }
}
condition.notify_all();

// databasetasks.cpp
{
    std::scoped_lock guard(taskLock);
    setState(THREAD_STATE_TERMINATED);
}
taskSignal.notify_all();
```

Twelve notify sites across `reactor.cpp`, `thread_pool.cpp/h` and `databasetasks.cpp`; eleven take the lock around the state change. This was the twelfth.

### Fix

Take the mutex around the state change, matching everything else.

### One thing worth a second opinion

`shutdown()` is `noexcept`, and `std::mutex::lock()` can in principle throw `std::system_error`, which would terminate rather than propagate. In practice that only happens on programming errors such as a deadlock or an invalid mutex, and the rest of the file already locks this mutex freely — but it is your call whether you would rather drop `noexcept`.
