### PR TITLE
fix(schema): two tables exist only in migrations, so fresh installs never get them

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -736,6 +736,45 @@ CREATE TABLE IF NOT EXISTS `towns` (
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
+-- Created by migration 34. A fresh install starts at db_version 62, so that
+-- migration never runs and the roulette scripts find no table.
+CREATE TABLE IF NOT EXISTS `roulette_plays` (
+  `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `player_id` int(11) NOT NULL,
+  `uuid` VARCHAR(255) NOT NULL,
+  `reward_id` int(11) NOT NULL,
+  `reward_count` int(11) NOT NULL,
+  `status` tinyint(1) NOT NULL DEFAULT 0 COMMENT '0 = rolling | 1 = pending | 2 = delivered',
+  `created_at` bigint(20) NOT NULL DEFAULT (UNIX_TIMESTAMP()),
+  `updated_at` bigint(20) NOT NULL DEFAULT (UNIX_TIMESTAMP()),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`uuid`),
+  FOREIGN KEY (`player_id`) REFERENCES `players` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Created by migration 48, same problem: the engine logs
+-- "[Hireling] player_hirelings table is missing" on every fresh install.
+CREATE TABLE IF NOT EXISTS `player_hirelings` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `player_id` INT NOT NULL,
+  `name` VARCHAR(32) NOT NULL,
+  `active` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `sex` TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  `posx` INT NOT NULL DEFAULT 0,
+  `posy` INT NOT NULL DEFAULT 0,
+  `posz` INT NOT NULL DEFAULT 0,
+  `lookbody` INT NOT NULL DEFAULT 34,
+  `lookfeet` INT NOT NULL DEFAULT 116,
+  `lookhead` INT NOT NULL DEFAULT 97,
+  `looklegs` INT NOT NULL DEFAULT 3,
+  `looktype` INT NOT NULL DEFAULT 1108,
+  PRIMARY KEY (`id`),
+  KEY `idx_player_hirelings_player_id` (`player_id`),
+  CONSTRAINT `fk_player_hirelings_player_id`
+    FOREIGN KEY (`player_id`) REFERENCES `players` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 INSERT INTO server_config (config, value) VALUES ('db_version', '62'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 CREATE TABLE IF NOT EXISTS guild_transactions (


### PR DESCRIPTION
`schema.sql` seeds `db_version = 62`, which is the newest migration. `updateDatabase()` reads that value and walks **forward**, so on a fresh install every migration below 62 is skipped — by design, because the schema is supposed to already contain their result.

Two tables never made it back into the schema:

| Table | Migration | Used by |
|---|---|---|
| `player_hirelings` | 48 | `data/scripts/lib/hireling.lua` |
| `roulette_plays` | 34 | six scripts under `data/scripts/magic-roulette-master/` |

So they exist only on servers old enough to have upgraded through those migrations. **Every fresh install has been missing both.**

### How I found it

Booting the server on a clean database, which prints:

```
[Hireling] player_hirelings table is missing
```

I had written that off as a harmless datapack quirk. It is not — it is the visible half of a schema gap. `roulette_plays` is the silent half; nothing warns about it.

### Verification

Definitions are copied verbatim from the migrations. I loaded the modified `schema.sql` into an empty database: it applies with no errors, and both tables are present afterwards — 58 tables total, which is the previous 56 plus these two.

### One I deliberately left out

`guildwar_kills_backup` is also migration-only, and it should stay that way. Migration 32 creates it as a one-shot `LIKE guildwar_kills` copy before altering that table, and nothing else in `src/` or `data/` ever references it. A fresh install has nothing to back up.

### Worth considering separately

Nothing stops this from happening again. A CI step that loads `schema.sql` into an empty database and then diffs the resulting table list against a database built by running every migration from 0 would catch the next one. I have not written that — it is a bigger change than this fix and I would rather you decide whether you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording roulette plays.
  * Added support for managing player hirelings.
  * Added data integrity safeguards for unique records, default values, and automatic cleanup when players are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->