### PR TITLE
fix(data): four constants that do not exist on this engine

### DIFF
--- a/data/scripts/spells/attack/monk/chained_penance.lua
+++ b/data/scripts/spells/attack/monk/chained_penance.lua
@@ -117,7 +117,7 @@ local function onGetFormulaValues(player, weaponDamage)
 		basePower = math.floor(basePower * 1.06) -- 6%
 	end
 
-	local skill = player:getSkillLevel(SKILL_FIRST)
+	local skill = player:getSkillLevel(SKILL_FIST)
 	local attackValue = calculateAttackValue(player, skill, weaponDamage)
 
 	local spellFactor = 2.0

--- a/data/scripts/spells/attack/monk/spiritual_outburst.lua
+++ b/data/scripts/spells/attack/monk/spiritual_outburst.lua
@@ -105,7 +105,7 @@ local config = {
 local function onGetFormulaValues(player, weaponDamage)
 	local basePower = 42
 
-	local skill = player:getSkillLevel(SKILL_FIRST)
+	local skill = player:getSkillLevel(SKILL_FIST)
 	local attackValue = calculateAttackValue(player, skill, weaponDamage)
 
 	local spellFactor = 2.5

--- a/data/scripts/spells/spells_monsters/azerus_skill_reducer_3.lua
+++ b/data/scripts/spells/spells_monsters/azerus_skill_reducer_3.lua
@@ -7,7 +7,7 @@ for i = 45, 55 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 15000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	combat[i]:addCondition(condition)
 end
 

--- a/data/scripts/spells/spells_monsters/barbarian_brutetamer_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/barbarian_brutetamer_skill_reducer.lua
@@ -8,7 +8,7 @@ for i = 90, 99 do
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 8000)
 	condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
 
 	combat[i]:addCondition(condition)

--- a/data/scripts/spells/spells_monsters/cults_of_tibia_armor_buff.lua
+++ b/data/scripts/spells/spells_monsters/cults_of_tibia_armor_buff.lua
@@ -6,7 +6,7 @@ for i = 130, 150 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 6000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	arr = {
 		{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },

--- a/data/scripts/spells/spells_monsters/dark_torturer_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/dark_torturer_skill_reducer.lua
@@ -6,7 +6,7 @@ for i = 1, 40 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 4000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea({
 		{ 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },

--- a/data/scripts/spells/spells_monsters/dreadwing_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/dreadwing_skill_reducer.lua
@@ -7,7 +7,7 @@ for i = 30, 60 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 10000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	combat[i]:addCondition(condition)
 end
 

--- a/data/scripts/spells/spells_monsters/enslaved_dwarf_skill_reducer_1.lua
+++ b/data/scripts/spells/spells_monsters/enslaved_dwarf_skill_reducer_1.lua
@@ -6,7 +6,7 @@ for i = 20, 65 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 6000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE2X2)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/forest_fury_skill_reducer_1.lua
+++ b/data/scripts/spells/spells_monsters/forest_fury_skill_reducer_1.lua
@@ -7,7 +7,7 @@ for i = 40, 50 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 7000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE2X2)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/fury_skill_reducer_1.lua
+++ b/data/scripts/spells/spells_monsters/fury_skill_reducer_1.lua
@@ -6,7 +6,7 @@ for i = 65, 80 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 5000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE3X3)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/ghazbaran_skill_reducer_2.lua
+++ b/data/scripts/spells/spells_monsters/ghazbaran_skill_reducer_2.lua
@@ -6,7 +6,7 @@ for i = 0, 15 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 10000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	arr = {
 		{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },

--- a/data/scripts/spells/spells_monsters/gnomevil_skill_reducer_1.lua
+++ b/data/scripts/spells/spells_monsters/gnomevil_skill_reducer_1.lua
@@ -6,7 +6,7 @@ for i = 10, 45 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 10000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE2X2)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/gnorre_chyllson_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/gnorre_chyllson_skill_reducer.lua
@@ -8,7 +8,7 @@ for i = 45, 55 do
 	condition:setParameter(CONDITION_PARAM_TICKS, 3000)
 	condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE3X3)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/gorerilla_small_ring.lua
+++ b/data/scripts/spells/spells_monsters/gorerilla_small_ring.lua
@@ -1,5 +1,5 @@
 local combat = Combat()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGEDAMAGE)
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_EXPLOSIONAREA)
 arr = {
 	{ 0, 0, 0, 0, 0, 0, 0, 0, 0 },

--- a/data/scripts/spells/spells_monsters/hirintror_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/hirintror_skill_reducer.lua
@@ -8,7 +8,7 @@ for i = 20, 40 do
 	condition:setParameter(CONDITION_PARAM_TICKS, 15000)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
 	condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_SQUARE1X1)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/ice_golem_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/ice_golem_skill_reducer.lua
@@ -8,7 +8,7 @@ for i = 20, 40 do
 	condition:setParameter(CONDITION_PARAM_TICKS, 15000)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
 	condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_SQUARE1X1)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/ironblight_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/ironblight_skill_reducer.lua
@@ -6,7 +6,7 @@ for i = 30, 70 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 4000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE2X2)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/large_holy_ring.lua
+++ b/data/scripts/spells/spells_monsters/large_holy_ring.lua
@@ -18,7 +18,7 @@ local aLarge = {
 
 local combatLargeRing = Combat()
 combatLargeRing:setParameter(COMBAT_PARAM_TYPE, COMBAT_HOLYDAMAGE)
-combatLargeRing:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_CONST_ME_HOLYAREA)
+combatLargeRing:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HOLYAREA)
 combatLargeRing:setArea(createCombatArea(aLarge))
 
 local combats = { combatLargeRing }

--- a/data/scripts/spells/spells_monsters/lisa_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/lisa_skill_reducer.lua
@@ -7,7 +7,7 @@ for i = 60, 75 do
 	local condition1 = Condition(CONDITION_ATTRIBUTES)
 	condition1:setParameter(CONDITION_PARAM_TICKS, 7000)
 	condition1:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition1:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition1:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local condition2 = Condition(CONDITION_ATTRIBUTES)
 	condition2:setParameter(CONDITION_PARAM_TICKS, 7000)
@@ -16,7 +16,7 @@ for i = 60, 75 do
 	local condition3 = Condition(CONDITION_ATTRIBUTES)
 	condition3:setParameter(CONDITION_PARAM_TICKS, 7000)
 	condition3:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
-	condition3:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition3:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	arr = {
 		{ 0, 0, 0, 1, 1, 1, 0, 0, 0 },

--- a/data/scripts/spells/spells_monsters/mooh'tah_master_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/mooh'tah_master_skill_reducer.lua
@@ -4,7 +4,7 @@ combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_SUDDENDEATH)
 
 local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_TICKS, 3000)
-condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, -100)
+condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, -100)
 combat:addCondition(condition)
 
 local spell = Spell("instant")

--- a/data/scripts/spells/spells_monsters/morgaroth_skill_reducer_2.lua
+++ b/data/scripts/spells/spells_monsters/morgaroth_skill_reducer_2.lua
@@ -8,7 +8,7 @@ for i = 15, 30 do
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 15000)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	combat[i]:addCondition(condition)
 end
 

--- a/data/scripts/spells/spells_monsters/pixie_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/pixie_skill_reducer.lua
@@ -4,7 +4,7 @@ combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_PIXIE_EXPLOSION)
 local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_TICKS, 6000)
 condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, 30)
-condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, 30)
+condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, 30)
 condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, 30)
 
 local area = createCombatArea(AREA_CIRCLE2X2)

--- a/data/scripts/spells/spells_monsters/shock_head_skill_reducer_1.lua
+++ b/data/scripts/spells/spells_monsters/shock_head_skill_reducer_1.lua
@@ -22,7 +22,7 @@ for i = 15, 30 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 6000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(arr)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/terofar_skill_reducer_1.lua
+++ b/data/scripts/spells/spells_monsters/terofar_skill_reducer_1.lua
@@ -7,7 +7,7 @@ for i = 1, 10 do
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 15000)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
 
 	local area = createCombatArea({

--- a/data/scripts/spells/spells_monsters/tyrn_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/tyrn_skill_reducer.lua
@@ -7,7 +7,7 @@ for i = 40, 55 do
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 12000)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	arr = {
 		{ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 },

--- a/data/scripts/spells/spells_monsters/walker_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/walker_skill_reducer.lua
@@ -6,7 +6,7 @@ for i = 45, 60 do
 	local condition1 = Condition(CONDITION_ATTRIBUTES)
 	condition1:setParameter(CONDITION_PARAM_TICKS, 7000)
 	condition1:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition1:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition1:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local condition2 = Condition(CONDITION_ATTRIBUTES)
 	condition2:setParameter(CONDITION_PARAM_TICKS, 7000)
@@ -15,7 +15,7 @@ for i = 45, 60 do
 	local condition3 = Condition(CONDITION_ATTRIBUTES)
 	condition3:setParameter(CONDITION_PARAM_TICKS, 7000)
 	condition3:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
-	condition3:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition3:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE3X3)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/war_golem_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/war_golem_skill_reducer.lua
@@ -6,7 +6,7 @@ for i = 40, 60 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 8000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local arr = {
 		{ 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0 },

--- a/data/scripts/spells/spells_monsters/warlock_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/warlock_skill_reducer.lua
@@ -8,7 +8,7 @@ for i = 40, 50 do
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 6000)
 	condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	combat[i]:addCondition(condition)
 end
 

--- a/data/scripts/spells/spells_monsters/weeper_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/weeper_skill_reducer.lua
@@ -6,7 +6,7 @@ for i = 15, 55 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 7000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 
 	local area = createCombatArea(AREA_CIRCLE1X1)
 	combat[i]:setArea(area)

--- a/data/scripts/spells/spells_monsters/zugurosh_pillar_skill_reducer.lua
+++ b/data/scripts/spells/spells_monsters/zugurosh_pillar_skill_reducer.lua
@@ -7,7 +7,7 @@ for i = 1, 20 do
 
 	local condition = Condition(CONDITION_ATTRIBUTES)
 	condition:setParameter(CONDITION_PARAM_TICKS, 7000)
-	condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)
+	condition:setParameter(CONDITION_PARAM_SKILL_SHIELDPERCENT, i)
 	combat[i]:addCondition(condition)
 end
 


### PR DESCRIPTION
Follow-up to the identifier sweep behind #231/#232/#233. I diffed every ALL_CAPS identifier used across the 4,164 files in `data/` against the globals the C++ side actually registers, discarded everything `data/` defines itself, and worked through what was left.

### `CONDITION_PARAM_SKILL_DEFENSEPERCENT` → `CONDITION_PARAM_SKILL_SHIELDPERCENT` — 26 files

This is the one that matters. The surrounding lines settle the intent:

```lua
condition:setParameter(CONDITION_PARAM_SKILL_MELEEPERCENT, i)
condition:setParameter(CONDITION_PARAM_SKILL_DISTANCEPERCENT, i)
condition:setParameter(CONDITION_PARAM_SKILL_DEFENSEPERCENT, i)   -- nil
```

Melee, distance, and then the third one — which this engine calls `SHIELD`, not `DEFENSE`. All 26 are monster skill-reducer spells (ice golem, dreadwing, gnorre chyllson, mooh'tah master, zugurosh pillar and so on), and **none of them has ever reduced shielding.** Those monsters have been easier than designed.

### `SKILL_FIRST` → `SKILL_FIST` — 2 files

`player:getSkillLevel(SKILL_FIRST)` in two monk spells. The enum has `SKILL_FIST`; fist fighting is the obvious thing for a monk spell to scale on.

### `CONST_ME_CONST_ME_HOLYAREA` → `CONST_ME_HOLYAREA` — 1 file

Doubled prefix.

### `COMBAT_PHYSICALDAMAGEDAMAGE` → `COMBAT_PHYSICALDAMAGE` — 1 file

Doubled suffix.

### Verification

All 30 changed files pass `luac -p`. These are pure identifier substitutions; no logic touched.

### What I deliberately did not change

`CONST_ME_POISON` (2 uses) does not exist either, but I am not guessing at it. The candidates are `CONST_ME_POISONAREA` and `CONST_ME_HITBYPOISON`, and the two call sites pull in different directions — `plagirath_bog.lua` sets it as an area effect, while `harpy.lua` uses it on a `target = true` combat. Tell me which you want and I will send it.

Still unresolved from the same sweep, listed so they are not lost: `CONST_SLOT_WHEREEVER` (17 uses), `MESSAGE_FAILURE` (10), `MESSAGE_ADMIN` (6), `MESSAGE_LOOK` (4), `MESSAGE_EXPERIENCE` (3), `SCREENSHOT_TYPE_BOSSDEFEATED` (2), `ITEM_ATTRIBUTE_REDUCESKILLLOSS` (2), plus a handful of one-offs. None has an obvious single correct name, so they need someone who knows the intent rather than a search-and-replace.
