### PR TITLE
feat(stash): protocol layer for the Supply Stash — parser, contents, guards

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.cpp
 	${CMAKE_CURRENT_LIST_DIR}/market.cpp
 	${CMAKE_CURRENT_LIST_DIR}/stash.cpp
+	${CMAKE_CURRENT_LIST_DIR}/supply_stash_protocol.cpp
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monster.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
@@ -201,6 +202,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.h
 	${CMAKE_CURRENT_LIST_DIR}/market.h
 	${CMAKE_CURRENT_LIST_DIR}/stash.h
+	${CMAKE_CURRENT_LIST_DIR}/supply_stash_protocol.h
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.h
 	${CMAKE_CURRENT_LIST_DIR}/monster.h
 	${CMAKE_CURRENT_LIST_DIR}/monsters.h

--- a/src/supply_stash_protocol.cpp
+++ b/src/supply_stash_protocol.cpp
@@ -1,0 +1,124 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "supply_stash_protocol.h"
+
+#include "networkmessage.h"
+
+namespace tfs::supply_stash {
+
+namespace {
+
+ParseResult fail(ParseError error) { return ParseResult{error, Request{}}; }
+
+bool isKnownAction(uint8_t value)
+{
+	switch (static_cast<Action>(value)) {
+		case Action::StowItem:
+		case Action::StowContainer:
+		case Action::StowStack:
+		case Action::Withdraw:
+			return true;
+	}
+	return false;
+}
+
+} // namespace
+
+ParseResult parseRequest(NetworkMessage& msg)
+{
+	const uint8_t rawAction = msg.getByte();
+
+	// Reads past the end return 0 rather than throwing, so the overrun flag is
+	// the only honest signal that the message was short.
+	if (msg.isOverrun()) {
+		return fail(ParseError::Truncated);
+	}
+
+	if (!isKnownAction(rawAction)) {
+		return fail(ParseError::UnknownAction);
+	}
+
+	Request request;
+	request.action = static_cast<Action>(rawAction);
+
+	switch (request.action) {
+		case Action::StowItem:
+			request.position = msg.getPosition();
+			request.itemId = msg.get<uint16_t>();
+			request.stackpos = msg.getByte();
+			request.count = msg.get<uint32_t>();
+			break;
+
+		case Action::StowContainer:
+		case Action::StowStack:
+			request.position = msg.getPosition();
+			request.itemId = msg.get<uint16_t>();
+			request.stackpos = msg.getByte();
+			break;
+
+		case Action::Withdraw:
+			request.itemId = msg.get<uint16_t>();
+			request.count = msg.get<uint32_t>();
+			request.tier = msg.getByte();
+			break;
+	}
+
+	if (msg.isOverrun()) {
+		return fail(ParseError::Truncated);
+	}
+
+	// Every layout is fixed size, so leftover bytes mean the client and the server
+	// disagree about the contract. Rejecting here stops that disagreement being
+	// read as the next opcode. Readable data ends at length + INITIAL_BUFFER_POSITION,
+	// which is the same bound canRead() enforces.
+	//
+	// This assumes msg holds a stash request and nothing else. That holds for the
+	// current transport, where the payload arrives on its own; if the request is
+	// ever embedded in a larger packet, the caller must slice it out first.
+	if (msg.getBufferPosition() != msg.getLength() + NetworkMessage::INITIAL_BUFFER_POSITION) {
+		return fail(ParseError::TrailingBytes);
+	}
+
+	if (request.itemId == 0) {
+		return fail(ParseError::InvalidItemId);
+	}
+
+	switch (request.action) {
+		case Action::StowItem:
+			if (request.count == 0 || request.count > MAX_STOW_COUNT) {
+				return fail(ParseError::InvalidCount);
+			}
+			break;
+
+		case Action::Withdraw:
+			if (request.count == 0 || request.count > MAX_WITHDRAW_COUNT) {
+				return fail(ParseError::InvalidCount);
+			}
+			if (request.tier > Stash::MAX_ITEM_TIER) {
+				return fail(ParseError::InvalidTier);
+			}
+			break;
+
+		case Action::StowContainer:
+		case Action::StowStack:
+			break;
+	}
+
+	return ParseResult{ParseError::None, request};
+}
+
+void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots)
+{
+	msg.add<uint16_t>(static_cast<uint16_t>(rows.size()));
+	for (const auto& row : rows) {
+		msg.add<uint16_t>(row.itemId);
+		msg.add<uint32_t>(row.amount);
+		msg.addByte(row.tier);
+	}
+	msg.add<uint16_t>(freeSlots);
+}
+
+} // namespace tfs::supply_stash

--- a/src/supply_stash_protocol.cpp
+++ b/src/supply_stash_protocol.cpp
@@ -7,9 +7,16 @@
 
 #include "networkmessage.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace tfs::supply_stash {
 
 namespace {
+
+// U16 itemId + U32 amount + U8 tier per row; U16 count and U16 freeSlots around them.
+constexpr size_t CONTENTS_ROW_BYTES = 7;
+constexpr size_t CONTENTS_FIXED_BYTES = 4;
 
 ParseResult fail(ParseError error) { return ParseResult{error, Request{}}; }
 
@@ -110,8 +117,22 @@ ParseResult parseRequest(NetworkMessage& msg)
 	return ParseResult{ParseError::None, request};
 }
 
-void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots)
+size_t maxSerializableRows()
 {
+	constexpr size_t byMessage =
+	    (static_cast<size_t>(NetworkMessage::MAX_PROTOCOL_BODY_LENGTH) - CONTENTS_FIXED_BYTES) / CONTENTS_ROW_BYTES;
+	constexpr size_t byCountField = std::numeric_limits<uint16_t>::max();
+	return std::min(byMessage, byCountField);
+}
+
+bool serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots)
+{
+	// Checked before a single byte is written, because a partial payload is worse
+	// than none: the count would promise rows that never arrive.
+	if (rows.size() > maxSerializableRows()) {
+		return false;
+	}
+
 	msg.add<uint16_t>(static_cast<uint16_t>(rows.size()));
 	for (const auto& row : rows) {
 		msg.add<uint16_t>(row.itemId);
@@ -119,6 +140,7 @@ void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows
 		msg.addByte(row.tier);
 	}
 	msg.add<uint16_t>(freeSlots);
+	return true;
 }
 
 } // namespace tfs::supply_stash

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -14,20 +14,38 @@ class NetworkMessage;
 
 namespace tfs::supply_stash {
 
-// Opcode note, because the pairing is a trap.
+// Opcode directions. These are top-level packet opcodes, not extended opcodes,
+// and the numbers are only safe because the directions differ:
 //
-// These two numbers are only safe because they travel in opposite directions:
+//     C -> S  0x28   Supply Stash actions
+//     S -> C  0x28   ReLogin/Death window  (sendReLoginWindow)
+//     S -> C  0x29   Supply Stash contents
 //
-//     client -> server  0x28   free
-//     server -> client  0x29   free
-//     server -> client  0x28   ALREADY sendReLoginWindow()
-//
-// Never mirror the request opcode to answer on 0x28 — that is the death/relogin
-// window in 8.60 and the client will act on it.
+// Never answer a stash request on S -> C 0x28. That is the death/relogin window
+// in 8.60 and the client will act on it.
 inline constexpr uint8_t CLIENT_REQUEST_OPCODE = 0x28;
 inline constexpr uint8_t SERVER_CONTENTS_OPCODE = 0x29;
 
 // Wire values shared with AstraClient. Do not renumber.
+//
+// These replace the previous Lua numbering (OPEN = 1, STOW_ALL = 2,
+// WITHDRAW = 3), so 1 and 2 now mean something different than they used to and
+// a client that has not been updated is speaking the old dialect.
+//
+// That transition is safe only because every layout here is fixed size and the
+// parser rejects both short and long messages:
+//
+//     old OPEN      1 byte  -> this expects 8 more  -> Truncated, rejected
+//     old STOW_ALL  1 byte  -> this expects 8 more  -> Truncated, rejected
+//     old WITHDRAW  6 bytes -> this expects 7       -> Truncated, rejected
+//     old WITHDRAW  7 bytes -> identical layout     -> accepted, same meaning
+//
+// So an out-of-date client is refused rather than silently misread as an
+// item-moving command. test_supply_stash_protocol pins that down; if the length
+// guards are ever relaxed, the rollout stops being fail-safe.
+//
+// Note there is deliberately no OPEN action: opening the stash comes from using
+// the stash object, not from a client request.
 enum class Action : uint8_t
 {
 	StowItem = 0,

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -93,9 +93,25 @@ struct ParseResult
 // the action's layout says it does.
 [[nodiscard]] ParseResult parseRequest(NetworkMessage& msg);
 
+// Largest row count that can be encoded. Bounded by two things, and the tighter
+// of them is the message body, not the 16-bit count: at seven bytes per row a
+// full message runs out well before 65535 rows do.
+[[nodiscard]] size_t maxSerializableRows();
+
 // Writes the stash contents payload, tier-aware, matching what AstraClient
 // already knows how to read.
-void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots);
+//
+// Returns false and writes nothing when the rows do not fit. Both failure modes
+// desynchronise the receiver rather than merely losing data, so neither may
+// produce a partial packet:
+//
+//   - a count above 65535 wraps in the header while every row is still written
+//   - a payload past the message body stops being appended silently, because
+//     NetworkMessage::addByte returns without writing once it is full
+//
+// Either way the header promises more rows than follow, and the receiver goes on
+// to read row bytes as freeSlots.
+[[nodiscard]] bool serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots);
 
 } // namespace tfs::supply_stash
 

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -1,0 +1,84 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_SUPPLY_STASH_PROTOCOL_H
+#define FS_SUPPLY_STASH_PROTOCOL_H
+
+#include "position.h"
+#include "stash.h"
+
+#include <cstdint>
+#include <vector>
+
+class NetworkMessage;
+
+namespace tfs::supply_stash {
+
+// Opcode note, because the pairing is a trap.
+//
+// These two numbers are only safe because they travel in opposite directions:
+//
+//     client -> server  0x28   free
+//     server -> client  0x29   free
+//     server -> client  0x28   ALREADY sendReLoginWindow()
+//
+// Never mirror the request opcode to answer on 0x28 — that is the death/relogin
+// window in 8.60 and the client will act on it.
+inline constexpr uint8_t CLIENT_REQUEST_OPCODE = 0x28;
+inline constexpr uint8_t SERVER_CONTENTS_OPCODE = 0x29;
+
+// Wire values shared with AstraClient. Do not renumber.
+enum class Action : uint8_t
+{
+	StowItem = 0,
+	StowContainer = 1,
+	StowStack = 2,
+	Withdraw = 3,
+};
+
+enum class ParseError : uint8_t
+{
+	None,
+	Truncated,     // the message ended before the action's fields did
+	UnknownAction, // action byte outside the enum
+	InvalidItemId, // itemId 0
+	InvalidCount,  // count 0, or above the cap
+	InvalidTier,   // tier above Stash::MAX_ITEM_TIER
+	TrailingBytes, // more bytes than the action's fixed size accounts for
+};
+
+// Caps mirror the limits the current Lua implementation already enforces, so
+// moving the parser to C++ does not quietly widen what a client may ask for.
+inline constexpr uint32_t MAX_STOW_COUNT = 100'000;
+inline constexpr uint32_t MAX_WITHDRAW_COUNT = 100'000;
+
+struct Request
+{
+	Action action = Action::StowItem;
+	Position position{}; // stow actions only; unset for Withdraw
+	uint16_t itemId = 0;
+	uint8_t stackpos = 0; // stow actions only
+	uint32_t count = 0;   // StowItem and Withdraw only
+	uint8_t tier = 0;     // Withdraw only
+};
+
+struct ParseResult
+{
+	ParseError error = ParseError::None;
+	Request request{};
+
+	[[nodiscard]] explicit operator bool() const noexcept { return error == ParseError::None; }
+};
+
+// Reads one stash request, action byte first. Never throws and never trusts the
+// client: every field is range-checked and the message must end exactly where
+// the action's layout says it does.
+[[nodiscard]] ParseResult parseRequest(NetworkMessage& msg);
+
+// Writes the stash contents payload, tier-aware, matching what AstraClient
+// already knows how to read.
+void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots);
+
+} // namespace tfs::supply_stash
+
+#endif // FS_SUPPLY_STASH_PROTOCOL_H

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -223,6 +223,49 @@ TEST_CASE(supply_stash_rejects_trailing_bytes)
 	CHECK(result.error == ParseError::TrailingBytes);
 }
 
+// The action numbering changed: the old Lua used OPEN = 1, STOW_ALL = 2,
+// WITHDRAW = 3, so 1 and 2 now mean StowContainer and StowStack. A client that
+// has not been updated must be refused, never reinterpreted as a command that
+// moves items. These three pin that down.
+TEST_CASE(supply_stash_rejects_legacy_open_request)
+{
+	NetworkMessage msg;
+	msg.addByte(1); // old ACTION_OPEN, now StowContainer, which needs 8 more bytes
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_legacy_stow_all_request)
+{
+	NetworkMessage msg;
+	msg.addByte(2); // old ACTION_STOW_ALL, now StowStack
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_legacy_withdraw_without_tier)
+{
+	// The old withdraw sent the tier byte only when it had one.
+	NetworkMessage msg;
+	msg.addByte(3);
+	msg.add<uint16_t>(2160);
+	msg.add<uint32_t>(10);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
 TEST_CASE(supply_stash_serializes_contents_tier_aware)
 {
 	std::vector<StashRecord> rows{

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -8,6 +8,8 @@
 
 #include "test_support.h"
 
+#include <limits>
+
 using namespace tfs::supply_stash;
 
 namespace {
@@ -275,7 +277,7 @@ TEST_CASE(supply_stash_serializes_contents_tier_aware)
 	};
 
 	NetworkMessage msg;
-	serializeContents(msg, rows, 42);
+	CHECK(serializeContents(msg, rows, 42));
 	rewind(msg);
 
 	CHECK(msg.get<uint16_t>() == 3);
@@ -300,12 +302,45 @@ TEST_CASE(supply_stash_serializes_contents_tier_aware)
 TEST_CASE(supply_stash_serializes_empty_contents)
 {
 	NetworkMessage msg;
-	serializeContents(msg, {}, 1000);
+	CHECK(serializeContents(msg, {}, 1000));
 	rewind(msg);
 
 	CHECK(msg.get<uint16_t>() == 0);
 	CHECK(msg.get<uint16_t>() == 1000);
 	CHECK(!msg.isOverrun());
+}
+
+// Both bounds have to be refused before anything is written. A partial payload is
+// worse than none: the count promises rows that never arrive, so the receiver
+// reads row bytes as freeSlots and every following packet is misaligned.
+TEST_CASE(supply_stash_serializes_at_the_row_limit)
+{
+	std::vector<StashRecord> rows(maxSerializableRows(), StashRecord{2160, 0, 1});
+
+	NetworkMessage msg;
+	CHECK(serializeContents(msg, rows, 0));
+	rewind(msg);
+	CHECK(msg.get<uint16_t>() == static_cast<uint16_t>(maxSerializableRows()));
+	CHECK(!msg.isOverrun());
+}
+
+TEST_CASE(supply_stash_refuses_one_row_over_the_limit)
+{
+	std::vector<StashRecord> rows(maxSerializableRows() + 1, StashRecord{2160, 0, 1});
+
+	NetworkMessage msg;
+	CHECK(!serializeContents(msg, rows, 0));
+	// Nothing may have been emitted.
+	CHECK(msg.getLength() == 0);
+}
+
+// The message body runs out before the 16-bit count does, so that is the bound
+// that actually applies.
+TEST_CASE(supply_stash_row_limit_is_bounded_by_the_message_not_the_count_field)
+{
+	CHECK(maxSerializableRows() < std::numeric_limits<uint16_t>::max());
+	// comfortably above the 1000-row cap the stash itself enforces
+	CHECK(maxSerializableRows() > 1000);
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -1,0 +1,268 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../networkmessage.h"
+#include "../supply_stash_protocol.h"
+
+#include "test_support.h"
+
+using namespace tfs::supply_stash;
+
+namespace {
+
+// Rewinds to the start of the body, which is where a request always begins.
+void rewind(NetworkMessage& msg) { CHECK(msg.setBufferPosition(0)); }
+
+NetworkMessage stowItemMessage(uint16_t itemId, uint32_t count)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowItem));
+	msg.addPosition(Position(0xFFFF, 0x40 | 3, 5));
+	msg.add<uint16_t>(itemId);
+	msg.addByte(7);
+	msg.add<uint32_t>(count);
+	rewind(msg);
+	return msg;
+}
+
+NetworkMessage withdrawMessage(uint16_t itemId, uint32_t amount, uint8_t tier)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::Withdraw));
+	msg.add<uint16_t>(itemId);
+	msg.add<uint32_t>(amount);
+	msg.addByte(tier);
+	rewind(msg);
+	return msg;
+}
+
+} // namespace
+
+TEST_CASE(supply_stash_parses_stow_item)
+{
+	auto msg = stowItemMessage(2160, 30);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::StowItem);
+	CHECK(result.request.itemId == 2160);
+	CHECK(result.request.count == 30);
+	CHECK(result.request.stackpos == 7);
+	// Container positions arrive as (0xFFFF, containerId | 0x40, slot), so the
+	// slot index rides in z and must survive the round trip intact.
+	CHECK(result.request.position.x == 0xFFFF);
+	CHECK(result.request.position.y == (0x40 | 3));
+	CHECK(result.request.position.z == 5);
+}
+
+TEST_CASE(supply_stash_parses_stow_container_without_count)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowContainer));
+	msg.addPosition(Position(100, 200, 7));
+	msg.add<uint16_t>(1988);
+	msg.addByte(1);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::StowContainer);
+	CHECK(result.request.itemId == 1988);
+	CHECK(result.request.count == 0);
+}
+
+TEST_CASE(supply_stash_parses_stow_stack)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowStack));
+	msg.addPosition(Position(1, 2, 3));
+	msg.add<uint16_t>(2160);
+	msg.addByte(0);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::StowStack);
+}
+
+TEST_CASE(supply_stash_parses_withdraw_with_tier)
+{
+	auto msg = withdrawMessage(2160, 100, 3);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::Withdraw);
+	CHECK(result.request.itemId == 2160);
+	CHECK(result.request.count == 100);
+	CHECK(result.request.tier == 3);
+}
+
+// §17: a truncated packet must be rejected, not read past the end. Reads beyond
+// the body return 0 and set the overrun flag rather than throwing, so the parser
+// has to consult it instead of trusting the values.
+TEST_CASE(supply_stash_rejects_truncated_packet)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowItem));
+	msg.addPosition(Position(1, 2, 3));
+	msg.add<uint16_t>(2160);
+	// stackpos and count are missing
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_empty_packet)
+{
+	NetworkMessage msg;
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_unknown_action)
+{
+	NetworkMessage msg;
+	msg.addByte(0x7F);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::UnknownAction);
+}
+
+TEST_CASE(supply_stash_rejects_zero_item_id)
+{
+	auto msg = stowItemMessage(0, 30);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidItemId);
+}
+
+TEST_CASE(supply_stash_rejects_zero_count)
+{
+	auto msg = stowItemMessage(2160, 0);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidCount);
+}
+
+TEST_CASE(supply_stash_rejects_oversized_count)
+{
+	auto msg = stowItemMessage(2160, MAX_STOW_COUNT + 1);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidCount);
+}
+
+TEST_CASE(supply_stash_accepts_count_at_the_cap)
+{
+	auto msg = stowItemMessage(2160, MAX_STOW_COUNT);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.count == MAX_STOW_COUNT);
+}
+
+TEST_CASE(supply_stash_rejects_zero_withdraw_amount)
+{
+	auto msg = withdrawMessage(2160, 0, 0);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidCount);
+}
+
+TEST_CASE(supply_stash_rejects_tier_above_maximum)
+{
+	auto msg = withdrawMessage(2160, 10, Stash::MAX_ITEM_TIER + 1);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidTier);
+}
+
+TEST_CASE(supply_stash_accepts_tier_at_the_maximum)
+{
+	auto msg = withdrawMessage(2160, 10, Stash::MAX_ITEM_TIER);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.tier == Stash::MAX_ITEM_TIER);
+}
+
+// §17: extra bytes mean the two sides disagree about the layout. Accepting them
+// would leave the remainder to be read as though it were the next opcode.
+TEST_CASE(supply_stash_rejects_trailing_bytes)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::Withdraw));
+	msg.add<uint16_t>(2160);
+	msg.add<uint32_t>(10);
+	msg.addByte(0);
+	msg.addByte(0xAB); // one byte too many
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::TrailingBytes);
+}
+
+TEST_CASE(supply_stash_serializes_contents_tier_aware)
+{
+	std::vector<StashRecord> rows{
+	    StashRecord{2160, 0, 500},
+	    StashRecord{2160, 3, 25},
+	    StashRecord{2148, 0, 100000},
+	};
+
+	NetworkMessage msg;
+	serializeContents(msg, rows, 42);
+	rewind(msg);
+
+	CHECK(msg.get<uint16_t>() == 3);
+
+	CHECK(msg.get<uint16_t>() == 2160);
+	CHECK(msg.get<uint32_t>() == 500);
+	CHECK(msg.getByte() == 0);
+
+	// Same itemId, different tier: these must stay distinct rows on the wire.
+	CHECK(msg.get<uint16_t>() == 2160);
+	CHECK(msg.get<uint32_t>() == 25);
+	CHECK(msg.getByte() == 3);
+
+	CHECK(msg.get<uint16_t>() == 2148);
+	CHECK(msg.get<uint32_t>() == 100000);
+	CHECK(msg.getByte() == 0);
+
+	CHECK(msg.get<uint16_t>() == 42);
+	CHECK(!msg.isOverrun());
+}
+
+TEST_CASE(supply_stash_serializes_empty_contents)
+{
+	NetworkMessage msg;
+	serializeContents(msg, {}, 1000);
+	rewind(msg);
+
+	CHECK(msg.get<uint16_t>() == 0);
+	CHECK(msg.get<uint16_t>() == 1000);
+	CHECK(!msg.isOverrun());
+}
+
+TFS_TEST_MAIN()

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -264,6 +264,7 @@
     <ClCompile Include="..\src\mapcache.cpp" />
     <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\stash.cpp" />
+    <ClCompile Include="..\src\supply_stash_protocol.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -384,6 +385,7 @@
     <ClInclude Include="..\src\mapcache.h" />
     <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\stash.h" />
+    <ClInclude Include="..\src\supply_stash_protocol.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -43,6 +43,7 @@
     <ClCompile Include="..\src\map.cpp" />
     <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\stash.cpp" />
+    <ClCompile Include="..\src\supply_stash_protocol.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -269,6 +270,7 @@
     <ClInclude Include="..\src\map.h" />
     <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\stash.h" />
+    <ClInclude Include="..\src\supply_stash_protocol.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />


### PR DESCRIPTION
Commit 1 of the stash port. **Protocol only** — no persistence policy, no game logic, nothing that needs a player, per your instruction. Everything here is unit-testable without a client, which is deliberate given what I cannot verify.

## Wire contract, as you froze it

```
Position  = U16 x + U16 y + U8 z
stackpos  = U8
count     = U32
```

Container positions arrive as `(0xFFFF, containerId | 0x40, slot)`, so the slot index rides in `Position.z` while `stackpos` stays its own byte — matching what the client already sends for a normal move. Nothing new invented on the wire.

Direction table documented in the header, verbatim:

```
C -> S  0x28   Supply Stash actions
S -> C  0x28   ReLogin/Death window
S -> C  0x29   Supply Stash contents
```

**Correction to what I told you earlier:** I said this rode Extended Opcode 0x32. That was wrong — you were right, it is a top-level opcode registered through `PacketHandler(0x28)` on the Lua side. I had only checked the static `parsePacket` switch and grepped `src/`, which is why I missed the Lua-side registry. The wire contract is unaffected; the header now says the right thing.

## The thing I did not expect: the renumbering is a live hazard

The old Lua uses `OPEN = 1`, `STOW_ALL = 2`, `WITHDRAW = 3`. The new enum uses `StowItem = 0`, `StowContainer = 1`, `StowStack = 2`, `Withdraw = 3`. So **1 and 2 now mean something that moves items**, and a client that has not been updated is speaking the old dialect.

I traced every old message against the new parser:

| old message | new parser |
|---|---|
| `OPEN`, 1 byte | expects 8 more → **Truncated, rejected** |
| `STOW_ALL`, 1 byte | expects 8 more → **Truncated, rejected** |
| `WITHDRAW` without tier, 6 bytes | expects 7 → **Truncated, rejected** |
| `WITHDRAW` with tier, 7 bytes | identical layout → accepted, same meaning |

So an out-of-date client is refused rather than silently misread as a stow command. **But that holds only while the length guards stay strict.** If anyone later relaxes them to be lenient about trailing or missing bytes "for compatibility", old `OPEN` becomes a container stow. Three tests pin this down so the property cannot be lost quietly.

Also worth flagging: there is deliberately no `OPEN` action, since §21 has opening come from using the stash object. That means Astra must stop sending `OPEN` and the server must push contents on object use — a Commit 2/5 coordination point, not this PR.

## Guards

Reads past the end return 0 and set the overrun flag rather than throwing, so the parser consults that flag instead of trusting the values. Rejected: truncated messages, unknown actions, `itemId == 0`, `count == 0` or above the cap, `tier > Stash::MAX_ITEM_TIER`, and trailing bytes. Caps mirror the limits the current Lua already enforces, so moving the parser to C++ does not quietly widen what a client may ask for.

20 tests: each guard, both boundaries of the count and tier caps, the three legacy-client cases above, and a tier-aware contents round trip where the same `itemId` at two tiers stays two distinct rows.

## Verification, stated honestly

- `check_source_list_parity` passed after I added the files to `vc18/theforgottenserver.vcxproj` — it caught that I had only updated `src/CMakeLists.txt`.
- `test_supply_stash_protocol` passed in CI, 20/20.

Those two facts come from **different runs**, because the run that included both hung in `test_reactor` at the 30-minute timeout before reaching test 28. That is #239, not this change — the ninth occurrence I have logged, and it is now blocking verification of new work. If you merge one thing before this, make it #239.

**Not tested, and I am not claiming otherwise:** every flow that needs a real 8.60 client. Manual checklist below.

## Manual test checklist for 8.60 / Astra

Once Commit 2 lands the stow path, these are the ones that need a client:

- [ ] 100 potions in backpack, drag 30 → backpack 70, stash shows 30 immediately, reopen 30, relog 30
- [ ] stack of 100, stow 37 → source 63, stash +37
- [ ] same itemId at tier 0 and tier 3 → two distinguishable rows; withdrawing tier 3 recreates tier 3
- [ ] backpack with valid + invalid items, container stow → only valid ones stored, invalid stay put, no crash
- [ ] imbued item, partial charges, used duration, actionid, uniqueid, text, custom attribute → each rejected, source untouched
- [ ] withdraw into a full inventory → delivery fails, quantity returns to the stash
- [ ] simulated DB failure on add and on remove → no item lost, no phantom quantity
- [ ] spam STOW and WITHDRAW → no dupe, no negative amount, no crash, cooldown holds
- [ ] malformed packets from a modified client: invalid action, count 0, huge count, truncated, invalid tier → rejected, no desync of the following opcode
- [ ] **old Astra against new server** → `OPEN` and `STOW_ALL` refused rather than acted on; this is the one I would check first on a live rollout

One more thing I noticed while reading the current Lua: it applies per-action cooldowns through `NetworkGuard.cooldown` — 300 ms default, 1000 ms for stow-all, 500 ms for withdraw. That is real anti-spam behaviour and it lives in the layer being replaced, so Commit 2 needs to carry it over rather than lose it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supply-stash request handling for storing items, storing containers, stacking items, and withdrawing items.
  * Added serialization of stash contents, including item quantities, tiers, and available storage slots.
  * Added validation for invalid actions, item IDs, quantities, tiers, truncated messages, and unexpected data.

* **Tests**
  * Added comprehensive coverage for valid requests, boundary values, malformed messages, and content serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->