### PR TITLE
feat(stash): authoritative in-memory stash state, with dirty tracking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/party.cpp
 	${CMAKE_CURRENT_LIST_DIR}/performance_metrics.cpp
 	${CMAKE_CURRENT_LIST_DIR}/player.cpp
+	${CMAKE_CURRENT_LIST_DIR}/player_stash.cpp
 	${CMAKE_CURRENT_LIST_DIR}/position.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocol.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.cpp
@@ -215,6 +216,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/party.h
 	${CMAKE_CURRENT_LIST_DIR}/performance_metrics.h
 	${CMAKE_CURRENT_LIST_DIR}/player.h
+	${CMAKE_CURRENT_LIST_DIR}/player_stash.h
 	${CMAKE_CURRENT_LIST_DIR}/position.h
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.h
 	${CMAKE_CURRENT_LIST_DIR}/protocol.h

--- a/src/player_stash.cpp
+++ b/src/player_stash.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "player_stash.h"
+
+#include <algorithm>
+#include <limits>
+
+void PlayerStash::load(uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (itemId == 0 || amount == 0) {
+		return;
+	}
+
+	rows[Key{itemId, Stash::normalizeTier(tier)}] = amount;
+}
+
+bool PlayerStash::add(uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (itemId == 0 || amount == 0) {
+		return false;
+	}
+
+	const Key key{itemId, Stash::normalizeTier(tier)};
+	const auto it = rows.find(key);
+	const uint32_t current = it != rows.end() ? it->second : 0;
+
+	// A row that does not exist yet costs one against the cap. Checked before any
+	// mutation so a rejected stow leaves the physical item where it was.
+	if (current == 0 && rows.size() >= MAX_UNIQUE_ROWS) {
+		return false;
+	}
+
+	// The column is unsigned 32-bit; wrapping here would turn a huge stash into an
+	// empty one.
+	if (amount > std::numeric_limits<uint32_t>::max() - current) {
+		return false;
+	}
+
+	rows[key] = current + amount;
+	markDirty(key);
+	return true;
+}
+
+bool PlayerStash::remove(uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (itemId == 0 || amount == 0) {
+		return false;
+	}
+
+	const Key key{itemId, Stash::normalizeTier(tier)};
+	const auto it = rows.find(key);
+	if (it == rows.end() || it->second < amount) {
+		return false;
+	}
+
+	it->second -= amount;
+	if (it->second == 0) {
+		// Drop the emptied row rather than keeping a zero, so the row cap reflects
+		// what is actually stored.
+		rows.erase(it);
+	}
+
+	markDirty(key);
+	return true;
+}
+
+uint32_t PlayerStash::getCount(uint16_t itemId, uint8_t tier) const
+{
+	const auto it = rows.find(Key{itemId, Stash::normalizeTier(tier)});
+	return it != rows.end() ? it->second : 0;
+}
+
+bool PlayerStash::wouldExceedRowLimit(uint16_t itemId, uint8_t tier) const
+{
+	if (itemId == 0) {
+		return false;
+	}
+
+	if (rows.contains(Key{itemId, Stash::normalizeTier(tier)})) {
+		return false;
+	}
+
+	return rows.size() >= MAX_UNIQUE_ROWS;
+}
+
+void PlayerStash::markDirty(const Key& key)
+{
+	modifiedRows.insert(key);
+	rowRevisions[key] = ++dirtyRevision;
+}
+
+PlayerStash::DirtySnapshot PlayerStash::getDirtySnapshot() const
+{
+	return DirtySnapshot{dirtyRevision, modifiedRows};
+}
+
+void PlayerStash::acknowledgeDirty(const DirtySnapshot& snapshot)
+{
+	for (const auto& key : snapshot.modifiedRows) {
+		const auto revisionIt = rowRevisions.find(key);
+
+		// Changed again after the snapshot was taken, so it is still dirty and the
+		// next save has to pick it up. Without this, a stow landing while the save
+		// worker ran would be acknowledged away and lost.
+		if (revisionIt != rowRevisions.end() && revisionIt->second > snapshot.snapshotId) {
+			continue;
+		}
+
+		modifiedRows.erase(key);
+		if (revisionIt != rowRevisions.end()) {
+			rowRevisions.erase(revisionIt);
+		}
+	}
+}
+
+void PlayerStash::clearDirty()
+{
+	modifiedRows.clear();
+	rowRevisions.clear();
+}
+
+std::vector<StashRecord> PlayerStash::toRecords() const
+{
+	std::vector<StashRecord> records;
+	records.reserve(rows.size());
+	for (const auto& [key, amount] : rows) {
+		records.emplace_back(StashRecord{key.itemId, key.tier, amount});
+	}
+
+	std::sort(records.begin(), records.end(), [](const StashRecord& lhs, const StashRecord& rhs) {
+		if (lhs.itemId != rhs.itemId) {
+			return lhs.itemId < rhs.itemId;
+		}
+		return lhs.tier < rhs.tier;
+	});
+	return records;
+}

--- a/src/player_stash.h
+++ b/src/player_stash.h
@@ -1,0 +1,96 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_PLAYER_STASH_H
+#define FS_PLAYER_STASH_H
+
+#include "stash.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// Authoritative in-memory Supply Stash state for one player.
+//
+// The stash is logical storage: a count per (itemId, tier), never physical items.
+// This class owns that state, is mutated on the game thread, and tracks which rows
+// changed so a save can persist just those.
+//
+// It follows the same dirty/snapshot/acknowledge discipline the storage values
+// already use, including per-row revisions. That last part is the reason this is
+// not just a map plus a bool: a row modified *after* a snapshot is taken must
+// survive the acknowledgement of that snapshot, or a mutation made while the save
+// worker was running would be silently dropped.
+//
+// Deliberately free of Player, Item and Database, so it can be tested on its own.
+class PlayerStash
+{
+public:
+	struct Key
+	{
+		uint16_t itemId = 0;
+		uint8_t tier = 0;
+
+		bool operator==(const Key& other) const noexcept
+		{
+			return itemId == other.itemId && tier == other.tier;
+		}
+	};
+
+	struct KeyHash
+	{
+		size_t operator()(const Key& key) const noexcept
+		{
+			return (static_cast<size_t>(key.itemId) << 8) ^ key.tier;
+		}
+	};
+
+	using Rows = std::unordered_map<Key, uint32_t, KeyHash>;
+	using KeySet = std::unordered_set<Key, KeyHash>;
+
+	struct DirtySnapshot
+	{
+		uint64_t snapshotId = 0;
+		KeySet modifiedRows;
+	};
+
+	// Tier is part of the row identity, so (2160, 0) and (2160, 3) are two rows
+	// against this cap, matching how the table is keyed.
+	static constexpr size_t MAX_UNIQUE_ROWS = 1000;
+
+	// Loads a row as it exists in the database. Does not mark anything dirty:
+	// nothing has changed yet at that point.
+	void load(uint16_t itemId, uint8_t tier, uint32_t amount);
+
+	// Both return false and change nothing on failure, so a caller that has
+	// already removed a physical item can roll back on a false.
+	[[nodiscard]] bool add(uint16_t itemId, uint8_t tier, uint32_t amount);
+	[[nodiscard]] bool remove(uint16_t itemId, uint8_t tier, uint32_t amount);
+
+	[[nodiscard]] uint32_t getCount(uint16_t itemId, uint8_t tier) const;
+	[[nodiscard]] const Rows& getRows() const noexcept { return rows; }
+	[[nodiscard]] size_t getUniqueRowCount() const noexcept { return rows.size(); }
+
+	// True when adding this row would introduce a new (itemId, tier) combination
+	// and the cap is already reached. Callers check before removing anything.
+	[[nodiscard]] bool wouldExceedRowLimit(uint16_t itemId, uint8_t tier) const;
+
+	[[nodiscard]] bool isDirty() const noexcept { return !modifiedRows.empty(); }
+	[[nodiscard]] DirtySnapshot getDirtySnapshot() const;
+	void acknowledgeDirty(const DirtySnapshot& snapshot);
+	void clearDirty();
+
+	// Flattened view for serialisation, sorted so the wire order is stable.
+	[[nodiscard]] std::vector<StashRecord> toRecords() const;
+
+private:
+	void markDirty(const Key& key);
+
+	Rows rows;
+	KeySet modifiedRows;
+	std::unordered_map<Key, uint64_t, KeyHash> rowRevisions;
+	uint64_t dirtyRevision = 0;
+};
+
+#endif // FS_PLAYER_STASH_H

--- a/src/tests/test_player_stash.cpp
+++ b/src/tests/test_player_stash.cpp
@@ -1,0 +1,232 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../player_stash.h"
+
+#include "test_support.h"
+
+#include <limits>
+
+TEST_CASE(player_stash_add_and_count)
+{
+	PlayerStash stash;
+
+	CHECK(stash.add(2160, 0, 30));
+	CHECK(stash.getCount(2160, 0) == 30);
+
+	CHECK(stash.add(2160, 0, 12));
+	CHECK(stash.getCount(2160, 0) == 42);
+}
+
+// Tier is part of the row identity, exactly as the table is keyed. The same
+// itemId at two tiers must never be merged into one count.
+TEST_CASE(player_stash_keeps_tiers_apart)
+{
+	PlayerStash stash;
+
+	CHECK(stash.add(2160, 0, 100));
+	CHECK(stash.add(2160, 3, 5));
+
+	CHECK(stash.getCount(2160, 0) == 100);
+	CHECK(stash.getCount(2160, 3) == 5);
+	CHECK(stash.getUniqueRowCount() == 2);
+}
+
+TEST_CASE(player_stash_remove_is_guarded)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 50));
+
+	// Asking for more than is stored must change nothing, so a caller can treat
+	// false as "nothing happened" and roll back.
+	CHECK(!stash.remove(2160, 0, 51));
+	CHECK(stash.getCount(2160, 0) == 50);
+
+	CHECK(stash.remove(2160, 0, 20));
+	CHECK(stash.getCount(2160, 0) == 30);
+}
+
+TEST_CASE(player_stash_removing_everything_drops_the_row)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.getUniqueRowCount() == 1);
+
+	CHECK(stash.remove(2160, 0, 10));
+	CHECK(stash.getCount(2160, 0) == 0);
+	// An emptied row must not keep occupying a slot against the cap.
+	CHECK(stash.getUniqueRowCount() == 0);
+}
+
+TEST_CASE(player_stash_rejects_removing_from_an_empty_stash)
+{
+	PlayerStash stash;
+	CHECK(!stash.remove(2160, 0, 1));
+}
+
+TEST_CASE(player_stash_rejects_zero_and_invalid_input)
+{
+	PlayerStash stash;
+
+	CHECK(!stash.add(0, 0, 10));
+	CHECK(!stash.add(2160, 0, 0));
+	CHECK(!stash.remove(2160, 0, 0));
+	CHECK(stash.getUniqueRowCount() == 0);
+}
+
+// The amount column is unsigned 32-bit. Wrapping would turn a nearly full stash
+// into an empty one, which is the worst possible failure mode here.
+TEST_CASE(player_stash_add_does_not_overflow)
+{
+	PlayerStash stash;
+	constexpr uint32_t max = std::numeric_limits<uint32_t>::max();
+
+	CHECK(stash.add(2160, 0, max - 5));
+	CHECK(!stash.add(2160, 0, 6));
+	CHECK(stash.getCount(2160, 0) == max - 5);
+
+	CHECK(stash.add(2160, 0, 5));
+	CHECK(stash.getCount(2160, 0) == max);
+}
+
+TEST_CASE(player_stash_enforces_the_unique_row_limit)
+{
+	PlayerStash stash;
+
+	for (uint16_t i = 0; i < PlayerStash::MAX_UNIQUE_ROWS; ++i) {
+		CHECK(stash.add(static_cast<uint16_t>(i + 1), 0, 1));
+	}
+	CHECK(stash.getUniqueRowCount() == PlayerStash::MAX_UNIQUE_ROWS);
+
+	// A brand new row is refused once the cap is reached...
+	CHECK(stash.wouldExceedRowLimit(60000, 0));
+	CHECK(!stash.add(60000, 0, 1));
+
+	// ...but topping up a row that already exists is still fine.
+	CHECK(!stash.wouldExceedRowLimit(1, 0));
+	CHECK(stash.add(1, 0, 10));
+	CHECK(stash.getCount(1, 0) == 11);
+}
+
+// A new tier of an item already held is a new row, so it counts against the cap.
+TEST_CASE(player_stash_row_limit_counts_tiers_separately)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 1));
+
+	CHECK(!stash.wouldExceedRowLimit(2160, 0));
+	CHECK(stash.wouldExceedRowLimit(2160, 1) == false); // room is available here
+	CHECK(stash.add(2160, 1, 1));
+	CHECK(stash.getUniqueRowCount() == 2);
+}
+
+TEST_CASE(player_stash_load_does_not_mark_dirty)
+{
+	PlayerStash stash;
+
+	stash.load(2160, 0, 500);
+	stash.load(2148, 2, 25);
+
+	CHECK(stash.getCount(2160, 0) == 500);
+	CHECK(stash.getCount(2148, 2) == 25);
+	// Loading is what the database already holds, so there is nothing to save.
+	CHECK(!stash.isDirty());
+}
+
+TEST_CASE(player_stash_mutations_mark_dirty)
+{
+	PlayerStash stash;
+	CHECK(!stash.isDirty());
+
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.isDirty());
+
+	stash.clearDirty();
+	CHECK(!stash.isDirty());
+
+	CHECK(stash.remove(2160, 0, 1));
+	CHECK(stash.isDirty());
+}
+
+TEST_CASE(player_stash_failed_mutations_do_not_mark_dirty)
+{
+	PlayerStash stash;
+	stash.load(2160, 0, 5);
+
+	CHECK(!stash.remove(2160, 0, 6));
+	CHECK(!stash.add(0, 0, 1));
+	CHECK(!stash.isDirty());
+}
+
+TEST_CASE(player_stash_acknowledge_clears_only_what_was_saved)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.add(2148, 0, 20));
+
+	const auto snapshot = stash.getDirtySnapshot();
+	CHECK(snapshot.modifiedRows.size() == 2);
+
+	stash.acknowledgeDirty(snapshot);
+	CHECK(!stash.isDirty());
+}
+
+// The reason this class tracks per-row revisions at all: a stow landing while the
+// save worker is running must not be acknowledged away by that save.
+TEST_CASE(player_stash_keeps_rows_changed_after_the_snapshot)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.add(2148, 0, 20));
+
+	const auto snapshot = stash.getDirtySnapshot();
+
+	// The save is in flight; the player stows more of 2160.
+	CHECK(stash.add(2160, 0, 5));
+
+	stash.acknowledgeDirty(snapshot);
+
+	// 2148 was written and is clean; 2160 changed afterwards and is still pending.
+	CHECK(stash.isDirty());
+	const auto pending = stash.getDirtySnapshot();
+	CHECK(pending.modifiedRows.size() == 1);
+	CHECK(pending.modifiedRows.contains(PlayerStash::Key{2160, 0}));
+	CHECK(stash.getCount(2160, 0) == 15);
+}
+
+TEST_CASE(player_stash_records_are_sorted_and_tier_aware)
+{
+	PlayerStash stash;
+	stash.load(2160, 3, 25);
+	stash.load(2148, 0, 100);
+	stash.load(2160, 0, 500);
+
+	const auto records = stash.toRecords();
+
+	CHECK(records.size() == 3);
+	CHECK(records[0].itemId == 2148);
+	CHECK(records[0].amount == 100);
+
+	CHECK(records[1].itemId == 2160);
+	CHECK(records[1].tier == 0);
+	CHECK(records[1].amount == 500);
+
+	CHECK(records[2].itemId == 2160);
+	CHECK(records[2].tier == 3);
+	CHECK(records[2].amount == 25);
+}
+
+TEST_CASE(player_stash_normalizes_tier_consistently)
+{
+	PlayerStash stash;
+
+	// Above the maximum clamps, and must clamp the same way on read as on write,
+	// otherwise a stow and its withdraw would address different rows.
+	CHECK(stash.add(2160, Stash::MAX_ITEM_TIER + 5, 7));
+	CHECK(stash.getCount(2160, Stash::MAX_ITEM_TIER) == 7);
+	CHECK(stash.getUniqueRowCount() == 1);
+}
+
+TFS_TEST_MAIN()

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -284,6 +284,7 @@
     <ClCompile Include="..\src\party.cpp" />
     <ClCompile Include="..\src\performance_metrics.cpp" />
     <ClCompile Include="..\src\player.cpp" />
+    <ClCompile Include="..\src\player_stash.cpp" />
     <ClCompile Include="..\src\position.cpp" />
     <ClCompile Include="..\src\protocol.cpp" />
     <ClCompile Include="..\src\protocolgame.cpp" />
@@ -400,6 +401,7 @@
     <ClInclude Include="..\src\party.h" />
     <ClInclude Include="..\src\performance_metrics.h" />
     <ClInclude Include="..\src\player.h" />
+    <ClInclude Include="..\src\player_stash.h" />
     <ClInclude Include="..\src\position.h" />
     <ClInclude Include="..\src\protocol.h" />
     <ClInclude Include="..\src\protocolgame.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -55,6 +55,7 @@
     <ClCompile Include="..\src\outputmessage.cpp" />
     <ClCompile Include="..\src\party.cpp" />
     <ClCompile Include="..\src\player.cpp" />
+    <ClCompile Include="..\src\player_stash.cpp" />
     <ClCompile Include="..\src\position.cpp" />
     <ClCompile Include="..\src\protocol.cpp" />
     <ClCompile Include="..\src\protocolgame.cpp" />
@@ -283,6 +284,7 @@
     <ClInclude Include="..\src\packet_backlog.h" />
     <ClInclude Include="..\src\party.h" />
     <ClInclude Include="..\src\player.h" />
+    <ClInclude Include="..\src\player_stash.h" />
     <ClInclude Include="..\src\position.h" />
     <ClInclude Include="..\src\protocol.h" />
     <ClInclude Include="..\src\protocolgame.h" />


### PR DESCRIPTION
Groundwork for Commit 2, following your persistence decision. **No database access, no protocol, no `Player` wiring yet** — just the state the stash needs to own, deliberately built so it can be tested standalone.

Independent of #246; the two do not touch each other.

## What this is

The stash is logical storage: a count per `(itemId, tier)`, never physical items. This class owns that state, is mutated on the game thread, and records which rows changed so a later save can persist just those — instead of a synchronous SQL round trip per drag.

It follows the discipline `setStorageValue` already uses, **including per-row revisions**. That part is not decoration:

```cpp
// save worker is running with a snapshot in hand
const auto snapshot = stash.getDirtySnapshot();
CHECK(stash.add(2160, 0, 5));      // player stows more, mid-flight
stash.acknowledgeDirty(snapshot);

CHECK(stash.isDirty());            // 2160 is still pending, not acknowledged away
```

Without the revision check, that stow would be marked clean by a save that never contained it, and silently lost at logout. There is a test for exactly that case.

## Guards carried over

These are the invariants the spec asks for and the current Lua enforces, so nothing is quietly relaxed by moving into C++:

| guard | why |
|---|---|
| unique-row cap, tier counted as identity | checked **before** any mutation, so a rejected stow leaves the physical item where it was |
| `uint32` overflow on add | the column is unsigned 32-bit; wrapping would turn a nearly full stash into an empty one |
| remove refuses to exceed what is stored | returns false and changes nothing, so a caller can treat false as "roll back" |
| emptied rows are dropped, not kept at zero | otherwise a spent row keeps occupying a slot against the cap |
| tier normalised identically on read and write | otherwise a stow and its withdraw address different rows |

`load()` deliberately does **not** mark dirty — it reflects what the database already holds, so there is nothing to save.

## Verification

**31/31 tests pass**, `test_player_stash` among them. 17 tests here covering each guard, both boundaries of the overflow and row-limit cases, tier separation, and the mid-flight snapshot case above.

Registered in `src/CMakeLists.txt`, `vc18/theforgottenserver.vcxproj` and the `.filters` — `check_source_list_parity` caught me forgetting the MSVC project on the previous PR.

## What is deliberately not here

- No `Player` member, no login load, no hook into `buildPlayerSave`/`flushPlayerSave`. That is the next step and it is where the design decisions actually bite — in particular whether the stash rows join the same transaction as inventory and depot, which you said you wanted.
- No `canStowSupplyItem` eligibility logic yet.
- Nothing that needs a client, so nothing here is in the untested bucket.

If the shape looks right I will wire it into `Player` and the save path next, and keep the eligibility rules as their own commit after that.
