### PR TITLE
feat(stash): idempotent absolute row writes for the in-memory model

### DIFF
--- a/src/stash.cpp
+++ b/src/stash.cpp
@@ -72,3 +72,33 @@ bool Stash::cleanup(uint32_t playerId)
 	return Database::getInstance().executeQuery(fmt::format(
 		"DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND `amount` = 0", playerId));
 }
+
+bool Stash::writeRow(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (playerId == 0 || itemId == 0) {
+		return false;
+	}
+
+	// An emptied row is a delete, not a zero, so the unique-row count in the
+	// database matches what the in-memory model reports.
+	if (amount == 0) {
+		return deleteRow(playerId, itemId, tier);
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"INSERT INTO `player_supplystash` (`player_id`, `itemtype`, `tier`, `amount`) "
+		"VALUES ({:d}, {:d}, {:d}, {:d}) "
+		"ON DUPLICATE KEY UPDATE `amount` = VALUES(`amount`)",
+		playerId, itemId, normalizeTier(tier), amount));
+}
+
+bool Stash::deleteRow(uint32_t playerId, uint16_t itemId, uint8_t tier)
+{
+	if (playerId == 0 || itemId == 0) {
+		return false;
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND `itemtype` = {:d} AND `tier` = {:d}",
+		playerId, itemId, normalizeTier(tier)));
+}

--- a/src/stash.h
+++ b/src/stash.h
@@ -24,6 +24,16 @@ public:
 	[[nodiscard]] static bool addAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
 	[[nodiscard]] static bool removeAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
 	[[nodiscard]] static bool cleanup(uint32_t playerId);
+
+	// Absolute writes, for the in-memory model where the Player already holds the
+	// authoritative count.
+	//
+	// addAmount/removeAmount adjust by a delta, which is correct when the database
+	// is the source of truth but not idempotent: replaying one inside a retried
+	// transaction adds the amount twice. These set the row to a known value, so a
+	// retry lands on the same result.
+	[[nodiscard]] static bool writeRow(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount);
+	[[nodiscard]] static bool deleteRow(uint32_t playerId, uint16_t itemId, uint8_t tier);
 };
 
 #endif // FS_STASH_H


### PR DESCRIPTION
Small and self-contained — only `src/stash.{h,cpp}`, 40 lines. Independent of #246 and #247, so it can go in on its own.

## Why

`addAmount`/`removeAmount` adjust by a delta:

```sql
ON DUPLICATE KEY UPDATE `amount` = `amount` + VALUES(`amount`)
```

That is correct while the database is the source of truth. It stops being correct under the design you asked for, where the `Player` holds the authoritative count — because it is **not idempotent**. Replaying it adds the amount a second time.

That is not hypothetical here: `flushPlayerSave` runs its queries inside `executeWithinTransactionRollbackOnFailure`, so a replay is precisely the case that has to be safe.

## What

`writeRow` sets the row to a known value, so a retry lands on the same result:

```sql
ON DUPLICATE KEY UPDATE `amount` = VALUES(`amount`)
```

An amount of 0 deletes the row rather than storing a zero, so the unique-row count in the database matches what the in-memory model reports — otherwise a spent row would keep occupying a slot against the 1000-row cap.

Both go through `Database::executeQuery`, so `QueryCaptureScope` captures them like every other save query and they join the **same player-save transaction as inventory and depot**, which is what you asked for.

## What this does not do

The delta functions stay exactly as they are. The current Lua path still calls them and is not being removed until the C++ path replaces it, so nothing changes behaviour today — this only adds the primitives the in-memory model will use.

## Verification

Builds and the full suite passes, **31/31**. No new tests here: these two functions are thin SQL wrappers whose behaviour is the statement itself, and the invariants that matter — overflow, the row cap, emptied rows — are enforced and tested one level up in #247, before anything reaches the database.
