### PR TITLE
feat(stash): Supply Stash port — protocol, in-memory state, persistence, eligibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/party.cpp
 	${CMAKE_CURRENT_LIST_DIR}/performance_metrics.cpp
 	${CMAKE_CURRENT_LIST_DIR}/player.cpp
+	${CMAKE_CURRENT_LIST_DIR}/player_stash.cpp
 	${CMAKE_CURRENT_LIST_DIR}/position.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocol.cpp
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.cpp
@@ -217,6 +218,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/party.h
 	${CMAKE_CURRENT_LIST_DIR}/performance_metrics.h
 	${CMAKE_CURRENT_LIST_DIR}/player.h
+	${CMAKE_CURRENT_LIST_DIR}/player_stash.h
 	${CMAKE_CURRENT_LIST_DIR}/position.h
 	${CMAKE_CURRENT_LIST_DIR}/protocolgame.h
 	${CMAKE_CURRENT_LIST_DIR}/protocol.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/market.cpp
 	${CMAKE_CURRENT_LIST_DIR}/stash.cpp
 	${CMAKE_CURRENT_LIST_DIR}/supply_stash_protocol.cpp
+	${CMAKE_CURRENT_LIST_DIR}/supply_stash_rules.cpp
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monster.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
@@ -204,6 +205,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/market.h
 	${CMAKE_CURRENT_LIST_DIR}/stash.h
 	${CMAKE_CURRENT_LIST_DIR}/supply_stash_protocol.h
+	${CMAKE_CURRENT_LIST_DIR}/supply_stash_rules.h
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.h
 	${CMAKE_CURRENT_LIST_DIR}/monster.h
 	${CMAKE_CURRENT_LIST_DIR}/monsters.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.cpp
 	${CMAKE_CURRENT_LIST_DIR}/market.cpp
 	${CMAKE_CURRENT_LIST_DIR}/stash.cpp
+	${CMAKE_CURRENT_LIST_DIR}/supply_stash_protocol.cpp
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monster.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
@@ -201,6 +202,7 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/mapcache.h
 	${CMAKE_CURRENT_LIST_DIR}/market.h
 	${CMAKE_CURRENT_LIST_DIR}/stash.h
+	${CMAKE_CURRENT_LIST_DIR}/supply_stash_protocol.h
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.h
 	${CMAKE_CURRENT_LIST_DIR}/monster.h
 	${CMAKE_CURRENT_LIST_DIR}/monsters.h

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2014,6 +2014,120 @@ void Game::playerStowContainer(uint32_t playerId, const Position& pos, uint16_t 
 	}
 }
 
+void Game::playerStowStack(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos)
+{
+	const auto player = getPlayerByID(playerId);
+	if (!player || player->isRemoved()) {
+		return;
+	}
+
+	if (!tfs::supply_stash::hasSupplyStashAccess(player.get())) {
+		player->sendCancelMessage("You need to be near a depot to use the supply stash.");
+		return;
+	}
+
+	// Resolve the named item only to learn which type the player meant. Everything
+	// stowed afterwards is found by walking the player's own inventory, never by
+	// trusting a position the client supplied for each one.
+	uint8_t fromIndex = 0;
+	if (pos.x == 0xFFFF) {
+		fromIndex = (pos.y & 0x40) ? static_cast<uint8_t>(pos.z) : static_cast<uint8_t>(pos.y);
+	} else {
+		fromIndex = stackpos;
+	}
+
+	Thing* thing = internalGetThing(player.get(), pos, fromIndex, 0, STACKPOS_MOVE);
+	if (!thing) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	Item* named = thing->getItem();
+	if (!named || named->getClientID() != spriteId) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	if (!tfs::supply_stash::canStowSupplyItem(named)) {
+		player->sendCancelMessage("You cannot stow this item.");
+		return;
+	}
+
+	const uint16_t wantedId = named->getID();
+	const uint8_t wantedTier = named->getTier();
+
+	// Phase one: collect every matching item the player carries, without touching
+	// anything. Scoped to the player's own inventory and containers, so this cannot
+	// reach items lying on the map.
+	struct StowEntry
+	{
+		std::shared_ptr<Item> item;
+		uint32_t count;
+	};
+	std::vector<StowEntry> planned;
+
+	const auto collect = [&](Item* candidate) {
+		if (!candidate || candidate->getID() != wantedId || candidate->getTier() != wantedTier) {
+			return;
+		}
+		if (!tfs::supply_stash::canStowSupplyItem(candidate)) {
+			return;
+		}
+		const uint32_t amount = candidate->isStackable() ? candidate->getItemCount() : 1;
+		if (amount > 0) {
+			planned.push_back(StowEntry{candidate->shared_from_this(), amount});
+		}
+	};
+
+	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
+		Item* inventoryItem = player->getInventoryItem(static_cast<slots_t>(slot));
+		if (!inventoryItem) {
+			continue;
+		}
+
+		if (Container* container = inventoryItem->getContainer()) {
+			auto iterator = container->iterator();
+			while (iterator.hasNext()) {
+				collect(*iterator);
+				iterator.advance();
+			}
+			continue;
+		}
+
+		collect(inventoryItem);
+	}
+
+	if (planned.empty()) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	auto& stash = player->getSupplyStash();
+	if (stash.wouldExceedRowLimit(wantedId, wantedTier)) {
+		player->sendCancelMessage("Your supply stash cannot hold any more different items.");
+		return;
+	}
+
+	// Phase two: execute, each entry rolling back on its own.
+	uint32_t stowed = 0;
+	for (const auto& entry : planned) {
+		if (!stash.add(wantedId, wantedTier, entry.count)) {
+			continue;
+		}
+
+		if (internalRemoveItem(entry.item.get(), static_cast<int32_t>(entry.count)) != RETURNVALUE_NOERROR) {
+			[[maybe_unused]] const bool rolledBack = stash.remove(wantedId, wantedTier, entry.count);
+			continue;
+		}
+
+		++stowed;
+	}
+
+	if (stowed == 0) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+	}
+}
+
 void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
                           const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder)
 {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1830,8 +1830,27 @@ void Game::playerStowItem(uint32_t playerId, const Position& pos, uint16_t sprit
 		return;
 	}
 
-	// An item lying on the map has to be within arm's reach and on the same floor.
-	// Items already carried are reachable by definition.
+	// Token security: the same rule playerMoveItem applies. Without it the stash
+	// would be a way to move protected items out while protection is on.
+	if (player->isTokenProtected()) {
+		bool fromPlayer = false;
+		for (Cylinder* current = fromCylinder; current; current = current->getParent()) {
+			if (current == player.get()) {
+				fromPlayer = true;
+				break;
+			}
+		}
+
+		if (fromPlayer && !player->canMoveOwnItems(item)) {
+			player->sendTextMessage(MESSAGE_EVENT_ADVANCE,
+			                        "[TOKEN]: To move your items out, disable token security!");
+			player->sendCancelMessage(RETURNVALUE_ITEMSTOKENPROTECTED);
+			return;
+		}
+	}
+
+	// An item lying on the map has to be within arm's reach, on the same floor, and
+	// actually visible. Items already carried are reachable by definition.
 	if (pos.x != 0xFFFF) {
 		const Position& playerPos = player->getPosition();
 		if (playerPos.z != pos.z) {
@@ -1841,6 +1860,11 @@ void Game::playerStowItem(uint32_t playerId, const Position& pos, uint16_t sprit
 		}
 		if (!playerPos.isInRange(pos, 1, 1)) {
 			player->sendCancelMessage(RETURNVALUE_TOOFARAWAY);
+			return;
+		}
+		// Range alone would let an item be taken through a wall one tile away.
+		if (!canThrowObjectTo(playerPos, pos, true, true)) {
+			player->sendCancelMessage(RETURNVALUE_CANNOTTHROW);
 			return;
 		}
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1839,7 +1839,7 @@ void Game::playerStowItem(uint32_t playerId, const Position& pos, uint16_t sprit
 			                                              : RETURNVALUE_FIRSTGODOWNSTAIRS);
 			return;
 		}
-		if (!Position::areInRange<1, 1>(playerPos, pos)) {
+		if (!playerPos.isInRange(pos, 1, 1)) {
 			player->sendCancelMessage(RETURNVALUE_TOOFARAWAY);
 			return;
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1909,6 +1909,111 @@ void Game::playerStowItem(uint32_t playerId, const Position& pos, uint16_t sprit
 	}
 }
 
+void Game::playerStowContainer(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos)
+{
+	const auto player = getPlayerByID(playerId);
+	if (!player || player->isRemoved()) {
+		return;
+	}
+
+	if (!tfs::supply_stash::hasSupplyStashAccess(player.get())) {
+		player->sendCancelMessage("You need to be near a depot to use the supply stash.");
+		return;
+	}
+
+	uint8_t fromIndex = 0;
+	if (pos.x == 0xFFFF) {
+		fromIndex = (pos.y & 0x40) ? static_cast<uint8_t>(pos.z) : static_cast<uint8_t>(pos.y);
+	} else {
+		fromIndex = stackpos;
+	}
+
+	Thing* thing = internalGetThing(player.get(), pos, fromIndex, 0, STACKPOS_MOVE);
+	if (!thing) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	Item* item = thing->getItem();
+	if (!item || item->getClientID() != spriteId) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	Container* container = item->getContainer();
+	if (!container) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	// Phase one: decide. Nothing is mutated here, because removing while walking
+	// the container would invalidate the iterator underneath us.
+	struct StowEntry
+	{
+		std::shared_ptr<Item> item;
+		uint16_t itemId;
+		uint8_t tier;
+		uint32_t count;
+	};
+	std::vector<StowEntry> planned;
+
+	auto& stash = player->getSupplyStash();
+	auto iterator = container->iterator();
+	while (iterator.hasNext()) {
+		Item* candidate = *iterator;
+		iterator.advance();
+
+		// The container itself is never stored, and a nested one is skipped rather
+		// than flattened away — its contents are reached by the iterator anyway.
+		if (!candidate || candidate->getContainer()) {
+			continue;
+		}
+
+		if (!tfs::supply_stash::canStowSupplyItem(candidate)) {
+			continue;
+		}
+
+		const uint16_t candidateId = candidate->getID();
+		const uint8_t candidateTier = candidate->getTier();
+		if (stash.wouldExceedRowLimit(candidateId, candidateTier)) {
+			continue;
+		}
+
+		const uint32_t amount = candidate->isStackable() ? candidate->getItemCount() : 1;
+		if (amount == 0) {
+			continue;
+		}
+
+		planned.push_back(StowEntry{candidate->shared_from_this(), candidateId, candidateTier, amount});
+	}
+
+	if (planned.empty()) {
+		player->sendCancelMessage("There is nothing in there that can be stowed.");
+		return;
+	}
+
+	// Phase two: execute. Each entry rolls back on its own, so one failure leaves
+	// the rest of the batch intact rather than aborting halfway with items already
+	// counted twice.
+	uint32_t stowed = 0;
+	for (const auto& entry : planned) {
+		if (!stash.add(entry.itemId, entry.tier, entry.count)) {
+			continue;
+		}
+
+		if (internalRemoveItem(entry.item.get(), static_cast<int32_t>(entry.count)) != RETURNVALUE_NOERROR) {
+			[[maybe_unused]] const bool rolledBack = stash.remove(entry.itemId, entry.tier, entry.count);
+			continue;
+		}
+
+		++stowed;
+	}
+
+	if (stowed == 0) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+	}
+}
+
 void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
                           const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder)
 {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1808,6 +1808,43 @@ void Game::playerStowItem(uint32_t playerId, const Position& pos, uint16_t sprit
 		return;
 	}
 
+	// Access to the stash service is not access to the item. Without these a
+	// modified client could name a position it has no business reaching and stow
+	// whatever internalGetThing resolves there. Same checks playerMoveItem applies.
+	if (item->getTopParent() == player.get()) {
+		item->setInstanceID(0);
+	}
+	if (!InstanceUtils::isPlayerInSameInstance(player.get(), item->getInstanceID())) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	if (hasNotMoveableActionId(*item)) {
+		player->sendCancelMessage(RETURNVALUE_NOTMOVEABLE);
+		return;
+	}
+
+	Cylinder* fromCylinder = internalGetCylinder(player.get(), pos);
+	if (!fromCylinder) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	// An item lying on the map has to be within arm's reach and on the same floor.
+	// Items already carried are reachable by definition.
+	if (pos.x != 0xFFFF) {
+		const Position& playerPos = player->getPosition();
+		if (playerPos.z != pos.z) {
+			player->sendCancelMessage(playerPos.z > pos.z ? RETURNVALUE_FIRSTGOUPSTAIRS
+			                                              : RETURNVALUE_FIRSTGODOWNSTAIRS);
+			return;
+		}
+		if (!Position::areInRange<1, 1>(playerPos, pos)) {
+			player->sendCancelMessage(RETURNVALUE_TOOFARAWAY);
+			return;
+		}
+	}
+
 	if (!tfs::supply_stash::canStowSupplyItem(item)) {
 		player->sendCancelMessage("You cannot stow this item.");
 		return;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5,6 +5,8 @@
 
 #include "game.h"
 
+#include "supply_stash_rules.h"
+
 #include "actions.h"
 #include "bed.h"
 #include "character_bazaar.h"
@@ -1762,6 +1764,88 @@ void Game::playerMoveItemByPlayerID(uint32_t playerId, const Position& fromPos, 
 		return;
 	}
 	playerMoveItem(player, fromPos, spriteId, fromStackPos, toPos, count, nullptr, nullptr);
+}
+
+void Game::playerStowItem(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count)
+{
+	const auto player = getPlayerByID(playerId);
+	if (!player || player->isRemoved()) {
+		return;
+	}
+
+	// Re-checked on every action rather than trusted from when the window opened:
+	// the player may have walked away, and a modified client can ask from anywhere.
+	if (!tfs::supply_stash::hasSupplyStashAccess(player.get())) {
+		player->sendCancelMessage("You need to be near a depot to use the supply stash.");
+		return;
+	}
+
+	// Resolve the real item from the position, the same way playerMoveItem does.
+	// The itemId the client sent is only used to confirm this resolution below.
+	uint8_t fromIndex = 0;
+	if (pos.x == 0xFFFF) {
+		fromIndex = (pos.y & 0x40) ? static_cast<uint8_t>(pos.z) : static_cast<uint8_t>(pos.y);
+	} else {
+		fromIndex = stackpos;
+	}
+
+	Thing* thing = internalGetThing(player.get(), pos, fromIndex, 0, STACKPOS_MOVE);
+	if (!thing) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	Item* item = thing->getItem();
+	if (!item) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	// The client names what it thinks it dragged. A mismatch means the world moved
+	// under it, so refuse rather than stow whatever happens to be there now.
+	if (item->getClientID() != spriteId) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	if (!tfs::supply_stash::canStowSupplyItem(item)) {
+		player->sendCancelMessage("You cannot stow this item.");
+		return;
+	}
+
+	// Only the count survives, so clamp to what is actually there. A client asking
+	// for more than the stack holds must not create the difference.
+	const uint32_t available = item->isStackable() ? item->getItemCount() : 1;
+	const uint32_t amount = std::min<uint32_t>(count, available);
+	if (amount == 0) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	const uint16_t itemId = item->getID();
+	const uint8_t tier = item->getTier();
+
+	auto& stash = player->getSupplyStash();
+	if (stash.wouldExceedRowLimit(itemId, tier)) {
+		player->sendCancelMessage("Your supply stash cannot hold any more different items.");
+		return;
+	}
+
+	// Add first, remove second. If the removal fails the add is undone, so the
+	// worst case is a no-op rather than an item that exists in both places or in
+	// neither.
+	if (!stash.add(itemId, tier, amount)) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	if (internalRemoveItem(item, static_cast<int32_t>(amount)) != RETURNVALUE_NOERROR) {
+		// Roll back the logical count. remove() only fails when the row holds less
+		// than asked, which cannot happen for an amount just added.
+		[[maybe_unused]] const bool rolledBack = stash.remove(itemId, tier, amount);
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
 }
 
 void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2128,6 +2128,79 @@ void Game::playerStowStack(uint32_t playerId, const Position& pos, uint16_t spri
 	}
 }
 
+void Game::playerStashWithdraw(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	const auto player = getPlayerByID(playerId);
+	if (!player || player->isRemoved()) {
+		return;
+	}
+
+	if (!tfs::supply_stash::hasSupplyStashAccess(player.get())) {
+		player->sendCancelMessage("You need to be near a depot to use the supply stash.");
+		return;
+	}
+
+	if (itemId == 0 || amount == 0 || tier > Stash::MAX_ITEM_TIER) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	const ItemType& type = Item::items[itemId];
+	if (type.id == 0) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		return;
+	}
+
+	// Non-stackables come out one object at a time, so the cap is much lower —
+	// the same split the Lua makes. Without it a single request could try to
+	// create a hundred thousand separate items.
+	const uint32_t cap = type.stackable ? 100'000u : 100u;
+	const uint32_t wanted = std::min<uint32_t>(amount, cap);
+
+	auto& stash = player->getSupplyStash();
+	// Taken from the logical count first. remove() refuses to go below zero, so a
+	// request for more than is stored fails here rather than half-way through
+	// handing items over.
+	if (!stash.remove(itemId, tier, wanted)) {
+		player->sendCancelMessage("You do not have that many stored.");
+		return;
+	}
+
+	const uint32_t stackSize = type.stackable ? std::max<uint32_t>(1, Item::items[itemId].stackSize) : 1;
+	uint32_t remaining = wanted;
+	uint32_t delivered = 0;
+
+	while (remaining > 0) {
+		const uint32_t chunk = std::min(remaining, stackSize);
+		auto created = Item::CreateItem(itemId, static_cast<uint16_t>(chunk));
+		if (!created) {
+			break;
+		}
+
+		if (tier > 0) {
+			created->setTier(tier);
+		}
+
+		// dropOnMap so a full inventory does not silently swallow the withdrawal.
+		if (internalPlayerAddItem(player.get(), created.get(), true) != RETURNVALUE_NOERROR) {
+			break;
+		}
+
+		delivered += chunk;
+		remaining -= chunk;
+	}
+
+	// Whatever could not be handed over goes back, so the count never disappears
+	// between the stash and the player.
+	if (remaining > 0) {
+		[[maybe_unused]] const bool refunded = stash.add(itemId, tier, remaining);
+	}
+
+	if (delivered == 0) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+	}
+}
+
 void Game::playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
                           const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder)
 {

--- a/src/game.h
+++ b/src/game.h
@@ -402,6 +402,7 @@ public:
 	// never to pick the item.
 	void playerStowItem(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count);
 	void playerStowContainer(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos);
+	void playerStowStack(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos);
 
 	void playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                    const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder);

--- a/src/game.h
+++ b/src/game.h
@@ -403,6 +403,7 @@ public:
 	void playerStowItem(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count);
 	void playerStowContainer(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos);
 	void playerStowStack(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos);
+	void playerStashWithdraw(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount);
 
 	void playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                    const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder);

--- a/src/game.h
+++ b/src/game.h
@@ -397,6 +397,11 @@ public:
 	                        Tile* toTile);
 	void playerMoveItemByPlayerID(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                              const Position& toPos, uint8_t count);
+	// Supply Stash. The item is resolved server-side from the position the client
+	// sent; the itemId in the packet is only ever used to confirm the resolution,
+	// never to pick the item.
+	void playerStowItem(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count);
+
 	void playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                    const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder);
 	void playerMove(uint32_t playerId, Direction direction);

--- a/src/game.h
+++ b/src/game.h
@@ -401,6 +401,7 @@ public:
 	// sent; the itemId in the packet is only ever used to confirm the resolution,
 	// never to pick the item.
 	void playerStowItem(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count);
+	void playerStowContainer(uint32_t playerId, const Position& pos, uint16_t spriteId, uint8_t stackpos);
 
 	void playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                    const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder);

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -6,6 +6,8 @@
 
 #include "iologindata.h"
 
+#include "stash.h"
+
 #include "character_bazaar.h"
 #include "configmanager.h"
 #include "stats.h"
@@ -911,6 +913,14 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result, bool deferWorl
 		} while (result->next());
 	}
 	player->clearBestiaryDirty();
+
+	// Supply Stash rows become authoritative in memory for as long as the player is
+	// online. Loaded here rather than read per action, and deliberately not marked
+	// dirty: this is exactly what the database already holds.
+	for (const auto& row : Stash::getRows(player->getGUID())) {
+		player->loadSupplyStashRow(row.itemId, row.tier, row.amount);
+	}
+	player->clearSupplyStashDirty();
 	if ((result = db.storeQuery(fmt::format(
 	         "SELECT `points` FROM `player_bosstiary` WHERE `player_id` = {:d}", player->getGUID())))) {
 		player->bosstiaryPoints = result->getNumber<uint32_t>("points");
@@ -1063,10 +1073,11 @@ std::optional<IOLoginData::PlayerSaveSnapshot> IOLoginData::buildPlayerSave(Play
 
 	const Player::StorageDirtySnapshot storageSnapshot = player->getStorageDirtySnapshot();
 	const Player::BestiaryDirtySnapshot bestiarySnapshot = player->getBestiaryDirtySnapshot();
+	const PlayerStash::DirtySnapshot stashSnapshot = player->getSupplyStashDirtySnapshot();
 	std::vector<std::string> queries;
 	try {
 		QueryCaptureScope capture{queries};
-		if (!savePlayerQueries(player, bestiarySnapshot)) {
+		if (!savePlayerQueries(player, bestiarySnapshot, stashSnapshot)) {
 			return std::nullopt;
 		}
 	} catch (const std::exception& e) {
@@ -1080,7 +1091,9 @@ std::optional<IOLoginData::PlayerSaveSnapshot> IOLoginData::buildPlayerSave(Play
 		storageSnapshot.modifiedKeys,
 		storageSnapshot.removedKeys,
 		bestiarySnapshot.snapshotId,
-		bestiarySnapshot.modifiedRaceIds
+		bestiarySnapshot.modifiedRaceIds,
+		stashSnapshot.snapshotId,
+		stashSnapshot.modifiedRows
 	};
 }
 
@@ -1115,11 +1128,16 @@ bool IOLoginData::savePlayer(Player* player)
 			queries->bestiarySnapshotId,
 			queries->snapshotModifiedBestiaryRaceIds
 		});
+		player->acknowledgeSupplyStashDirty(PlayerStash::DirtySnapshot{
+			queries->stashSnapshotId,
+			queries->snapshotModifiedStashRows
+		});
 	}
 	return success;
 }
 
-bool IOLoginData::savePlayerQueries(Player* player, const Player::BestiaryDirtySnapshot& bestiarySnapshot)
+bool IOLoginData::savePlayerQueries(Player* player, const Player::BestiaryDirtySnapshot& bestiarySnapshot,
+                                    const PlayerStash::DirtySnapshot& stashSnapshot)
 {
 	AutoStat stat("savePlayer", "full");
 
@@ -1494,6 +1512,46 @@ bool IOLoginData::savePlayerQueries(Player* player, const Player::BestiaryDirtyS
 			}
 		}
 		if (!bestiaryQuery.execute()) {
+			return false;
+		}
+	}
+
+	// Supply Stash, same captured transaction. The Player holds the authoritative
+	// count, so rows are written absolutely rather than by a delta: these queries
+	// run inside executeWithinTransactionRollbackOnFailure, and a replayed delta
+	// would add the amount twice.
+	if (!stashSnapshot.modifiedRows.empty()) {
+		const auto& stash = player->getSupplyStash();
+		DBInsert stashQuery(
+		    "INSERT INTO `player_supplystash` (`player_id`, `itemtype`, `tier`, `amount`) VALUES ");
+		stashQuery.upsert(std::vector<std::string>{"amount"});
+
+		std::string emptied;
+		for (const auto& key : stashSnapshot.modifiedRows) {
+			const uint32_t amount = stash.getCount(key.itemId, key.tier);
+			if (amount == 0) {
+				// Emptied rows are deleted, not stored as zero, so the row count in
+				// the database matches what the in-memory model reports.
+				if (!emptied.empty()) {
+					emptied += " OR ";
+				}
+				emptied += fmt::format("(`itemtype` = {:d} AND `tier` = {:d})", key.itemId, key.tier);
+				continue;
+			}
+
+			if (!stashQuery.addRow(
+			        fmt::format("{:d}, {:d}, {:d}, {:d}", player->getGUID(), key.itemId, key.tier, amount))) {
+				return false;
+			}
+		}
+
+		if (!stashQuery.execute()) {
+			return false;
+		}
+
+		if (!emptied.empty() &&
+		    !db.executeQuery(fmt::format("DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND ({:s})",
+		                                 player->getGUID(), emptied))) {
 			return false;
 		}
 	}

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -60,6 +60,8 @@ public:
 		std::unordered_set<uint32_t> snapshotRemovedKeys;
 		uint64_t bestiarySnapshotId = 0;
 		std::unordered_set<uint16_t> snapshotModifiedBestiaryRaceIds;
+		uint64_t stashSnapshotId = 0;
+		PlayerStash::KeySet snapshotModifiedStashRows;
 	};
 	static std::optional<PlayerSaveSnapshot> buildPlayerSave(Player* player);
 	static bool flushPlayerSave(const PlayerSaveSnapshot& snapshot);
@@ -103,7 +105,8 @@ private:
 	static void cleanupItemMap(ItemMap& itemMap);
 	static void loadPlayerGuild(Player* player);
 	static bool savePlayer(Player* player);
-	static bool savePlayerQueries(Player* player, const Player::BestiaryDirtySnapshot& bestiarySnapshot);
+	static bool savePlayerQueries(Player* player, const Player::BestiaryDirtySnapshot& bestiarySnapshot,
+	                              const PlayerStash::DirtySnapshot& stashSnapshot);
 	static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert,
 	                      PropWriteStream& propWriteStream);
 };

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -8,6 +8,7 @@
 #include "database.h"
 #include "observer_ptr.h"
 #include "player.h"
+#include "player_stash.h"
 #include <optional>
 #include <unordered_set>
 #include <vector>

--- a/src/player.h
+++ b/src/player.h
@@ -15,6 +15,7 @@
 #include "guild.h"
 #include "outfit.h"
 #include "party.h"
+#include "player_stash.h"
 #include "protocolgame.h"
 #include "protocolspectator.h"
 #include "rewardchest.h"
@@ -501,6 +502,25 @@ public:
 	StorageDirtySnapshot getStorageDirtySnapshot() const;
 	void acknowledgeStorageDirty(const StorageDirtySnapshot& snapshot);
 	void clearStorageDirty();
+
+	// Supply Stash. Authoritative in memory while online, persisted through the
+	// same player-save transaction as everything else rather than by a synchronous
+	// write per stow.
+	PlayerStash& getSupplyStash() { return supplyStash; }
+	const PlayerStash& getSupplyStash() const { return supplyStash; }
+	bool hasSupplyStashDirty() const { return supplyStash.isDirty(); }
+	PlayerStash::DirtySnapshot getSupplyStashDirtySnapshot() const { return supplyStash.getDirtySnapshot(); }
+	void acknowledgeSupplyStashDirty(const PlayerStash::DirtySnapshot& snapshot)
+	{
+		supplyStash.acknowledgeDirty(snapshot);
+	}
+	void clearSupplyStashDirty() { supplyStash.clearDirty(); }
+	// Login path: fills the row without marking it dirty, since it is what the
+	// database already holds.
+	void loadSupplyStashRow(uint16_t itemId, uint8_t tier, uint32_t amount)
+	{
+		supplyStash.load(itemId, tier, amount);
+	}
 
 	void setGroup(const std::shared_ptr<Group>& newGroup) { group = newGroup; }
 	Group* getGroup() const { return group.get(); }
@@ -1649,6 +1669,7 @@ private:
 	std::unordered_set<uint32_t> VIPList;
 	std::unordered_set<uint32_t> modifiedStorageKeys;
 	std::unordered_set<uint32_t> removedStorageKeys;
+	PlayerStash supplyStash;
 	uint64_t storageDirtyRevision = 0;
 	std::unordered_map<uint32_t, uint64_t> storageDirtyKeyRevisions;
 	std::unordered_map<std::string, PreyCombatBonus> preyCombatBonuses;

--- a/src/player_stash.cpp
+++ b/src/player_stash.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "player_stash.h"
+
+#include <algorithm>
+#include <limits>
+
+void PlayerStash::load(uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (itemId == 0 || amount == 0) {
+		return;
+	}
+
+	rows[Key{itemId, Stash::normalizeTier(tier)}] = amount;
+}
+
+bool PlayerStash::add(uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (itemId == 0 || amount == 0) {
+		return false;
+	}
+
+	const Key key{itemId, Stash::normalizeTier(tier)};
+	const auto it = rows.find(key);
+	const uint32_t current = it != rows.end() ? it->second : 0;
+
+	// A row that does not exist yet costs one against the cap. Checked before any
+	// mutation so a rejected stow leaves the physical item where it was.
+	if (current == 0 && rows.size() >= MAX_UNIQUE_ROWS) {
+		return false;
+	}
+
+	// The column is unsigned 32-bit; wrapping here would turn a huge stash into an
+	// empty one.
+	if (amount > std::numeric_limits<uint32_t>::max() - current) {
+		return false;
+	}
+
+	rows[key] = current + amount;
+	markDirty(key);
+	return true;
+}
+
+bool PlayerStash::remove(uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (itemId == 0 || amount == 0) {
+		return false;
+	}
+
+	const Key key{itemId, Stash::normalizeTier(tier)};
+	const auto it = rows.find(key);
+	if (it == rows.end() || it->second < amount) {
+		return false;
+	}
+
+	it->second -= amount;
+	if (it->second == 0) {
+		// Drop the emptied row rather than keeping a zero, so the row cap reflects
+		// what is actually stored.
+		rows.erase(it);
+	}
+
+	markDirty(key);
+	return true;
+}
+
+uint32_t PlayerStash::getCount(uint16_t itemId, uint8_t tier) const
+{
+	const auto it = rows.find(Key{itemId, Stash::normalizeTier(tier)});
+	return it != rows.end() ? it->second : 0;
+}
+
+bool PlayerStash::wouldExceedRowLimit(uint16_t itemId, uint8_t tier) const
+{
+	if (itemId == 0) {
+		return false;
+	}
+
+	if (rows.contains(Key{itemId, Stash::normalizeTier(tier)})) {
+		return false;
+	}
+
+	return rows.size() >= MAX_UNIQUE_ROWS;
+}
+
+void PlayerStash::markDirty(const Key& key)
+{
+	modifiedRows.insert(key);
+	rowRevisions[key] = ++dirtyRevision;
+}
+
+PlayerStash::DirtySnapshot PlayerStash::getDirtySnapshot() const
+{
+	return DirtySnapshot{dirtyRevision, modifiedRows};
+}
+
+void PlayerStash::acknowledgeDirty(const DirtySnapshot& snapshot)
+{
+	for (const auto& key : snapshot.modifiedRows) {
+		const auto revisionIt = rowRevisions.find(key);
+
+		// Changed again after the snapshot was taken, so it is still dirty and the
+		// next save has to pick it up. Without this, a stow landing while the save
+		// worker ran would be acknowledged away and lost.
+		if (revisionIt != rowRevisions.end() && revisionIt->second > snapshot.snapshotId) {
+			continue;
+		}
+
+		modifiedRows.erase(key);
+		if (revisionIt != rowRevisions.end()) {
+			rowRevisions.erase(revisionIt);
+		}
+	}
+}
+
+void PlayerStash::clearDirty()
+{
+	modifiedRows.clear();
+	rowRevisions.clear();
+}
+
+std::vector<StashRecord> PlayerStash::toRecords() const
+{
+	std::vector<StashRecord> records;
+	records.reserve(rows.size());
+	for (const auto& [key, amount] : rows) {
+		records.emplace_back(StashRecord{key.itemId, key.tier, amount});
+	}
+
+	std::sort(records.begin(), records.end(), [](const StashRecord& lhs, const StashRecord& rhs) {
+		if (lhs.itemId != rhs.itemId) {
+			return lhs.itemId < rhs.itemId;
+		}
+		return lhs.tier < rhs.tier;
+	});
+	return records;
+}

--- a/src/player_stash.h
+++ b/src/player_stash.h
@@ -1,0 +1,96 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_PLAYER_STASH_H
+#define FS_PLAYER_STASH_H
+
+#include "stash.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// Authoritative in-memory Supply Stash state for one player.
+//
+// The stash is logical storage: a count per (itemId, tier), never physical items.
+// This class owns that state, is mutated on the game thread, and tracks which rows
+// changed so a save can persist just those.
+//
+// It follows the same dirty/snapshot/acknowledge discipline the storage values
+// already use, including per-row revisions. That last part is the reason this is
+// not just a map plus a bool: a row modified *after* a snapshot is taken must
+// survive the acknowledgement of that snapshot, or a mutation made while the save
+// worker was running would be silently dropped.
+//
+// Deliberately free of Player, Item and Database, so it can be tested on its own.
+class PlayerStash
+{
+public:
+	struct Key
+	{
+		uint16_t itemId = 0;
+		uint8_t tier = 0;
+
+		bool operator==(const Key& other) const noexcept
+		{
+			return itemId == other.itemId && tier == other.tier;
+		}
+	};
+
+	struct KeyHash
+	{
+		size_t operator()(const Key& key) const noexcept
+		{
+			return (static_cast<size_t>(key.itemId) << 8) ^ key.tier;
+		}
+	};
+
+	using Rows = std::unordered_map<Key, uint32_t, KeyHash>;
+	using KeySet = std::unordered_set<Key, KeyHash>;
+
+	struct DirtySnapshot
+	{
+		uint64_t snapshotId = 0;
+		KeySet modifiedRows;
+	};
+
+	// Tier is part of the row identity, so (2160, 0) and (2160, 3) are two rows
+	// against this cap, matching how the table is keyed.
+	static constexpr size_t MAX_UNIQUE_ROWS = 1000;
+
+	// Loads a row as it exists in the database. Does not mark anything dirty:
+	// nothing has changed yet at that point.
+	void load(uint16_t itemId, uint8_t tier, uint32_t amount);
+
+	// Both return false and change nothing on failure, so a caller that has
+	// already removed a physical item can roll back on a false.
+	[[nodiscard]] bool add(uint16_t itemId, uint8_t tier, uint32_t amount);
+	[[nodiscard]] bool remove(uint16_t itemId, uint8_t tier, uint32_t amount);
+
+	[[nodiscard]] uint32_t getCount(uint16_t itemId, uint8_t tier) const;
+	[[nodiscard]] const Rows& getRows() const noexcept { return rows; }
+	[[nodiscard]] size_t getUniqueRowCount() const noexcept { return rows.size(); }
+
+	// True when adding this row would introduce a new (itemId, tier) combination
+	// and the cap is already reached. Callers check before removing anything.
+	[[nodiscard]] bool wouldExceedRowLimit(uint16_t itemId, uint8_t tier) const;
+
+	[[nodiscard]] bool isDirty() const noexcept { return !modifiedRows.empty(); }
+	[[nodiscard]] DirtySnapshot getDirtySnapshot() const;
+	void acknowledgeDirty(const DirtySnapshot& snapshot);
+	void clearDirty();
+
+	// Flattened view for serialisation, sorted so the wire order is stable.
+	[[nodiscard]] std::vector<StashRecord> toRecords() const;
+
+private:
+	void markDirty(const Key& key);
+
+	Rows rows;
+	KeySet modifiedRows;
+	std::unordered_map<Key, uint64_t, KeyHash> rowRevisions;
+	uint64_t dirtyRevision = 0;
+};
+
+#endif // FS_PLAYER_STASH_H

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -19,6 +19,8 @@
 #include "outputmessage.h"
 #include "player.h"
 #include "protocolgame.h"
+
+#include "supply_stash_protocol.h"
 #include "protocollogin.h"
 #include "imbuement.h"
 #include "familiar.h"
@@ -3080,6 +3082,68 @@ void ProtocolGame::sendAddMarker(const Position& pos, uint8_t markType, std::str
 	msg.addPosition(pos);
 	msg.addByte(markType);
 	msg.addString(desc);
+	writeToOutputBuffer(msg);
+}
+
+void ProtocolGame::parseSupplyStashAction(NetworkMessage& msg)
+{
+	if (!player) {
+		return;
+	}
+
+	const auto parsed = tfs::supply_stash::parseRequest(msg);
+	if (!parsed) {
+		// Malformed requests are dropped without answering. The parser already
+		// guarantees the read stopped inside the message, so the connection stays
+		// aligned for whatever follows.
+		return;
+	}
+
+	const auto& request = parsed.request;
+	const uint32_t playerId = player->getID();
+
+	switch (request.action) {
+		case tfs::supply_stash::Action::StowItem:
+			g_game.playerStowItem(playerId, request.position, request.itemId, request.stackpos, request.count);
+			break;
+
+		case tfs::supply_stash::Action::StowContainer:
+			g_game.playerStowContainer(playerId, request.position, request.itemId, request.stackpos);
+			break;
+
+		case tfs::supply_stash::Action::StowStack:
+			g_game.playerStowStack(playerId, request.position, request.itemId, request.stackpos);
+			break;
+
+		case tfs::supply_stash::Action::Withdraw:
+			g_game.playerStashWithdraw(playerId, request.itemId, request.tier, request.count);
+			break;
+	}
+
+	sendSupplyStash();
+}
+
+void ProtocolGame::sendSupplyStash()
+{
+	if (!player) {
+		return;
+	}
+
+	const auto records = player->getSupplyStash().toRecords();
+
+	NetworkMessage msg;
+	msg.addByte(tfs::supply_stash::SERVER_CONTENTS_OPCODE);
+
+	const size_t used = player->getSupplyStash().getUniqueRowCount();
+	const uint16_t freeSlots = static_cast<uint16_t>(
+	    used >= PlayerStash::MAX_UNIQUE_ROWS ? 0 : PlayerStash::MAX_UNIQUE_ROWS - used);
+
+	// Nothing is sent if the payload will not fit, rather than a truncated one the
+	// client would read past the end of.
+	if (!tfs::supply_stash::serializeContents(msg, records, freeSlots)) {
+		return;
+	}
+
 	writeToOutputBuffer(msg);
 }
 

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -201,6 +201,13 @@ private:
 	void sendTextMessage(const TextMessage& message);
 	void sendReLoginWindow();
 
+	// Supply Stash. parseSupplyStashAction is deliberately NOT wired into
+	// parsePacket yet: the Lua PacketHandler(0x28) is still authoritative, and a
+	// native case would take precedence and leave two implementations mutating the
+	// stash. Wiring is one case label when the replacement path is ready to test.
+	void parseSupplyStashAction(NetworkMessage& msg);
+	void sendSupplyStash();
+
 	void sendTutorial(uint8_t tutorialId);
 	void sendAddMarker(const Position& pos, uint8_t markType, std::string_view desc);
 

--- a/src/save_manager.cpp
+++ b/src/save_manager.cpp
@@ -173,6 +173,10 @@ bool SaveManager::savePlayerSync(Player* player)
 				save->bestiarySnapshotId,
 				save->snapshotModifiedBestiaryRaceIds
 			});
+			player->acknowledgeSupplyStashDirty(PlayerStash::DirtySnapshot{
+				save->stashSnapshotId,
+				save->snapshotModifiedStashRows
+			});
 			success = true;
 			break;
 		}
@@ -340,6 +344,10 @@ void SaveManager::acknowledgePlayerSave(uint32_t guid, const IOLoginData::Player
 		player->acknowledgeBestiaryDirty(Player::BestiaryDirtySnapshot{
 			save.bestiarySnapshotId,
 			save.snapshotModifiedBestiaryRaceIds
+		});
+		player->acknowledgeSupplyStashDirty(PlayerStash::DirtySnapshot{
+			save.stashSnapshotId,
+			save.snapshotModifiedStashRows
 		});
 	}
 }

--- a/src/stash.cpp
+++ b/src/stash.cpp
@@ -72,3 +72,33 @@ bool Stash::cleanup(uint32_t playerId)
 	return Database::getInstance().executeQuery(fmt::format(
 		"DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND `amount` = 0", playerId));
 }
+
+bool Stash::writeRow(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount)
+{
+	if (playerId == 0 || itemId == 0) {
+		return false;
+	}
+
+	// An emptied row is a delete, not a zero, so the unique-row count in the
+	// database matches what the in-memory model reports.
+	if (amount == 0) {
+		return deleteRow(playerId, itemId, tier);
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"INSERT INTO `player_supplystash` (`player_id`, `itemtype`, `tier`, `amount`) "
+		"VALUES ({:d}, {:d}, {:d}, {:d}) "
+		"ON DUPLICATE KEY UPDATE `amount` = VALUES(`amount`)",
+		playerId, itemId, normalizeTier(tier), amount));
+}
+
+bool Stash::deleteRow(uint32_t playerId, uint16_t itemId, uint8_t tier)
+{
+	if (playerId == 0 || itemId == 0) {
+		return false;
+	}
+
+	return Database::getInstance().executeQuery(fmt::format(
+		"DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND `itemtype` = {:d} AND `tier` = {:d}",
+		playerId, itemId, normalizeTier(tier)));
+}

--- a/src/stash.cpp
+++ b/src/stash.cpp
@@ -73,7 +73,7 @@ bool Stash::cleanup(uint32_t playerId)
 		"DELETE FROM `player_supplystash` WHERE `player_id` = {:d} AND `amount` = 0", playerId));
 }
 
-bool Stash::writeRow(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount)
+bool Stash::writeRow(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier)
 {
 	if (playerId == 0 || itemId == 0) {
 		return false;

--- a/src/stash.h
+++ b/src/stash.h
@@ -24,6 +24,16 @@ public:
 	[[nodiscard]] static bool addAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
 	[[nodiscard]] static bool removeAmount(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
 	[[nodiscard]] static bool cleanup(uint32_t playerId);
+
+	// Absolute writes, for the in-memory model where the Player already holds the
+	// authoritative count.
+	//
+	// addAmount/removeAmount adjust by a delta, which is correct when the database
+	// is the source of truth but not idempotent: replaying one inside a retried
+	// transaction adds the amount twice. These set the row to a known value, so a
+	// retry lands on the same result.
+	[[nodiscard]] static bool writeRow(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount);
+	[[nodiscard]] static bool deleteRow(uint32_t playerId, uint16_t itemId, uint8_t tier);
 };
 
 #endif // FS_STASH_H

--- a/src/stash.h
+++ b/src/stash.h
@@ -32,7 +32,7 @@ public:
 	// is the source of truth but not idempotent: replaying one inside a retried
 	// transaction adds the amount twice. These set the row to a known value, so a
 	// retry lands on the same result.
-	[[nodiscard]] static bool writeRow(uint32_t playerId, uint16_t itemId, uint8_t tier, uint32_t amount);
+	[[nodiscard]] static bool writeRow(uint32_t playerId, uint16_t itemId, uint32_t amount, uint8_t tier);
 	[[nodiscard]] static bool deleteRow(uint32_t playerId, uint16_t itemId, uint8_t tier);
 };
 

--- a/src/supply_stash_protocol.cpp
+++ b/src/supply_stash_protocol.cpp
@@ -1,0 +1,124 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "supply_stash_protocol.h"
+
+#include "networkmessage.h"
+
+namespace tfs::supply_stash {
+
+namespace {
+
+ParseResult fail(ParseError error) { return ParseResult{error, Request{}}; }
+
+bool isKnownAction(uint8_t value)
+{
+	switch (static_cast<Action>(value)) {
+		case Action::StowItem:
+		case Action::StowContainer:
+		case Action::StowStack:
+		case Action::Withdraw:
+			return true;
+	}
+	return false;
+}
+
+} // namespace
+
+ParseResult parseRequest(NetworkMessage& msg)
+{
+	const uint8_t rawAction = msg.getByte();
+
+	// Reads past the end return 0 rather than throwing, so the overrun flag is
+	// the only honest signal that the message was short.
+	if (msg.isOverrun()) {
+		return fail(ParseError::Truncated);
+	}
+
+	if (!isKnownAction(rawAction)) {
+		return fail(ParseError::UnknownAction);
+	}
+
+	Request request;
+	request.action = static_cast<Action>(rawAction);
+
+	switch (request.action) {
+		case Action::StowItem:
+			request.position = msg.getPosition();
+			request.itemId = msg.get<uint16_t>();
+			request.stackpos = msg.getByte();
+			request.count = msg.get<uint32_t>();
+			break;
+
+		case Action::StowContainer:
+		case Action::StowStack:
+			request.position = msg.getPosition();
+			request.itemId = msg.get<uint16_t>();
+			request.stackpos = msg.getByte();
+			break;
+
+		case Action::Withdraw:
+			request.itemId = msg.get<uint16_t>();
+			request.count = msg.get<uint32_t>();
+			request.tier = msg.getByte();
+			break;
+	}
+
+	if (msg.isOverrun()) {
+		return fail(ParseError::Truncated);
+	}
+
+	// Every layout is fixed size, so leftover bytes mean the client and the server
+	// disagree about the contract. Rejecting here stops that disagreement being
+	// read as the next opcode. Readable data ends at length + INITIAL_BUFFER_POSITION,
+	// which is the same bound canRead() enforces.
+	//
+	// This assumes msg holds a stash request and nothing else. That holds for the
+	// current transport, where the payload arrives on its own; if the request is
+	// ever embedded in a larger packet, the caller must slice it out first.
+	if (msg.getBufferPosition() != msg.getLength() + NetworkMessage::INITIAL_BUFFER_POSITION) {
+		return fail(ParseError::TrailingBytes);
+	}
+
+	if (request.itemId == 0) {
+		return fail(ParseError::InvalidItemId);
+	}
+
+	switch (request.action) {
+		case Action::StowItem:
+			if (request.count == 0 || request.count > MAX_STOW_COUNT) {
+				return fail(ParseError::InvalidCount);
+			}
+			break;
+
+		case Action::Withdraw:
+			if (request.count == 0 || request.count > MAX_WITHDRAW_COUNT) {
+				return fail(ParseError::InvalidCount);
+			}
+			if (request.tier > Stash::MAX_ITEM_TIER) {
+				return fail(ParseError::InvalidTier);
+			}
+			break;
+
+		case Action::StowContainer:
+		case Action::StowStack:
+			break;
+	}
+
+	return ParseResult{ParseError::None, request};
+}
+
+void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots)
+{
+	msg.add<uint16_t>(static_cast<uint16_t>(rows.size()));
+	for (const auto& row : rows) {
+		msg.add<uint16_t>(row.itemId);
+		msg.add<uint32_t>(row.amount);
+		msg.addByte(row.tier);
+	}
+	msg.add<uint16_t>(freeSlots);
+}
+
+} // namespace tfs::supply_stash

--- a/src/supply_stash_protocol.cpp
+++ b/src/supply_stash_protocol.cpp
@@ -117,10 +117,18 @@ ParseResult parseRequest(NetworkMessage& msg)
 	return ParseResult{ParseError::None, request};
 }
 
-size_t maxSerializableRows()
+size_t maxSerializableRows(const NetworkMessage& msg)
 {
-	constexpr size_t byMessage =
-	    (static_cast<size_t>(NetworkMessage::MAX_PROTOCOL_BODY_LENGTH) - CONTENTS_FIXED_BYTES) / CONTENTS_ROW_BYTES;
+	// Against what is left in this message, not against an empty one. The payload
+	// may be appended after other data, and a bound computed from a fresh message
+	// would promise room that is already spent.
+	const size_t used = msg.getLength();
+	const size_t capacity = static_cast<size_t>(NetworkMessage::MAX_PROTOCOL_BODY_LENGTH);
+	if (used + CONTENTS_FIXED_BYTES >= capacity) {
+		return 0;
+	}
+
+	const size_t byMessage = (capacity - used - CONTENTS_FIXED_BYTES) / CONTENTS_ROW_BYTES;
 	constexpr size_t byCountField = std::numeric_limits<uint16_t>::max();
 	return std::min(byMessage, byCountField);
 }
@@ -129,7 +137,7 @@ bool serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows
 {
 	// Checked before a single byte is written, because a partial payload is worse
 	// than none: the count would promise rows that never arrive.
-	if (rows.size() > maxSerializableRows()) {
+	if (rows.size() > maxSerializableRows(msg)) {
 		return false;
 	}
 

--- a/src/supply_stash_protocol.cpp
+++ b/src/supply_stash_protocol.cpp
@@ -7,9 +7,16 @@
 
 #include "networkmessage.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace tfs::supply_stash {
 
 namespace {
+
+// U16 itemId + U32 amount + U8 tier per row; U16 count and U16 freeSlots around them.
+constexpr size_t CONTENTS_ROW_BYTES = 7;
+constexpr size_t CONTENTS_FIXED_BYTES = 4;
 
 ParseResult fail(ParseError error) { return ParseResult{error, Request{}}; }
 
@@ -110,8 +117,22 @@ ParseResult parseRequest(NetworkMessage& msg)
 	return ParseResult{ParseError::None, request};
 }
 
-void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots)
+size_t maxSerializableRows()
 {
+	constexpr size_t byMessage =
+	    (static_cast<size_t>(NetworkMessage::MAX_PROTOCOL_BODY_LENGTH) - CONTENTS_FIXED_BYTES) / CONTENTS_ROW_BYTES;
+	constexpr size_t byCountField = std::numeric_limits<uint16_t>::max();
+	return std::min(byMessage, byCountField);
+}
+
+bool serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots)
+{
+	// Checked before a single byte is written, because a partial payload is worse
+	// than none: the count would promise rows that never arrive.
+	if (rows.size() > maxSerializableRows()) {
+		return false;
+	}
+
 	msg.add<uint16_t>(static_cast<uint16_t>(rows.size()));
 	for (const auto& row : rows) {
 		msg.add<uint16_t>(row.itemId);
@@ -119,6 +140,7 @@ void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows
 		msg.addByte(row.tier);
 	}
 	msg.add<uint16_t>(freeSlots);
+	return true;
 }
 
 } // namespace tfs::supply_stash

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -14,20 +14,38 @@ class NetworkMessage;
 
 namespace tfs::supply_stash {
 
-// Opcode note, because the pairing is a trap.
+// Opcode directions. These are top-level packet opcodes, not extended opcodes,
+// and the numbers are only safe because the directions differ:
 //
-// These two numbers are only safe because they travel in opposite directions:
+//     C -> S  0x28   Supply Stash actions
+//     S -> C  0x28   ReLogin/Death window  (sendReLoginWindow)
+//     S -> C  0x29   Supply Stash contents
 //
-//     client -> server  0x28   free
-//     server -> client  0x29   free
-//     server -> client  0x28   ALREADY sendReLoginWindow()
-//
-// Never mirror the request opcode to answer on 0x28 — that is the death/relogin
-// window in 8.60 and the client will act on it.
+// Never answer a stash request on S -> C 0x28. That is the death/relogin window
+// in 8.60 and the client will act on it.
 inline constexpr uint8_t CLIENT_REQUEST_OPCODE = 0x28;
 inline constexpr uint8_t SERVER_CONTENTS_OPCODE = 0x29;
 
 // Wire values shared with AstraClient. Do not renumber.
+//
+// These replace the previous Lua numbering (OPEN = 1, STOW_ALL = 2,
+// WITHDRAW = 3), so 1 and 2 now mean something different than they used to and
+// a client that has not been updated is speaking the old dialect.
+//
+// That transition is safe only because every layout here is fixed size and the
+// parser rejects both short and long messages:
+//
+//     old OPEN      1 byte  -> this expects 8 more  -> Truncated, rejected
+//     old STOW_ALL  1 byte  -> this expects 8 more  -> Truncated, rejected
+//     old WITHDRAW  6 bytes -> this expects 7       -> Truncated, rejected
+//     old WITHDRAW  7 bytes -> identical layout     -> accepted, same meaning
+//
+// So an out-of-date client is refused rather than silently misread as an
+// item-moving command. test_supply_stash_protocol pins that down; if the length
+// guards are ever relaxed, the rollout stops being fail-safe.
+//
+// Note there is deliberately no OPEN action: opening the stash comes from using
+// the stash object, not from a client request.
 enum class Action : uint8_t
 {
 	StowItem = 0,

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -93,10 +93,13 @@ struct ParseResult
 // the action's layout says it does.
 [[nodiscard]] ParseResult parseRequest(NetworkMessage& msg);
 
-// Largest row count that can be encoded. Bounded by two things, and the tighter
-// of them is the message body, not the 16-bit count: at seven bytes per row a
-// full message runs out well before 65535 rows do.
-[[nodiscard]] size_t maxSerializableRows();
+// Largest row count that still fits in this message. Bounded by two things, and
+// the tighter is usually the body rather than the 16-bit count: at seven bytes
+// per row a full message runs out well before 65535 rows do.
+//
+// Takes the message because the payload may follow other data — a bound computed
+// from an empty message would promise room that is already spent.
+[[nodiscard]] size_t maxSerializableRows(const NetworkMessage& msg);
 
 // Writes the stash contents payload, tier-aware, matching what AstraClient
 // already knows how to read.

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -93,9 +93,25 @@ struct ParseResult
 // the action's layout says it does.
 [[nodiscard]] ParseResult parseRequest(NetworkMessage& msg);
 
+// Largest row count that can be encoded. Bounded by two things, and the tighter
+// of them is the message body, not the 16-bit count: at seven bytes per row a
+// full message runs out well before 65535 rows do.
+[[nodiscard]] size_t maxSerializableRows();
+
 // Writes the stash contents payload, tier-aware, matching what AstraClient
 // already knows how to read.
-void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots);
+//
+// Returns false and writes nothing when the rows do not fit. Both failure modes
+// desynchronise the receiver rather than merely losing data, so neither may
+// produce a partial packet:
+//
+//   - a count above 65535 wraps in the header while every row is still written
+//   - a payload past the message body stops being appended silently, because
+//     NetworkMessage::addByte returns without writing once it is full
+//
+// Either way the header promises more rows than follow, and the receiver goes on
+// to read row bytes as freeSlots.
+[[nodiscard]] bool serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots);
 
 } // namespace tfs::supply_stash
 

--- a/src/supply_stash_protocol.h
+++ b/src/supply_stash_protocol.h
@@ -1,0 +1,84 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_SUPPLY_STASH_PROTOCOL_H
+#define FS_SUPPLY_STASH_PROTOCOL_H
+
+#include "position.h"
+#include "stash.h"
+
+#include <cstdint>
+#include <vector>
+
+class NetworkMessage;
+
+namespace tfs::supply_stash {
+
+// Opcode note, because the pairing is a trap.
+//
+// These two numbers are only safe because they travel in opposite directions:
+//
+//     client -> server  0x28   free
+//     server -> client  0x29   free
+//     server -> client  0x28   ALREADY sendReLoginWindow()
+//
+// Never mirror the request opcode to answer on 0x28 — that is the death/relogin
+// window in 8.60 and the client will act on it.
+inline constexpr uint8_t CLIENT_REQUEST_OPCODE = 0x28;
+inline constexpr uint8_t SERVER_CONTENTS_OPCODE = 0x29;
+
+// Wire values shared with AstraClient. Do not renumber.
+enum class Action : uint8_t
+{
+	StowItem = 0,
+	StowContainer = 1,
+	StowStack = 2,
+	Withdraw = 3,
+};
+
+enum class ParseError : uint8_t
+{
+	None,
+	Truncated,     // the message ended before the action's fields did
+	UnknownAction, // action byte outside the enum
+	InvalidItemId, // itemId 0
+	InvalidCount,  // count 0, or above the cap
+	InvalidTier,   // tier above Stash::MAX_ITEM_TIER
+	TrailingBytes, // more bytes than the action's fixed size accounts for
+};
+
+// Caps mirror the limits the current Lua implementation already enforces, so
+// moving the parser to C++ does not quietly widen what a client may ask for.
+inline constexpr uint32_t MAX_STOW_COUNT = 100'000;
+inline constexpr uint32_t MAX_WITHDRAW_COUNT = 100'000;
+
+struct Request
+{
+	Action action = Action::StowItem;
+	Position position{}; // stow actions only; unset for Withdraw
+	uint16_t itemId = 0;
+	uint8_t stackpos = 0; // stow actions only
+	uint32_t count = 0;   // StowItem and Withdraw only
+	uint8_t tier = 0;     // Withdraw only
+};
+
+struct ParseResult
+{
+	ParseError error = ParseError::None;
+	Request request{};
+
+	[[nodiscard]] explicit operator bool() const noexcept { return error == ParseError::None; }
+};
+
+// Reads one stash request, action byte first. Never throws and never trusts the
+// client: every field is range-checked and the message must end exactly where
+// the action's layout says it does.
+[[nodiscard]] ParseResult parseRequest(NetworkMessage& msg);
+
+// Writes the stash contents payload, tier-aware, matching what AstraClient
+// already knows how to read.
+void serializeContents(NetworkMessage& msg, const std::vector<StashRecord>& rows, uint16_t freeSlots);
+
+} // namespace tfs::supply_stash
+
+#endif // FS_SUPPLY_STASH_PROTOCOL_H

--- a/src/supply_stash_rules.cpp
+++ b/src/supply_stash_rules.cpp
@@ -32,6 +32,25 @@ constexpr itemAttrTypes RESTRICTED_ATTRIBUTES[] = {
     ITEM_ATTRIBUTE_STOREITEM,    ITEM_ATTRIBUTE_ATTACK_SPEED, ITEM_ATTRIBUTE_REWARDID,
 };
 
+// Blocked outright, matching the Lua's blockedItems table. Currency has its own
+// handling, and the container types would either nest the stash inside itself or
+// lose everything they hold.
+constexpr uint16_t BLOCKED_ITEM_IDS[] = {
+    ITEM_GOLD_COIN, ITEM_PLATINUM_COIN, ITEM_CRYSTAL_COIN, ITEM_GOLD_NUGGET,
+    ITEM_MARKET,    ITEM_SUPPLY_STASH,  ITEM_INBOX,        ITEM_STORE_INBOX,
+    ITEM_DEPOT,
+};
+
+bool isBlockedItemId(uint16_t itemId)
+{
+	for (const uint16_t blocked : BLOCKED_ITEM_IDS) {
+		if (itemId == blocked) {
+			return true;
+		}
+	}
+	return false;
+}
+
 } // namespace
 
 StowRejection getStowRejection(const Item* item)
@@ -46,9 +65,32 @@ StowRejection getStowRejection(const Item* item)
 		return StowRejection::IsContainer;
 	}
 
+	const uint16_t itemId = item->getID();
+	if (itemId == 0 || isBlockedItemId(itemId)) {
+		return StowRejection::BlockedItemId;
+	}
+
+	const ItemType& type = Item::items[itemId];
+
+	// An item with no name has nothing sensible to show in the stash window.
+	if (type.name.empty()) {
+		return StowRejection::Nameless;
+	}
+
+	if (type.corpseType != RACE_NONE || type.isDoor() || type.isFluidContainer() || type.isMagicField() ||
+	    type.isGroundTile()) {
+		return StowRejection::UnsupportedType;
+	}
+
 	// Covers ground, doors, magic fields and anything else that is not a loose item.
 	if (!item->isPickupable()) {
 		return StowRejection::NotPickupable;
+	}
+
+	// The Lua required movable *and* pickupable. Pickupable alone would let through
+	// things the player is not allowed to move.
+	if (!type.moveable) {
+		return StowRejection::NotMovable;
 	}
 
 	if (item->isStoreItem() || item->hasAttribute(ITEM_ATTRIBUTE_STOREITEM)) {
@@ -75,9 +117,13 @@ StowRejection getStowRejection(const Item* item)
 	// only the count survives. Anything less would be refunded to full on withdraw,
 	// which is a quiet duplication of value.
 	if (item->hasAttribute(ITEM_ATTRIBUTE_DURATION)) {
-		const uint32_t duration = static_cast<uint32_t>(item->getDuration());
-		const uint32_t maxDuration = std::max(item->getDefaultDurationMin(), item->getDefaultDurationMax());
-		if (maxDuration == 0 || duration < maxDuration) {
+		// Compared signed. getDuration() returns int32_t and casting a negative to
+		// uint32_t wraps to something enormous, which would sail past the check and
+		// let a spent item through as though it were full.
+		const int64_t duration = item->getDuration();
+		const int64_t maxDuration =
+		    std::max<int64_t>(item->getDefaultDurationMin(), item->getDefaultDurationMax());
+		if (maxDuration <= 0 || duration < maxDuration) {
 			return StowRejection::PartialDuration;
 		}
 	}

--- a/src/supply_stash_rules.cpp
+++ b/src/supply_stash_rules.cpp
@@ -1,0 +1,91 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "supply_stash_rules.h"
+
+#include "item.h"
+
+#include <algorithm>
+
+namespace tfs::supply_stash {
+
+namespace {
+
+// Every attribute here is per-instance state the stash cannot carry. Stowing an
+// item that has one would drop it silently, and the withdraw would hand back a
+// plain item — same list the Lua refuses on.
+constexpr itemAttrTypes RESTRICTED_ATTRIBUTES[] = {
+    ITEM_ATTRIBUTE_ACTIONID,     ITEM_ATTRIBUTE_UNIQUEID,   ITEM_ATTRIBUTE_DESCRIPTION,
+    ITEM_ATTRIBUTE_TEXT,         ITEM_ATTRIBUTE_DATE,       ITEM_ATTRIBUTE_WRITER,
+    ITEM_ATTRIBUTE_NAME,         ITEM_ATTRIBUTE_ARTICLE,    ITEM_ATTRIBUTE_PLURALNAME,
+    ITEM_ATTRIBUTE_WEIGHT,       ITEM_ATTRIBUTE_ATTACK,     ITEM_ATTRIBUTE_DEFENSE,
+    ITEM_ATTRIBUTE_EXTRADEFENSE, ITEM_ATTRIBUTE_ARMOR,      ITEM_ATTRIBUTE_HITCHANCE,
+    ITEM_ATTRIBUTE_SHOOTRANGE,   ITEM_ATTRIBUTE_OWNER,      ITEM_ATTRIBUTE_CORPSEOWNER,
+    ITEM_ATTRIBUTE_FLUIDTYPE,    ITEM_ATTRIBUTE_DOORID,     ITEM_ATTRIBUTE_WRAPID,
+    ITEM_ATTRIBUTE_STOREITEM,    ITEM_ATTRIBUTE_ATTACK_SPEED, ITEM_ATTRIBUTE_REWARDID,
+};
+
+} // namespace
+
+StowRejection getStowRejection(const Item* item)
+{
+	if (!item) {
+		return StowRejection::NoItem;
+	}
+
+	// A container is stowed through the container action, which walks its contents.
+	// Storing the container itself would lose everything inside it.
+	if (item->getContainer()) {
+		return StowRejection::IsContainer;
+	}
+
+	// Covers ground, doors, magic fields and anything else that is not a loose item.
+	if (!item->isPickupable()) {
+		return StowRejection::NotPickupable;
+	}
+
+	if (item->isStoreItem() || item->hasAttribute(ITEM_ATTRIBUTE_STOREITEM)) {
+		return StowRejection::StoreItem;
+	}
+
+	if (item->hasImbuements()) {
+		return StowRejection::HasImbuements;
+	}
+
+	for (const itemAttrTypes attribute : RESTRICTED_ATTRIBUTES) {
+		if (item->hasAttribute(attribute)) {
+			return StowRejection::InstanceAttribute;
+		}
+	}
+
+	// A decaying item carries a deadline. Stowing it would stop the clock and hand
+	// back a fresh one later.
+	if (item->hasAttribute(ITEM_ATTRIBUTE_DECAYSTATE) || item->hasAttribute(ITEM_ATTRIBUTE_DURATION_TIMESTAMP)) {
+		return StowRejection::Decaying;
+	}
+
+	// A partly used item may only be stowed if it is still at full value, because
+	// only the count survives. Anything less would be refunded to full on withdraw,
+	// which is a quiet duplication of value.
+	if (item->hasAttribute(ITEM_ATTRIBUTE_DURATION)) {
+		const uint32_t duration = static_cast<uint32_t>(item->getDuration());
+		const uint32_t maxDuration = std::max(item->getDefaultDurationMin(), item->getDefaultDurationMax());
+		if (maxDuration == 0 || duration < maxDuration) {
+			return StowRejection::PartialDuration;
+		}
+	}
+
+	if (item->hasAttribute(ITEM_ATTRIBUTE_CHARGES)) {
+		const uint32_t charges = item->getCharges();
+		const uint32_t maxCharges = Item::items[item->getID()].charges;
+		if (maxCharges == 0 || charges < maxCharges) {
+			return StowRejection::PartialCharges;
+		}
+	}
+
+	return StowRejection::None;
+}
+
+} // namespace tfs::supply_stash

--- a/src/supply_stash_rules.cpp
+++ b/src/supply_stash_rules.cpp
@@ -7,6 +7,10 @@
 
 #include "item.h"
 
+#include "game.h"
+#include "player.h"
+#include "tile.h"
+
 #include <algorithm>
 
 namespace tfs::supply_stash {
@@ -86,6 +90,67 @@ StowRejection getStowRejection(const Item* item)
 	}
 
 	return StowRejection::None;
+}
+
+namespace {
+
+// A tile grants access if it holds a depot or the stash object itself.
+bool tileGrantsStashAccess(const Tile* tile)
+{
+	if (!tile) {
+		return false;
+	}
+
+	const TileItemVector* items = tile->getItemList();
+	if (!items) {
+		return false;
+	}
+
+	for (const Item* item : *items) {
+		if (!item) {
+			continue;
+		}
+		const ItemType& type = Item::items[item->getID()];
+		if (type.isDepot() || item->getID() == ITEM_SUPPLY_STASH) {
+			return true;
+		}
+	}
+	return false;
+}
+
+} // namespace
+
+bool hasSupplyStashAccess(const Player* player)
+{
+	if (!player) {
+		return false;
+	}
+
+	const Position& position = player->getPosition();
+	const Tile* playerTile = g_game.map.getTile(position.x, position.y, position.z);
+
+	// Protection zone first: the stash is a town service, and requiring it keeps
+	// the whole thing out of reach mid-fight.
+	if (!playerTile || !playerTile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+		return false;
+	}
+
+	if (tileGrantsStashAccess(playerTile)) {
+		return true;
+	}
+
+	for (int32_t dx = -1; dx <= 1; ++dx) {
+		for (int32_t dy = -1; dy <= 1; ++dy) {
+			if (dx == 0 && dy == 0) {
+				continue;
+			}
+			if (tileGrantsStashAccess(g_game.map.getTile(static_cast<uint16_t>(position.x + dx),
+			                                             static_cast<uint16_t>(position.y + dy), position.z))) {
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 } // namespace tfs::supply_stash

--- a/src/supply_stash_rules.cpp
+++ b/src/supply_stash_rules.cpp
@@ -12,6 +12,7 @@
 #include "tile.h"
 
 #include <algorithm>
+#include <limits>
 
 namespace tfs::supply_stash {
 
@@ -144,8 +145,19 @@ bool hasSupplyStashAccess(const Player* player)
 			if (dx == 0 && dy == 0) {
 				continue;
 			}
-			if (tileGrantsStashAccess(g_game.map.getTile(static_cast<uint16_t>(position.x + dx),
-			                                             static_cast<uint16_t>(position.y + dy), position.z))) {
+
+			// Kept signed and bounds-checked before the cast. At x or y of 0 the
+			// neighbour is -1, and casting that to uint16_t gives 65535 — a depot at
+			// the opposite edge of the map would satisfy an adjacency check.
+			const int32_t neighbourX = static_cast<int32_t>(position.x) + dx;
+			const int32_t neighbourY = static_cast<int32_t>(position.y) + dy;
+			if (neighbourX < 0 || neighbourY < 0 || neighbourX > std::numeric_limits<uint16_t>::max() ||
+			    neighbourY > std::numeric_limits<uint16_t>::max()) {
+				continue;
+			}
+
+			if (tileGrantsStashAccess(g_game.map.getTile(static_cast<uint16_t>(neighbourX),
+			                                             static_cast<uint16_t>(neighbourY), position.z))) {
 				return true;
 			}
 		}

--- a/src/supply_stash_rules.cpp
+++ b/src/supply_stash_rules.cpp
@@ -106,7 +106,7 @@ bool tileGrantsStashAccess(const Tile* tile)
 		return false;
 	}
 
-	for (const Item* item : *items) {
+	for (const auto& item : *items) {
 		if (!item) {
 			continue;
 		}

--- a/src/supply_stash_rules.h
+++ b/src/supply_stash_rules.h
@@ -1,0 +1,45 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_SUPPLY_STASH_RULES_H
+#define FS_SUPPLY_STASH_RULES_H
+
+#include <cstdint>
+
+class Item;
+
+namespace tfs::supply_stash {
+
+// Why an item may not be stowed. Carried back so the caller can tell the player
+// something better than a flat refusal, and so tests name the reason instead of
+// just checking a bool.
+enum class StowRejection : uint8_t
+{
+	None,
+	NoItem,
+	IsContainer,       // containers go through the container action, not this one
+	NotPickupable,     // ground, doors, magic fields and anything else fixed in place
+	StoreItem,
+	HasImbuements,
+	InstanceAttribute, // actionid, uniqueid, custom name, owner, custom armor…
+	Decaying,          // a decay state or timestamp would be lost
+	PartialDuration,   // used duration would silently reset to full
+	PartialCharges,    // spent charges would silently come back
+};
+
+// The stash stores (itemId, tier, amount) and nothing else, so anything carrying
+// per-instance state has to be refused: stowing it would quietly destroy that
+// state and hand back a plain item on withdraw.
+//
+// These rules are ported from the Lua that this replaces, deliberately without
+// relaxing any of them.
+[[nodiscard]] StowRejection getStowRejection(const Item* item);
+
+[[nodiscard]] inline bool canStowSupplyItem(const Item* item)
+{
+	return getStowRejection(item) == StowRejection::None;
+}
+
+} // namespace tfs::supply_stash
+
+#endif // FS_SUPPLY_STASH_RULES_H

--- a/src/supply_stash_rules.h
+++ b/src/supply_stash_rules.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 class Item;
+class Player;
 
 namespace tfs::supply_stash {
 
@@ -39,6 +40,13 @@ enum class StowRejection : uint8_t
 {
 	return getStowRejection(item) == StowRejection::None;
 }
+
+// The stash is only reachable standing in a protection zone, on or next to a
+// depot or the stash object itself. Checked server-side on every action: an open
+// window on the client proves nothing, and the player may have walked away since.
+//
+// Ported from hasCurrentSupplyStashAccess in the Lua, same 3x3 area.
+[[nodiscard]] bool hasSupplyStashAccess(const Player* player);
 
 } // namespace tfs::supply_stash
 

--- a/src/supply_stash_rules.h
+++ b/src/supply_stash_rules.h
@@ -20,6 +20,10 @@ enum class StowRejection : uint8_t
 	NoItem,
 	IsContainer,       // containers go through the container action, not this one
 	NotPickupable,     // ground, doors, magic fields and anything else fixed in place
+	NotMovable,        // pickupable is not enough; the Lua required both
+	BlockedItemId,     // currency, market, inbox, store inbox, depot, the stash itself
+	UnsupportedType,   // corpse, door, container, fluid container, magic field, ground
+	Nameless,          // no name in items.xml, so nothing sensible to show in the stash
 	StoreItem,
 	HasImbuements,
 	InstanceAttribute, // actionid, uniqueid, custom name, owner, custom armor…

--- a/src/tests/test_player_stash.cpp
+++ b/src/tests/test_player_stash.cpp
@@ -1,0 +1,232 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../player_stash.h"
+
+#include "test_support.h"
+
+#include <limits>
+
+TEST_CASE(player_stash_add_and_count)
+{
+	PlayerStash stash;
+
+	CHECK(stash.add(2160, 0, 30));
+	CHECK(stash.getCount(2160, 0) == 30);
+
+	CHECK(stash.add(2160, 0, 12));
+	CHECK(stash.getCount(2160, 0) == 42);
+}
+
+// Tier is part of the row identity, exactly as the table is keyed. The same
+// itemId at two tiers must never be merged into one count.
+TEST_CASE(player_stash_keeps_tiers_apart)
+{
+	PlayerStash stash;
+
+	CHECK(stash.add(2160, 0, 100));
+	CHECK(stash.add(2160, 3, 5));
+
+	CHECK(stash.getCount(2160, 0) == 100);
+	CHECK(stash.getCount(2160, 3) == 5);
+	CHECK(stash.getUniqueRowCount() == 2);
+}
+
+TEST_CASE(player_stash_remove_is_guarded)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 50));
+
+	// Asking for more than is stored must change nothing, so a caller can treat
+	// false as "nothing happened" and roll back.
+	CHECK(!stash.remove(2160, 0, 51));
+	CHECK(stash.getCount(2160, 0) == 50);
+
+	CHECK(stash.remove(2160, 0, 20));
+	CHECK(stash.getCount(2160, 0) == 30);
+}
+
+TEST_CASE(player_stash_removing_everything_drops_the_row)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.getUniqueRowCount() == 1);
+
+	CHECK(stash.remove(2160, 0, 10));
+	CHECK(stash.getCount(2160, 0) == 0);
+	// An emptied row must not keep occupying a slot against the cap.
+	CHECK(stash.getUniqueRowCount() == 0);
+}
+
+TEST_CASE(player_stash_rejects_removing_from_an_empty_stash)
+{
+	PlayerStash stash;
+	CHECK(!stash.remove(2160, 0, 1));
+}
+
+TEST_CASE(player_stash_rejects_zero_and_invalid_input)
+{
+	PlayerStash stash;
+
+	CHECK(!stash.add(0, 0, 10));
+	CHECK(!stash.add(2160, 0, 0));
+	CHECK(!stash.remove(2160, 0, 0));
+	CHECK(stash.getUniqueRowCount() == 0);
+}
+
+// The amount column is unsigned 32-bit. Wrapping would turn a nearly full stash
+// into an empty one, which is the worst possible failure mode here.
+TEST_CASE(player_stash_add_does_not_overflow)
+{
+	PlayerStash stash;
+	constexpr uint32_t max = std::numeric_limits<uint32_t>::max();
+
+	CHECK(stash.add(2160, 0, max - 5));
+	CHECK(!stash.add(2160, 0, 6));
+	CHECK(stash.getCount(2160, 0) == max - 5);
+
+	CHECK(stash.add(2160, 0, 5));
+	CHECK(stash.getCount(2160, 0) == max);
+}
+
+TEST_CASE(player_stash_enforces_the_unique_row_limit)
+{
+	PlayerStash stash;
+
+	for (uint16_t i = 0; i < PlayerStash::MAX_UNIQUE_ROWS; ++i) {
+		CHECK(stash.add(static_cast<uint16_t>(i + 1), 0, 1));
+	}
+	CHECK(stash.getUniqueRowCount() == PlayerStash::MAX_UNIQUE_ROWS);
+
+	// A brand new row is refused once the cap is reached...
+	CHECK(stash.wouldExceedRowLimit(60000, 0));
+	CHECK(!stash.add(60000, 0, 1));
+
+	// ...but topping up a row that already exists is still fine.
+	CHECK(!stash.wouldExceedRowLimit(1, 0));
+	CHECK(stash.add(1, 0, 10));
+	CHECK(stash.getCount(1, 0) == 11);
+}
+
+// A new tier of an item already held is a new row, so it counts against the cap.
+TEST_CASE(player_stash_row_limit_counts_tiers_separately)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 1));
+
+	CHECK(!stash.wouldExceedRowLimit(2160, 0));
+	CHECK(stash.wouldExceedRowLimit(2160, 1) == false); // room is available here
+	CHECK(stash.add(2160, 1, 1));
+	CHECK(stash.getUniqueRowCount() == 2);
+}
+
+TEST_CASE(player_stash_load_does_not_mark_dirty)
+{
+	PlayerStash stash;
+
+	stash.load(2160, 0, 500);
+	stash.load(2148, 2, 25);
+
+	CHECK(stash.getCount(2160, 0) == 500);
+	CHECK(stash.getCount(2148, 2) == 25);
+	// Loading is what the database already holds, so there is nothing to save.
+	CHECK(!stash.isDirty());
+}
+
+TEST_CASE(player_stash_mutations_mark_dirty)
+{
+	PlayerStash stash;
+	CHECK(!stash.isDirty());
+
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.isDirty());
+
+	stash.clearDirty();
+	CHECK(!stash.isDirty());
+
+	CHECK(stash.remove(2160, 0, 1));
+	CHECK(stash.isDirty());
+}
+
+TEST_CASE(player_stash_failed_mutations_do_not_mark_dirty)
+{
+	PlayerStash stash;
+	stash.load(2160, 0, 5);
+
+	CHECK(!stash.remove(2160, 0, 6));
+	CHECK(!stash.add(0, 0, 1));
+	CHECK(!stash.isDirty());
+}
+
+TEST_CASE(player_stash_acknowledge_clears_only_what_was_saved)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.add(2148, 0, 20));
+
+	const auto snapshot = stash.getDirtySnapshot();
+	CHECK(snapshot.modifiedRows.size() == 2);
+
+	stash.acknowledgeDirty(snapshot);
+	CHECK(!stash.isDirty());
+}
+
+// The reason this class tracks per-row revisions at all: a stow landing while the
+// save worker is running must not be acknowledged away by that save.
+TEST_CASE(player_stash_keeps_rows_changed_after_the_snapshot)
+{
+	PlayerStash stash;
+	CHECK(stash.add(2160, 0, 10));
+	CHECK(stash.add(2148, 0, 20));
+
+	const auto snapshot = stash.getDirtySnapshot();
+
+	// The save is in flight; the player stows more of 2160.
+	CHECK(stash.add(2160, 0, 5));
+
+	stash.acknowledgeDirty(snapshot);
+
+	// 2148 was written and is clean; 2160 changed afterwards and is still pending.
+	CHECK(stash.isDirty());
+	const auto pending = stash.getDirtySnapshot();
+	CHECK(pending.modifiedRows.size() == 1);
+	CHECK(pending.modifiedRows.contains(PlayerStash::Key{2160, 0}));
+	CHECK(stash.getCount(2160, 0) == 15);
+}
+
+TEST_CASE(player_stash_records_are_sorted_and_tier_aware)
+{
+	PlayerStash stash;
+	stash.load(2160, 3, 25);
+	stash.load(2148, 0, 100);
+	stash.load(2160, 0, 500);
+
+	const auto records = stash.toRecords();
+
+	CHECK(records.size() == 3);
+	CHECK(records[0].itemId == 2148);
+	CHECK(records[0].amount == 100);
+
+	CHECK(records[1].itemId == 2160);
+	CHECK(records[1].tier == 0);
+	CHECK(records[1].amount == 500);
+
+	CHECK(records[2].itemId == 2160);
+	CHECK(records[2].tier == 3);
+	CHECK(records[2].amount == 25);
+}
+
+TEST_CASE(player_stash_normalizes_tier_consistently)
+{
+	PlayerStash stash;
+
+	// Above the maximum clamps, and must clamp the same way on read as on write,
+	// otherwise a stow and its withdraw would address different rows.
+	CHECK(stash.add(2160, Stash::MAX_ITEM_TIER + 5, 7));
+	CHECK(stash.getCount(2160, Stash::MAX_ITEM_TIER) == 7);
+	CHECK(stash.getUniqueRowCount() == 1);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -315,18 +315,20 @@ TEST_CASE(supply_stash_serializes_empty_contents)
 // reads row bytes as freeSlots and every following packet is misaligned.
 TEST_CASE(supply_stash_serializes_at_the_row_limit)
 {
-	std::vector<StashRecord> rows(maxSerializableRows(), StashRecord{2160, 0, 1});
+	NetworkMessage sizing;
+	std::vector<StashRecord> rows(maxSerializableRows(sizing), StashRecord{2160, 0, 1});
 
 	NetworkMessage msg;
 	CHECK(serializeContents(msg, rows, 0));
 	rewind(msg);
-	CHECK(msg.get<uint16_t>() == static_cast<uint16_t>(maxSerializableRows()));
+	CHECK(msg.get<uint16_t>() == static_cast<uint16_t>(rows.size()));
 	CHECK(!msg.isOverrun());
 }
 
 TEST_CASE(supply_stash_refuses_one_row_over_the_limit)
 {
-	std::vector<StashRecord> rows(maxSerializableRows() + 1, StashRecord{2160, 0, 1});
+	NetworkMessage sizing;
+	std::vector<StashRecord> rows(maxSerializableRows(sizing) + 1, StashRecord{2160, 0, 1});
 
 	NetworkMessage msg;
 	CHECK(!serializeContents(msg, rows, 0));
@@ -338,9 +340,17 @@ TEST_CASE(supply_stash_refuses_one_row_over_the_limit)
 // that actually applies.
 TEST_CASE(supply_stash_row_limit_is_bounded_by_the_message_not_the_count_field)
 {
-	CHECK(maxSerializableRows() < std::numeric_limits<uint16_t>::max());
+	NetworkMessage empty;
+	CHECK(maxSerializableRows(empty) < std::numeric_limits<uint16_t>::max());
 	// comfortably above the 1000-row cap the stash itself enforces
-	CHECK(maxSerializableRows() > 1000);
+	CHECK(maxSerializableRows(empty) > 1000);
+
+	// And it shrinks as the message fills, which is the point of taking it.
+	NetworkMessage partlyUsed;
+	for (int i = 0; i < 1000; ++i) {
+		partlyUsed.add<uint32_t>(0);
+	}
+	CHECK(maxSerializableRows(partlyUsed) < maxSerializableRows(empty));
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -223,6 +223,49 @@ TEST_CASE(supply_stash_rejects_trailing_bytes)
 	CHECK(result.error == ParseError::TrailingBytes);
 }
 
+// The action numbering changed: the old Lua used OPEN = 1, STOW_ALL = 2,
+// WITHDRAW = 3, so 1 and 2 now mean StowContainer and StowStack. A client that
+// has not been updated must be refused, never reinterpreted as a command that
+// moves items. These three pin that down.
+TEST_CASE(supply_stash_rejects_legacy_open_request)
+{
+	NetworkMessage msg;
+	msg.addByte(1); // old ACTION_OPEN, now StowContainer, which needs 8 more bytes
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_legacy_stow_all_request)
+{
+	NetworkMessage msg;
+	msg.addByte(2); // old ACTION_STOW_ALL, now StowStack
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_legacy_withdraw_without_tier)
+{
+	// The old withdraw sent the tier byte only when it had one.
+	NetworkMessage msg;
+	msg.addByte(3);
+	msg.add<uint16_t>(2160);
+	msg.add<uint32_t>(10);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
 TEST_CASE(supply_stash_serializes_contents_tier_aware)
 {
 	std::vector<StashRecord> rows{

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -8,6 +8,8 @@
 
 #include "test_support.h"
 
+#include <limits>
+
 using namespace tfs::supply_stash;
 
 namespace {
@@ -275,7 +277,7 @@ TEST_CASE(supply_stash_serializes_contents_tier_aware)
 	};
 
 	NetworkMessage msg;
-	serializeContents(msg, rows, 42);
+	CHECK(serializeContents(msg, rows, 42));
 	rewind(msg);
 
 	CHECK(msg.get<uint16_t>() == 3);
@@ -300,12 +302,45 @@ TEST_CASE(supply_stash_serializes_contents_tier_aware)
 TEST_CASE(supply_stash_serializes_empty_contents)
 {
 	NetworkMessage msg;
-	serializeContents(msg, {}, 1000);
+	CHECK(serializeContents(msg, {}, 1000));
 	rewind(msg);
 
 	CHECK(msg.get<uint16_t>() == 0);
 	CHECK(msg.get<uint16_t>() == 1000);
 	CHECK(!msg.isOverrun());
+}
+
+// Both bounds have to be refused before anything is written. A partial payload is
+// worse than none: the count promises rows that never arrive, so the receiver
+// reads row bytes as freeSlots and every following packet is misaligned.
+TEST_CASE(supply_stash_serializes_at_the_row_limit)
+{
+	std::vector<StashRecord> rows(maxSerializableRows(), StashRecord{2160, 0, 1});
+
+	NetworkMessage msg;
+	CHECK(serializeContents(msg, rows, 0));
+	rewind(msg);
+	CHECK(msg.get<uint16_t>() == static_cast<uint16_t>(maxSerializableRows()));
+	CHECK(!msg.isOverrun());
+}
+
+TEST_CASE(supply_stash_refuses_one_row_over_the_limit)
+{
+	std::vector<StashRecord> rows(maxSerializableRows() + 1, StashRecord{2160, 0, 1});
+
+	NetworkMessage msg;
+	CHECK(!serializeContents(msg, rows, 0));
+	// Nothing may have been emitted.
+	CHECK(msg.getLength() == 0);
+}
+
+// The message body runs out before the 16-bit count does, so that is the bound
+// that actually applies.
+TEST_CASE(supply_stash_row_limit_is_bounded_by_the_message_not_the_count_field)
+{
+	CHECK(maxSerializableRows() < std::numeric_limits<uint16_t>::max());
+	// comfortably above the 1000-row cap the stash itself enforces
+	CHECK(maxSerializableRows() > 1000);
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_supply_stash_protocol.cpp
+++ b/src/tests/test_supply_stash_protocol.cpp
@@ -1,0 +1,268 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../networkmessage.h"
+#include "../supply_stash_protocol.h"
+
+#include "test_support.h"
+
+using namespace tfs::supply_stash;
+
+namespace {
+
+// Rewinds to the start of the body, which is where a request always begins.
+void rewind(NetworkMessage& msg) { CHECK(msg.setBufferPosition(0)); }
+
+NetworkMessage stowItemMessage(uint16_t itemId, uint32_t count)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowItem));
+	msg.addPosition(Position(0xFFFF, 0x40 | 3, 5));
+	msg.add<uint16_t>(itemId);
+	msg.addByte(7);
+	msg.add<uint32_t>(count);
+	rewind(msg);
+	return msg;
+}
+
+NetworkMessage withdrawMessage(uint16_t itemId, uint32_t amount, uint8_t tier)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::Withdraw));
+	msg.add<uint16_t>(itemId);
+	msg.add<uint32_t>(amount);
+	msg.addByte(tier);
+	rewind(msg);
+	return msg;
+}
+
+} // namespace
+
+TEST_CASE(supply_stash_parses_stow_item)
+{
+	auto msg = stowItemMessage(2160, 30);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::StowItem);
+	CHECK(result.request.itemId == 2160);
+	CHECK(result.request.count == 30);
+	CHECK(result.request.stackpos == 7);
+	// Container positions arrive as (0xFFFF, containerId | 0x40, slot), so the
+	// slot index rides in z and must survive the round trip intact.
+	CHECK(result.request.position.x == 0xFFFF);
+	CHECK(result.request.position.y == (0x40 | 3));
+	CHECK(result.request.position.z == 5);
+}
+
+TEST_CASE(supply_stash_parses_stow_container_without_count)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowContainer));
+	msg.addPosition(Position(100, 200, 7));
+	msg.add<uint16_t>(1988);
+	msg.addByte(1);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::StowContainer);
+	CHECK(result.request.itemId == 1988);
+	CHECK(result.request.count == 0);
+}
+
+TEST_CASE(supply_stash_parses_stow_stack)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowStack));
+	msg.addPosition(Position(1, 2, 3));
+	msg.add<uint16_t>(2160);
+	msg.addByte(0);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::StowStack);
+}
+
+TEST_CASE(supply_stash_parses_withdraw_with_tier)
+{
+	auto msg = withdrawMessage(2160, 100, 3);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.action == Action::Withdraw);
+	CHECK(result.request.itemId == 2160);
+	CHECK(result.request.count == 100);
+	CHECK(result.request.tier == 3);
+}
+
+// §17: a truncated packet must be rejected, not read past the end. Reads beyond
+// the body return 0 and set the overrun flag rather than throwing, so the parser
+// has to consult it instead of trusting the values.
+TEST_CASE(supply_stash_rejects_truncated_packet)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::StowItem));
+	msg.addPosition(Position(1, 2, 3));
+	msg.add<uint16_t>(2160);
+	// stackpos and count are missing
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_empty_packet)
+{
+	NetworkMessage msg;
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::Truncated);
+}
+
+TEST_CASE(supply_stash_rejects_unknown_action)
+{
+	NetworkMessage msg;
+	msg.addByte(0x7F);
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::UnknownAction);
+}
+
+TEST_CASE(supply_stash_rejects_zero_item_id)
+{
+	auto msg = stowItemMessage(0, 30);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidItemId);
+}
+
+TEST_CASE(supply_stash_rejects_zero_count)
+{
+	auto msg = stowItemMessage(2160, 0);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidCount);
+}
+
+TEST_CASE(supply_stash_rejects_oversized_count)
+{
+	auto msg = stowItemMessage(2160, MAX_STOW_COUNT + 1);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidCount);
+}
+
+TEST_CASE(supply_stash_accepts_count_at_the_cap)
+{
+	auto msg = stowItemMessage(2160, MAX_STOW_COUNT);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.count == MAX_STOW_COUNT);
+}
+
+TEST_CASE(supply_stash_rejects_zero_withdraw_amount)
+{
+	auto msg = withdrawMessage(2160, 0, 0);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidCount);
+}
+
+TEST_CASE(supply_stash_rejects_tier_above_maximum)
+{
+	auto msg = withdrawMessage(2160, 10, Stash::MAX_ITEM_TIER + 1);
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::InvalidTier);
+}
+
+TEST_CASE(supply_stash_accepts_tier_at_the_maximum)
+{
+	auto msg = withdrawMessage(2160, 10, Stash::MAX_ITEM_TIER);
+	const auto result = parseRequest(msg);
+
+	CHECK(static_cast<bool>(result));
+	CHECK(result.request.tier == Stash::MAX_ITEM_TIER);
+}
+
+// §17: extra bytes mean the two sides disagree about the layout. Accepting them
+// would leave the remainder to be read as though it were the next opcode.
+TEST_CASE(supply_stash_rejects_trailing_bytes)
+{
+	NetworkMessage msg;
+	msg.addByte(static_cast<uint8_t>(Action::Withdraw));
+	msg.add<uint16_t>(2160);
+	msg.add<uint32_t>(10);
+	msg.addByte(0);
+	msg.addByte(0xAB); // one byte too many
+	rewind(msg);
+
+	const auto result = parseRequest(msg);
+
+	CHECK(!static_cast<bool>(result));
+	CHECK(result.error == ParseError::TrailingBytes);
+}
+
+TEST_CASE(supply_stash_serializes_contents_tier_aware)
+{
+	std::vector<StashRecord> rows{
+	    StashRecord{2160, 0, 500},
+	    StashRecord{2160, 3, 25},
+	    StashRecord{2148, 0, 100000},
+	};
+
+	NetworkMessage msg;
+	serializeContents(msg, rows, 42);
+	rewind(msg);
+
+	CHECK(msg.get<uint16_t>() == 3);
+
+	CHECK(msg.get<uint16_t>() == 2160);
+	CHECK(msg.get<uint32_t>() == 500);
+	CHECK(msg.getByte() == 0);
+
+	// Same itemId, different tier: these must stay distinct rows on the wire.
+	CHECK(msg.get<uint16_t>() == 2160);
+	CHECK(msg.get<uint32_t>() == 25);
+	CHECK(msg.getByte() == 3);
+
+	CHECK(msg.get<uint16_t>() == 2148);
+	CHECK(msg.get<uint32_t>() == 100000);
+	CHECK(msg.getByte() == 0);
+
+	CHECK(msg.get<uint16_t>() == 42);
+	CHECK(!msg.isOverrun());
+}
+
+TEST_CASE(supply_stash_serializes_empty_contents)
+{
+	NetworkMessage msg;
+	serializeContents(msg, {}, 1000);
+	rewind(msg);
+
+	CHECK(msg.get<uint16_t>() == 0);
+	CHECK(msg.get<uint16_t>() == 1000);
+	CHECK(!msg.isOverrun());
+}
+
+TFS_TEST_MAIN()

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -265,6 +265,7 @@
     <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\stash.cpp" />
     <ClCompile Include="..\src\supply_stash_protocol.cpp" />
+    <ClCompile Include="..\src\supply_stash_rules.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -387,6 +388,7 @@
     <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\stash.h" />
     <ClInclude Include="..\src\supply_stash_protocol.h" />
+    <ClInclude Include="..\src\supply_stash_rules.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -264,6 +264,7 @@
     <ClCompile Include="..\src\mapcache.cpp" />
     <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\stash.cpp" />
+    <ClCompile Include="..\src\supply_stash_protocol.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -384,6 +385,7 @@
     <ClInclude Include="..\src\mapcache.h" />
     <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\stash.h" />
+    <ClInclude Include="..\src\supply_stash_protocol.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj
+++ b/vc18/theforgottenserver.vcxproj
@@ -285,6 +285,7 @@
     <ClCompile Include="..\src\party.cpp" />
     <ClCompile Include="..\src\performance_metrics.cpp" />
     <ClCompile Include="..\src\player.cpp" />
+    <ClCompile Include="..\src\player_stash.cpp" />
     <ClCompile Include="..\src\position.cpp" />
     <ClCompile Include="..\src\protocol.cpp" />
     <ClCompile Include="..\src\protocolgame.cpp" />
@@ -402,6 +403,7 @@
     <ClInclude Include="..\src\party.h" />
     <ClInclude Include="..\src\performance_metrics.h" />
     <ClInclude Include="..\src\player.h" />
+    <ClInclude Include="..\src\player_stash.h" />
     <ClInclude Include="..\src\position.h" />
     <ClInclude Include="..\src\protocol.h" />
     <ClInclude Include="..\src\protocolgame.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -56,6 +56,7 @@
     <ClCompile Include="..\src\outputmessage.cpp" />
     <ClCompile Include="..\src\party.cpp" />
     <ClCompile Include="..\src\player.cpp" />
+    <ClCompile Include="..\src\player_stash.cpp" />
     <ClCompile Include="..\src\position.cpp" />
     <ClCompile Include="..\src\protocol.cpp" />
     <ClCompile Include="..\src\protocolgame.cpp" />
@@ -285,6 +286,7 @@
     <ClInclude Include="..\src\packet_backlog.h" />
     <ClInclude Include="..\src\party.h" />
     <ClInclude Include="..\src\player.h" />
+    <ClInclude Include="..\src\player_stash.h" />
     <ClInclude Include="..\src\position.h" />
     <ClInclude Include="..\src\protocol.h" />
     <ClInclude Include="..\src\protocolgame.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -43,6 +43,7 @@
     <ClCompile Include="..\src\map.cpp" />
     <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\stash.cpp" />
+    <ClCompile Include="..\src\supply_stash_protocol.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -269,6 +270,7 @@
     <ClInclude Include="..\src\map.h" />
     <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\stash.h" />
+    <ClInclude Include="..\src\supply_stash_protocol.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />

--- a/vc18/theforgottenserver.vcxproj.filters
+++ b/vc18/theforgottenserver.vcxproj.filters
@@ -44,6 +44,7 @@
     <ClCompile Include="..\src\market.cpp" />
     <ClCompile Include="..\src\stash.cpp" />
     <ClCompile Include="..\src\supply_stash_protocol.cpp" />
+    <ClCompile Include="..\src\supply_stash_rules.cpp" />
     <ClCompile Include="..\src\matrixarea.cpp" />
     <ClCompile Include="..\src\monster.cpp" />
     <ClCompile Include="..\src\monsters.cpp" />
@@ -272,6 +273,7 @@
     <ClInclude Include="..\src\market.h" />
     <ClInclude Include="..\src\stash.h" />
     <ClInclude Include="..\src\supply_stash_protocol.h" />
+    <ClInclude Include="..\src\supply_stash_rules.h" />
     <ClInclude Include="..\src\matrixarea.h" />
     <ClInclude Include="..\src\monster.h" />
     <ClInclude Include="..\src\monsters.h" />


### PR DESCRIPTION
Consolidated as you asked: one branch, `feat/supply-stash-port`, one PR. #246, #247 and #248 are closed in favour of this — every commit and every test moved across, nothing dropped. From here all remaining stash work lands on this branch.

**32/32 tests pass.**

## Commits, in order

| # | Commit | What |
|---|---|---|
| 1 | protocol layer | action enum, parser, contents serializer, packet guards |
| 2 | legacy-client transition | tests pinning the numbering change |
| 3 | MSVC registration | `check_source_list_parity` |
| 4 | serialization bounds | refuse payloads that cannot be encoded |
| 5 | in-memory state | `PlayerStash`, dirty rows, per-row revisions |
| 6 | idempotent writes | absolute row writes for the save path |
| 7 | Player wiring | field, login load, save in the same transaction |
| 8 | eligibility rules | ported from `isPristineSupplyItem` |

## Wire contract, frozen as agreed

```
Position  = U16 x + U16 y + U8 z
stackpos  = U8
count     = U32
```

Container positions arrive as `(0xFFFF, containerId | 0x40, slot)`, so the slot index rides in `Position.z` and `stackpos` stays its own byte.

```
C -> S  0x28   Supply Stash actions
S -> C  0x28   ReLogin/Death window
S -> C  0x29   Supply Stash contents
```

Documented in the header because the numbers are only safe while the directions differ.

## Three things worth your attention

**The action numbering changes.** Old `OPEN = 1` and `STOW_ALL = 2` now mean `StowContainer` and `StowStack`. An un-updated Astra is safe **only** because the length guards reject short messages — `OPEN` is one byte where the new parser needs nine, so it is refused rather than acted on. Three tests pin that down. Relaxing those guards later turns old `OPEN` into a container stow.

**Persistence follows your decision.** The `Player` owns the count while online; rows are marked dirty and written through the existing snapshot/worker transaction, in the same transaction as inventory and depot. No synchronous SQL per drag. Rows are written **absolutely**, not by delta, because `flushPlayerSave` runs inside `executeWithinTransactionRollbackOnFailure` and a replayed delta would add twice.

Per-row revisions are the reason `PlayerStash` is not just a map: a stow landing while the save worker is running must survive that save's acknowledgement, or it is lost at logout. There is a test for exactly that.

Acknowledgement needed adding in **three** places, not two — `iologindata.cpp` plus both paths in `save_manager.cpp`.

**Eligibility is ported unchanged.** Containers, non-pickupables, store items, imbued items, 24 restricted instance attributes, decaying items, and partial duration or charges. The last two matter most: only the count survives a stow, so an item below full duration would come back refunded to full — a quiet duplication of value, not merely lost state.

## What this does not do

Nothing here is wired to gameplay. `supplystash.lua` still handles `PacketHandler(0x28)` exactly as before, so **behaviour is unchanged and there is nothing to compare before and after yet**. These are the pieces the stow path will stand on.

Still to come on this branch: `playerStowItem`/`playerStowContainer`/withdraw with rollback, the `playerMoveItem` interception, the Astra side, and removing the old Lua — **including carrying its `NetworkGuard` cooldowns across** (300 ms, 1000 ms for stow-all, 500 ms for withdraw), since that is the only anti-spam the stash has and it lives in the file being deleted.

## Verification

Unit tests only, and deliberately so — everything here is testable without a client. 23 protocol tests, 17 state tests, full suite green under GCC.

I have no 8.60 client, so drag and drop, tier round-trip, relog persistence and the dupe scenarios remain untested by me and I will not report them otherwise. The manual checklist is unchanged from what I sent with #246.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Supply Stash support for storing and withdrawing items, with quantities tracked by tier.
  * Supply Stash contents and available capacity now synchronize automatically.
  * Players can store eligible items from accessible depot or stash locations.
* **Validation**
  * Added safeguards for restricted items, invalid quantities, capacity limits, duplicates, and overflow.
* **Reliability**
  * Improved persistence so stash changes remain accurate across saves and acknowledgements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->