### PR TITLE
fix(proficiency): gate critical perks on spell/rune/auto-attack like …

### DIFF
--- a/data/scripts/network/battlepass/battlepass.lua
+++ b/data/scripts/network/battlepass/battlepass.lua
@@ -74,6 +74,31 @@ local function normalizeName(name)
 	return tostring(name or ""):lower()
 end
 
+-- onKill runs on every monster death, so it has to be able to reject a monster that no mission
+-- tracks before touching the KV store. Target names are normalized once here instead of on every
+-- comparison, and collected into a single lookup set.
+local missionWatchesEveryMonster = false
+local watchedMonsterNames = {}
+
+for _, mission in pairs(missionById) do
+	if mission.targets == "*" then
+		mission.normalizedTargets = "*"
+		missionWatchesEveryMonster = true
+	else
+		local normalized = {}
+		for _, targetName in ipairs(mission.targets or {}) do
+			local name = normalizeName(targetName)
+			normalized[name] = true
+			watchedMonsterNames[name] = true
+		end
+		mission.normalizedTargets = normalized
+	end
+end
+
+local function isMonsterWatched(normalizedName)
+	return missionWatchesEveryMonster or watchedMonsterNames[normalizedName] == true
+end
+
 local function clamp(value, minValue, maxValue)
 	value = tonumber(value) or 0
 	if value < minValue then
@@ -171,8 +196,6 @@ local function loadState(player)
 
 	if type(state) ~= "table" or state.seasonId ~= season.id then
 		state = resetStateForSeason(season)
-	else
-		ensureStateTables(state)
 	end
 
 	if state.dailyKey ~= daily.key then
@@ -220,18 +243,13 @@ local function addShopPoints(state, amount)
 	state.shopPoints = clamp((tonumber(state.shopPoints) or 0) + amount, 0, 0xFFFFFFFF)
 end
 
-local function missionMatches(mission, monsterName)
-	if mission.targets == "*" then
+-- Takes an already normalized monster name; see the precomputation above.
+local function missionMatches(mission, normalizedName)
+	local targets = mission.normalizedTargets
+	if targets == "*" then
 		return true
 	end
-
-	local normalized = normalizeName(monsterName)
-	for _, targetName in ipairs(mission.targets or {}) do
-		if normalized == normalizeName(targetName) then
-			return true
-		end
-	end
-	return false
+	return targets ~= nil and targets[normalizedName] == true
 end
 
 local function getMissionPayload(state, mission, daily)
@@ -1286,8 +1304,8 @@ function BattlePassSystem.rerollDailyMission(player, data)
 	return true
 end
 
-local function updateMissionProgress(player, state, mission, daily, monsterName)
-	if not mission or not missionMatches(mission, monsterName) then
+local function updateMissionProgress(player, state, mission, daily, normalizedName)
+	if not mission or not missionMatches(mission, normalizedName) then
 		return false
 	end
 
@@ -1323,6 +1341,14 @@ function BattlePassSystem.onKill(player, target)
 	if target:getMaster() then
 		return true
 	end
+
+	-- Reject monsters no mission tracks before anything else: loadState() reaches into the KV
+	-- store and deserializes the whole battle pass state, and this runs on every kill.
+	local normalizedName = normalizeName(target:getName())
+	if not isMonsterWatched(normalizedName) then
+		return true
+	end
+
 	if getRequirementError(player) then
 		return true
 	end
@@ -1332,7 +1358,6 @@ function BattlePassSystem.onKill(player, target)
 		return true
 	end
 
-	local monsterName = target:getName()
 	local changed = false
 	local previousStep = getCurrentRewardStep(state.points)
 	local wasCompleted = state.completed
@@ -1340,15 +1365,18 @@ function BattlePassSystem.onKill(player, target)
 
 	local dailyMissions = getActiveDailyMissions(state, daily.key)
 	if dailyMissions[1] then
-		changed = updateMissionProgress(player, state, dailyMissions[1], true, monsterName) or changed
+		changed = updateMissionProgress(player, state, dailyMissions[1], true, normalizedName) or changed
 	end
 	if isPremiumActive(state) and dailyMissions[2] then
-		changed = updateMissionProgress(player, state, dailyMissions[2], true, monsterName) or changed
+		changed = updateMissionProgress(player, state, dailyMissions[2], true, normalizedName) or changed
 	end
 
 	for _, mission in ipairs(generalMissions) do
-		if not state.completed and isGeneralMissionUnlocked(mission, season) then
-			changed = updateMissionProgress(player, state, mission, false, monsterName) or changed
+		-- state.completed is re-read every iteration on purpose: completing a mission here can
+		-- complete the whole battle pass, and the remaining missions must then be skipped.
+		if not state.completed and missionMatches(mission, normalizedName)
+			and isGeneralMissionUnlocked(mission, season) then
+			changed = updateMissionProgress(player, state, mission, false, normalizedName) or changed
 		end
 	end
 

--- a/data/scripts/network/proficiency/proficiency.lua
+++ b/data/scripts/network/proficiency/proficiency.lua
@@ -457,6 +457,10 @@ refreshProfileSpellAugments = function(player, profile)
 		if not shifted or shifted == 0 then
 			return COMBAT_NONE
 		end
+		-- Physical is 1, which has no trailing zeros and so falls outside the shift formula below.
+		if shifted == 1 then
+			return COMBAT_PHYSICALDAMAGE
+		end
 		-- undoShift: trailingZeros - 2
 		local unshifted = 0
 		local n = shifted

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -271,12 +271,14 @@ void Combat::doCombatCleave(Creature* caster, uint32_t primaryTargetId, const Co
 	}
 }
 
-CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target, std::string_view instantSpellName) const
+CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target, const CombatSource& source) const
 {
 	CombatDamage damage;
 	damage.origin = params.origin;
 	damage.primary.type = params.combatType;
-	damage.instantSpellName = instantSpellName;
+	damage.instantSpellName = source.instantSpellName;
+	damage.runeSpell = source.runeSpell;
+	damage.offensiveRune = source.offensiveRune;
 	if (formulaType == COMBAT_FORMULA_DAMAGE) {
 		damage.primary.value = normal_random(static_cast<int32_t>(mina), static_cast<int32_t>(maxa));
 	} else if (creature) {
@@ -1004,18 +1006,18 @@ void Combat::addDistanceEffect(Creature* caster, const Position& fromPos, const 
 	}
 }
 
-void Combat::doCombat(Creature* caster, Creature* target, std::string_view instantSpellName) const
+void Combat::doCombat(Creature* caster, Creature* target, const CombatSource& source) const
 {
 	PerformanceScope performanceScope(PerformanceMetric::CombatDoCombat);
 	if (params.chainCallback) {
-		if (doCombatChain(caster, target, params.aggressive, std::string(instantSpellName))) {
+		if (doCombatChain(caster, target, params.aggressive, source)) {
 			return;
 		}
 	}
 
 	// target combat callback function
 	if (params.combatType != COMBAT_NONE) {
-		CombatDamage damage = getCombatDamage(caster, target, instantSpellName);
+		CombatDamage damage = getCombatDamage(caster, target, source);
 
 		bool canCombat =
 		    !params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR);
@@ -1076,18 +1078,18 @@ void Combat::doCombat(Creature* caster, Creature* target, std::string_view insta
 	}
 }
 
-void Combat::doCombat(Creature* caster, const Position& position, std::string_view instantSpellName) const
+void Combat::doCombat(Creature* caster, const Position& position, const CombatSource& source) const
 {
 	PerformanceScope performanceScope(PerformanceMetric::CombatDoCombat);
 	if (params.chainCallback) {
-		if (doCombatChain(caster, nullptr, params.aggressive, std::string(instantSpellName))) {
+		if (doCombatChain(caster, nullptr, params.aggressive, source)) {
 			return;
 		}
 	}
 
 	// area combat callback function
 	if (params.combatType != COMBAT_NONE) {
-		CombatDamage damage = getCombatDamage(caster, nullptr, instantSpellName);
+		CombatDamage damage = getCombatDamage(caster, nullptr, source);
 		doAreaCombat(caster, position, area.get(), damage, params);
 	} else {
 		auto tiles = caster ? getCombatArea(caster->getPosition(), position, area.get())
@@ -1232,10 +1234,7 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 
 			if (!damage.critical && damage.primary.type != COMBAT_HEALING && damage.origin != ORIGIN_CONDITION) {
 				if (wpEnabled) {
-					casterPlayer->weaponProficiency().applyAutoAttackCritical(damage);
-					casterPlayer->weaponProficiency().applyGeneralCritical(damage);
-					casterPlayer->weaponProficiency().applyRunesCritical(damage, params.aggressive);
-					casterPlayer->weaponProficiency().applyElementCritical(damage);
+					casterPlayer->weaponProficiency().applyCriticalPerks(damage);
 				}
 
 				const uint16_t targetRaceId = target ? getMonsterRaceId(target->getMonster()) : 0;
@@ -1506,14 +1505,9 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 	const bool wpEnabled = casterPlayer && ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED);
 
 	if (wpEnabled) {
+		// The spell skill percentage is applied once, in getCombatDamage(), for both the target and
+		// the area path — applying it again here would double it for every area spell.
 		casterPlayer->weaponProficiency().applySkillAutoAttackPercentage(damage);
-		if (!damage.instantSpellName.empty()) {
-			if (damage.primary.type == COMBAT_HEALING) {
-				casterPlayer->weaponProficiency().applySkillSpellPercentage(damage, true);
-			} else {
-				casterPlayer->weaponProficiency().applySkillSpellPercentage(damage);
-			}
-		}
 	}
 
 	int32_t criticalPrimary = 0;
@@ -1521,10 +1515,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 	if (!damage.critical && damage.primary.type != COMBAT_HEALING && casterPlayer &&
 	    damage.origin != ORIGIN_CONDITION) {
 		if (wpEnabled) {
-			casterPlayer->weaponProficiency().applyAutoAttackCritical(damage);
-			casterPlayer->weaponProficiency().applyGeneralCritical(damage);
-			casterPlayer->weaponProficiency().applyRunesCritical(damage, params.aggressive);
-			casterPlayer->weaponProficiency().applyElementCritical(damage);
+			casterPlayer->weaponProficiency().applyCriticalPerks(damage);
 		}
 
 		int32_t chance = std::clamp<int32_t>(
@@ -2410,7 +2401,7 @@ std::vector<std::pair<Position, std::vector<uint32_t>>> Combat::pickChainTargets
 	return resultMap;
 }
 
-bool Combat::doCombatChain(Creature* caster, Creature* target, bool aggressive, std::string instantSpellName) const
+bool Combat::doCombatChain(Creature* caster, Creature* target, bool aggressive, const CombatSource& source) const
 {
 	if (!params.chainCallback) {
 		return false;
@@ -2428,13 +2419,18 @@ bool Combat::doCombatChain(Creature* caster, Creature* target, bool aggressive, 
 
 	auto self = shared_from_this();
 	const uint8_t capturedChainEffect = params.chainEffect;
+	// The chain fires from scheduled events, so the source has to be captured by value; its
+	// string_view would dangle by the time the event runs.
+	std::string instantSpellName{source.instantSpellName};
+	const bool runeSpell = source.runeSpell;
+	const bool offensiveRune = source.offensiveRune;
 	int i = 0;
 	for (const auto& [from, toVector] : targets) {
 		auto delay = i * std::max<int32_t>(MIN_TASK_INTERVAL, ConfigManager::getInteger(ConfigManager::COMBAT_CHAIN_DELAY));
 		++i;
 		for (const auto& to : toVector) {
 			g_scheduler.addEvent(delay, [self, casterId = caster ? caster->getID() : 0, to, from, capturedChainEffect,
-			                             instantSpellName]() {
+			                             instantSpellName, runeSpell, offensiveRune]() {
 				auto resolvedCasterRef = g_game.getCreatureByIDShared(casterId);
 				Creature* resolvedCaster = resolvedCasterRef.get();
 				auto nextTargetRef = g_game.getCreatureByIDShared(to);
@@ -2444,7 +2440,8 @@ bool Combat::doCombatChain(Creature* caster, Creature* target, bool aggressive, 
 				}
 				Combat::doChainEffect(from, nextTarget->getPosition(), capturedChainEffect, nextTarget->getInstanceID());
 				if (resolvedCaster) {
-					CombatDamage damage = self->getCombatDamage(resolvedCaster, nextTarget, instantSpellName);
+					CombatDamage damage = self->getCombatDamage(resolvedCaster, nextTarget,
+					                                            {instantSpellName, runeSpell, offensiveRune});
 					bool canCombat = !self->params.aggressive ||
 					                 (resolvedCaster != nextTarget &&
 					                  Combat::canDoCombat(resolvedCaster, nextTarget) == RETURNVALUE_NOERROR);

--- a/src/combat.h
+++ b/src/combat.h
@@ -6,6 +6,7 @@
 
 #include "baseevents.h"
 #include "condition.h"
+#include "luavariant.h"
 #include "map.h"
 #include "thing.h"
 
@@ -121,6 +122,21 @@ private:
 	bool hasExtArea = false;
 };
 
+// Identifies what produced a combat, so the damage can be attributed to an instant spell, a rune
+// or neither. Runes are indistinguishable from instant spells by origin alone (both are
+// ORIGIN_SPELL) and carry no name, which is what the weapon proficiency perks need to tell apart.
+struct CombatSource
+{
+	std::string_view instantSpellName;
+	bool runeSpell = false;
+	bool offensiveRune = false; // rune whose spell group is SPELLGROUP_ATTACK
+
+	static CombatSource fromVariant(const LuaVariant& variant)
+	{
+		return {variant.instantName, variant.runeSpell, variant.offensiveRune};
+	}
+};
+
 class Combat : public std::enable_shared_from_this<Combat>
 {
 public:
@@ -142,8 +158,8 @@ public:
 
 	static void addDistanceEffect(Creature* caster, const Position& fromPos, const Position& toPos, uint16_t effect);
 
-	void doCombat(Creature* caster, Creature* target, std::string_view instantSpellName = {}) const;
-	void doCombat(Creature* caster, const Position& position, std::string_view instantSpellName = {}) const;
+	void doCombat(Creature* caster, Creature* target, const CombatSource& source = {}) const;
+	void doCombat(Creature* caster, const Position& position, const CombatSource& source = {}) const;
 
 	static void doTargetCombat(Creature* caster, Creature* target, CombatDamage& damage, const CombatParams& params);
 	static void doAreaCombat(Creature* caster, const Position& position, const AreaCombat* area, CombatDamage& damage,
@@ -178,7 +194,7 @@ public:
 	}
 
 	void setupChain(const class Weapon* weapon);
-	bool doCombatChain(Creature* caster, Creature* target, bool aggressive, std::string instantSpellName = {}) const;
+	bool doCombatChain(Creature* caster, Creature* target, bool aggressive, const CombatSource& source = {}) const;
 	void setChainCallback(uint8_t chainTargets, uint8_t chainDistance, bool backtracking);
 
 private:
@@ -191,7 +207,7 @@ private:
 
 	static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile,
 	                              const CombatParams& params, AreaCombatMetricsSample* metrics = nullptr);
-	CombatDamage getCombatDamage(Creature* creature, Creature* target, std::string_view instantSpellName) const;
+	CombatDamage getCombatDamage(Creature* creature, Creature* target, const CombatSource& source) const;
 
 	// configurable
 	CombatParams params;

--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -5,7 +5,39 @@
 
 #include "depotlocker.h"
 
+#include "tools.h"
+
 DepotLocker::DepotLocker(uint16_t type) : Container(type, 4) {}
+
+ReturnValue DepotLocker::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags,
+                                  Creature* actor) const
+{
+	// The locker is only the shell that holds the depot chest, inbox, market and supply stash.
+	// Those are placed through internalAddThing, which does not go through queryAdd, so anything
+	// arriving here is an attempt to store an item in the locker itself. Items belong in the
+	// depot boxes inside the chest.
+	if (actor && !hasBitSet(FLAG_NOLIMIT, flags)) {
+		return RETURNVALUE_NOTPOSSIBLE;
+	}
+
+	if (!hasBitSet(FLAG_NOLIMIT, flags)) {
+		return RETURNVALUE_CONTAINERNOTENOUGHROOM;
+	}
+
+	const Item* item = thing.getItem();
+	if (!item) {
+		return RETURNVALUE_NOTPOSSIBLE;
+	}
+
+	if (item == this) {
+		return RETURNVALUE_THISISIMPOSSIBLE;
+	}
+
+	// No isPickupable() check here, unlike Inbox: what legitimately goes into the locker is the
+	// depot chest, inbox, market and supply stash, and those are fixed structures rather than
+	// pickupable items.
+	return RETURNVALUE_NOERROR;
+}
 
 Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 {

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -19,6 +19,10 @@ public:
 
 	void removeInbox(Inbox* inbox);
 
+	// cylinder implementations
+	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
+	                     Creature* actor = nullptr) const override;
+
 	// serialization
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -784,6 +784,10 @@ struct CombatDamage
 	bool initialOriginCaptured = false;
 	bool equipmentDamageBonusApplied = false;
 	bool equipmentDamageReductionApplied = false;
+	// Runes carry no instantSpellName, so these flags are what tells a rune hit apart from an
+	// instant spell hit (both arrive with origin == ORIGIN_SPELL).
+	bool runeSpell = false;
+	bool offensiveRune = false; // runeSpell whose spell group is SPELLGROUP_ATTACK
 	int32_t criticalDamage = 0;
 	int32_t criticalChance = 0;
 	int32_t perfectShotDamage = 0;

--- a/src/luacombat.cpp
+++ b/src/luacombat.cpp
@@ -330,21 +330,21 @@ int luaCombatExecute(lua_State* L)
 			}
 
 			if (combat->hasArea()) {
-				combat->doCombat(creature, target->getPosition(), variant.instantName);
+				combat->doCombat(creature, target->getPosition(), CombatSource::fromVariant(variant));
 			} else {
-				combat->doCombat(creature, target, variant.instantName);
+				combat->doCombat(creature, target, CombatSource::fromVariant(variant));
 			}
 			break;
 		}
 
 		case VARIANT_POSITION: {
-			combat->doCombat(creature, variant.getPosition(), variant.instantName);
+			combat->doCombat(creature, variant.getPosition(), CombatSource::fromVariant(variant));
 			break;
 		}
 
 		case VARIANT_TARGETPOSITION: {
 			if (combat->hasArea()) {
-				combat->doCombat(creature, variant.getTargetPosition(), variant.instantName);
+				combat->doCombat(creature, variant.getTargetPosition(), CombatSource::fromVariant(variant));
 			} else {
 				combat->postCombatEffects(creature, variant.getTargetPosition());
 				g_game.addMagicEffect(variant.getTargetPosition(), CONST_ME_POFF, creature ? creature->getInstanceID() : 0);
@@ -359,7 +359,7 @@ int luaCombatExecute(lua_State* L)
 				return 1;
 			}
 
-			combat->doCombat(creature, target.get(), variant.instantName);
+			combat->doCombat(creature, target.get(), CombatSource::fromVariant(variant));
 			break;
 		}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1007,9 +1007,11 @@ ReturnValue LuaScriptInterface::callReturnValueFunction(int params)
 
 void Lua::pushVariant(lua_State* L, const LuaVariant& var)
 {
-	lua_createtable(L, 0, 3);
+	lua_createtable(L, 0, 5);
 	setField(L, "type", var.type());
 	setField(L, "instantName", var.instantName);
+	setField(L, "runeSpell", var.runeSpell ? 1 : 0);
+	setField(L, "offensiveRune", var.offensiveRune ? 1 : 0);
 	switch (var.type()) {
 		case VARIANT_NUMBER:
 			setField(L, "number", var.getNumber());
@@ -1316,6 +1318,10 @@ LuaVariant Lua::getVariant(lua_State* L, int32_t arg)
 {
 	LuaVariant var;
 	var.instantName = getFieldString(L, arg, "instantName");
+	lua_pop(L, 1);
+	var.runeSpell = getField<uint8_t>(L, arg, "runeSpell") != 0;
+	lua_pop(L, 1);
+	var.offensiveRune = getField<uint8_t>(L, arg, "offensiveRune") != 0;
 	lua_pop(L, 1);
 	switch (getField<LuaVariantType_t>(L, arg, "type")) {
 		case VARIANT_NUMBER: {

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -18,6 +18,11 @@ class LuaVariant
 public:
 	std::string instantName;
 
+	// Set by RuneSpell before the variant is handed to onCastSpell, so that combat:execute()
+	// can tell the resulting damage apart from an instant spell.
+	bool runeSpell = false;
+	bool offensiveRune = false;
+
 	uint32_t getNumber() const { return std::get<VARIANT_NUMBER>(variant); }
 	const Position& getPosition() const { return std::get<VARIANT_POSITION>(variant); }
 	const Position& getTargetPosition() const { return std::get<VARIANT_TARGETPOSITION>(variant); }

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -1144,6 +1144,7 @@ bool RuneSpell::executeUse(Player* player, const std::shared_ptr<Item>& item, co
 	}
 
 	LuaVariant var;
+	markRuneSource(var);
 
 	if (needTarget) {
 		if (target == nullptr) {
@@ -1187,6 +1188,7 @@ bool RuneSpell::executeUse(Player* player, const std::shared_ptr<Item>& item, co
 bool RuneSpell::castSpell(Creature* creature)
 {
 	LuaVariant var;
+	markRuneSource(var);
 	var.setNumber(creature->getID());
 	return internalCastSpell(creature, var, false);
 }
@@ -1194,6 +1196,7 @@ bool RuneSpell::castSpell(Creature* creature)
 bool RuneSpell::castSpell(Creature* creature, Creature* target)
 {
 	LuaVariant var;
+	markRuneSource(var);
 	var.setNumber(target->getID());
 	return internalCastSpell(creature, var, false);
 }

--- a/src/spells.h
+++ b/src/spells.h
@@ -6,6 +6,7 @@
 
 #include "actions.h"
 #include "baseevents.h"
+#include "luavariant.h"
 #include "player.h"
 #include "talkaction.h"
 #include "tools.h"
@@ -319,6 +320,14 @@ private:
 	std::string_view getScriptEventName() const override;
 
 	bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
+
+	// Tags the variant handed to onCastSpell so the combat it triggers is attributed to a rune
+	// rather than an instant spell. Weapon proficiency perks distinguish the two.
+	void markRuneSource(LuaVariant& var) const
+	{
+		var.runeSpell = true;
+		var.offensiveRune = getGroup() == SPELLGROUP_ATTACK;
+	}
 
 	uint16_t runeId = 0;
 	uint32_t charges = 0;

--- a/src/tests/test_depot_locker.cpp
+++ b/src/tests/test_depot_locker.cpp
@@ -1,0 +1,91 @@
+#include "../otpch.h"
+
+#include "../depotchest.h"
+#include "../depotlocker.h"
+#include "../game.h"
+#include "../inbox.h"
+#include "../item.h"
+
+#include "test_support.h"
+
+namespace {
+
+void ensureItemTypesLoaded()
+{
+	if (Item::items.size() != 0) {
+		return;
+	}
+
+	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+	                       "data/items/items.otb";
+	CHECK(Item::items.loadFromOtb(itemsPath.string()));
+}
+
+// A creature pointer is all queryAdd needs to tell a player-driven move from an engine-driven
+// one; it is only compared against nullptr and never dereferenced.
+Creature* const someActor = reinterpret_cast<Creature*>(0x1);
+
+} // namespace
+
+TEST_CASE(depot_locker_rejects_items_dragged_by_a_player)
+{
+	ensureItemTypesLoaded();
+
+	DepotLocker locker(ITEM_LOCKER);
+	auto item = Item::CreateItem(ITEM_GOLD_COIN, 1);
+	CHECK(item != nullptr);
+
+	// This is the reported bug: dropping a normal item on the locker root used to succeed.
+	CHECK(locker.queryAdd(INDEX_WHEREEVER, *item, 1, 0, someActor) == RETURNVALUE_NOTPOSSIBLE);
+	CHECK(locker.queryAdd(0, *item, 1, 0, someActor) == RETURNVALUE_NOTPOSSIBLE);
+}
+
+TEST_CASE(depot_locker_rejects_items_moved_without_the_nolimit_flag)
+{
+	ensureItemTypesLoaded();
+
+	DepotLocker locker(ITEM_LOCKER);
+	auto item = Item::CreateItem(ITEM_GOLD_COIN, 1);
+	CHECK(item != nullptr);
+
+	// No actor, but also no FLAG_NOLIMIT: still not a legitimate way into the locker.
+	CHECK(locker.queryAdd(INDEX_WHEREEVER, *item, 1, 0, nullptr) == RETURNVALUE_CONTAINERNOTENOUGHROOM);
+}
+
+TEST_CASE(depot_locker_still_accepts_engine_driven_structure_items)
+{
+	ensureItemTypesLoaded();
+
+	DepotLocker locker(ITEM_LOCKER);
+	auto inbox = Item::CreateItem(ITEM_INBOX);
+	CHECK(inbox != nullptr);
+
+	// The chest, inbox, market and stash are placed with FLAG_NOLIMIT and no actor.
+	CHECK(locker.queryAdd(INDEX_WHEREEVER, *inbox, 1, FLAG_NOLIMIT, nullptr) == RETURNVALUE_NOERROR);
+}
+
+TEST_CASE(depot_box_still_accepts_items_from_a_player)
+{
+	ensureItemTypesLoaded();
+
+	// The fix must not touch where items actually belong.
+	DepotBox box(ITEM_DEPOT_BOX_1);
+	auto item = Item::CreateItem(ITEM_GOLD_COIN, 1);
+	CHECK(item != nullptr);
+
+	CHECK(box.queryAdd(INDEX_WHEREEVER, *item, 1, 0, someActor) == RETURNVALUE_NOERROR);
+}
+
+TEST_CASE(inbox_keeps_rejecting_player_moves)
+{
+	ensureItemTypesLoaded();
+
+	// Regression guard for the sibling container the locker fix was modelled on.
+	Inbox inbox(ITEM_INBOX);
+	auto item = Item::CreateItem(ITEM_GOLD_COIN, 1);
+	CHECK(item != nullptr);
+
+	CHECK(inbox.queryAdd(INDEX_WHEREEVER, *item, 1, 0, someActor) == RETURNVALUE_NOTPOSSIBLE);
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_weapon_proficiency.cpp
+++ b/src/tests/test_weapon_proficiency.cpp
@@ -10,18 +10,24 @@ namespace {
 
 using enum WeaponProficiencyBonus_t;
 
+// The config is process-wide and the tests share one binary, so every change to it has to be
+// undone before the next test runs.
 class ProficiencyEnabledGuard
 {
 public:
-	ProficiencyEnabledGuard() : previous(ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED))
+	explicit ProficiencyEnabledGuard(bool enabled = true) :
+		previous(ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED))
 	{
-		ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, true);
+		ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, enabled);
 	}
 
 	~ProficiencyEnabledGuard()
 	{
 		ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, previous);
 	}
+
+	ProficiencyEnabledGuard(const ProficiencyEnabledGuard&) = delete;
+	ProficiencyEnabledGuard& operator=(const ProficiencyEnabledGuard&) = delete;
 
 private:
 	bool previous;
@@ -213,7 +219,7 @@ TEST_CASE(disabling_the_system_keeps_combat_untouched)
 	proficiency.resetStats();
 
 	// With the system off applyPerk is a no-op, so nothing can leak into combat.
-	ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, false);
+	ProficiencyEnabledGuard disabled(false);
 	proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_HIT_CHANCE), 0.05);
 	applyIcePerks(proficiency);
 

--- a/src/tests/test_weapon_proficiency.cpp
+++ b/src/tests/test_weapon_proficiency.cpp
@@ -1,0 +1,266 @@
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../player.h"
+#include "../weapon_proficiency.h"
+
+#include "test_support.h"
+
+namespace {
+
+using enum WeaponProficiencyBonus_t;
+
+class ProficiencyEnabledGuard
+{
+public:
+	ProficiencyEnabledGuard() : previous(ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED))
+	{
+		ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, true);
+	}
+
+	~ProficiencyEnabledGuard()
+	{
+		ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, previous);
+	}
+
+private:
+	bool previous;
+};
+
+CombatDamage makeDamage(CombatOrigin origin, CombatType_t type)
+{
+	CombatDamage damage;
+	damage.origin = origin;
+	damage.primary.type = type;
+	damage.primary.value = -1000;
+	return damage;
+}
+
+CombatDamage makeInstantSpell(CombatType_t type)
+{
+	CombatDamage damage = makeDamage(ORIGIN_SPELL, type);
+	damage.instantSpellName = "exori frigo";
+	return damage;
+}
+
+CombatDamage makeRune(CombatType_t type, bool offensive)
+{
+	CombatDamage damage = makeDamage(ORIGIN_SPELL, type);
+	damage.runeSpell = true;
+	damage.offensiveRune = offensive;
+	return damage;
+}
+
+// Mirrors the perk set that triggered the original report: an ice rod carrying
+// "+2% critical hit chance for Ice spells and runes" and "+10% ice critical extra damage".
+void applyIcePerks(WeaponProficiency& proficiency)
+{
+	proficiency.applyPerk(static_cast<uint8_t>(ELEMENTAL_HIT_CHANCE), 0.02, 0, 0, SKILL_FIST, COMBAT_ICEDAMAGE);
+	proficiency.applyPerk(static_cast<uint8_t>(ELEMENTAL_CRITICAL_EXTRA_DAMAGE), 0.10, 0, 0, SKILL_FIST,
+	                      COMBAT_ICEDAMAGE);
+}
+
+} // namespace
+
+TEST_CASE(proficiency_perk_values_convert_to_basis_points)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+
+	// 0.02 in the JSON means 2%, which combat consumes as 200 out of 10000. It must never
+	// become 200% (20000) or 0.02% (2).
+	proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_HIT_CHANCE), 0.02);
+	proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_EXTRA_DAMAGE), 0.10);
+
+	CombatDamage damage = makeDamage(ORIGIN_MELEE, COMBAT_PHYSICALDAMAGE);
+	proficiency.applyCriticalPerks(damage);
+
+	CHECK(damage.criticalChance == 200);
+	CHECK(damage.criticalDamage == 1000);
+}
+
+TEST_CASE(elemental_crit_perks_skip_auto_attacks)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+	applyIcePerks(proficiency);
+
+	// A wand/rod swing is an auto attack, not a spell or rune: it must not pick up the
+	// "for Ice spells and runes" perk. This was the source of the inflated wand criticals.
+	for (const CombatOrigin origin : {ORIGIN_WAND, ORIGIN_MELEE, ORIGIN_RANGED}) {
+		CombatDamage damage = makeDamage(origin, COMBAT_ICEDAMAGE);
+		proficiency.applyCriticalPerks(damage);
+		CHECK(damage.criticalChance == 0);
+		CHECK(damage.criticalDamage == 0);
+	}
+}
+
+TEST_CASE(elemental_crit_perks_apply_to_spells_and_runes_of_that_element)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+	applyIcePerks(proficiency);
+
+	CombatDamage spell = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(spell);
+	CHECK(spell.criticalChance == 200);
+	CHECK(spell.criticalDamage == 1000);
+
+	CombatDamage rune = makeRune(COMBAT_ICEDAMAGE, true);
+	proficiency.applyCriticalPerks(rune);
+	CHECK(rune.criticalChance == 200);
+	CHECK(rune.criticalDamage == 1000);
+
+	// A non-attack rune is still "a rune" for the elemental perk, matching Crystal.
+	CombatDamage supportRune = makeRune(COMBAT_ICEDAMAGE, false);
+	proficiency.applyCriticalPerks(supportRune);
+	CHECK(supportRune.criticalChance == 200);
+
+	// Another element gets nothing.
+	CombatDamage fireSpell = makeInstantSpell(COMBAT_FIREDAMAGE);
+	proficiency.applyCriticalPerks(fireSpell);
+	CHECK(fireSpell.criticalChance == 0);
+	CHECK(fireSpell.criticalDamage == 0);
+}
+
+TEST_CASE(rune_crit_perks_require_an_offensive_rune)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+	proficiency.applyPerk(static_cast<uint8_t>(RUNE_CRITICAL_HIT_CHANCE), 0.02);
+	proficiency.applyPerk(static_cast<uint8_t>(RUNE_CRITICAL_EXTRA_DAMAGE), 0.05);
+
+	CombatDamage attackRune = makeRune(COMBAT_ICEDAMAGE, true);
+	proficiency.applyCriticalPerks(attackRune);
+	CHECK(attackRune.criticalChance == 200);
+	CHECK(attackRune.criticalDamage == 500);
+
+	// Instant spells must not collect the rune perk...
+	CombatDamage spell = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(spell);
+	CHECK(spell.criticalChance == 0);
+	CHECK(spell.criticalDamage == 0);
+
+	// ...nor runes outside the attack group, nor auto attacks.
+	CombatDamage supportRune = makeRune(COMBAT_ICEDAMAGE, false);
+	proficiency.applyCriticalPerks(supportRune);
+	CHECK(supportRune.criticalChance == 0);
+
+	CombatDamage wand = makeDamage(ORIGIN_WAND, COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(wand);
+	CHECK(wand.criticalChance == 0);
+}
+
+TEST_CASE(auto_attack_crit_perks_cover_wands_but_not_spells)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+	proficiency.applyPerk(static_cast<uint8_t>(AUTO_ATTACK_CRITICAL_HIT_CHANCE), 0.03);
+	proficiency.applyPerk(static_cast<uint8_t>(AUTO_ATTACK_CRITICAL_EXTRA_DAMAGE), 0.20);
+
+	for (const CombatOrigin origin : {ORIGIN_MELEE, ORIGIN_RANGED, ORIGIN_WAND}) {
+		CombatDamage damage = makeDamage(origin, COMBAT_PHYSICALDAMAGE);
+		proficiency.applyCriticalPerks(damage);
+		CHECK(damage.criticalChance == 300);
+		CHECK(damage.criticalDamage == 2000);
+	}
+
+	CombatDamage spell = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(spell);
+	CHECK(spell.criticalChance == 0);
+
+	CombatDamage rune = makeRune(COMBAT_ICEDAMAGE, true);
+	proficiency.applyCriticalPerks(rune);
+	CHECK(rune.criticalChance == 0);
+}
+
+TEST_CASE(general_crit_perks_apply_to_every_hit_exactly_once)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+	proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_HIT_CHANCE), 0.02);
+	proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_EXTRA_DAMAGE), 0.07);
+	// An elemental perk on the same element must not be double counted on an auto attack.
+	applyIcePerks(proficiency);
+
+	CombatDamage wand = makeDamage(ORIGIN_WAND, COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(wand);
+	CHECK(wand.criticalChance == 200);
+	CHECK(wand.criticalDamage == 700);
+
+	// On an ice spell the general and elemental perks stack, once each.
+	CombatDamage spell = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(spell);
+	CHECK(spell.criticalChance == 400);
+	CHECK(spell.criticalDamage == 1700);
+}
+
+TEST_CASE(disabling_the_system_keeps_combat_untouched)
+{
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+
+	{
+		ProficiencyEnabledGuard guard;
+		proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_HIT_CHANCE), 0.05);
+	}
+	proficiency.resetStats();
+
+	// With the system off applyPerk is a no-op, so nothing can leak into combat.
+	ConfigManager::setBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED, false);
+	proficiency.applyPerk(static_cast<uint8_t>(CRITICAL_HIT_CHANCE), 0.05);
+	applyIcePerks(proficiency);
+
+	CombatDamage spell = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(spell);
+	CHECK(spell.criticalChance == 0);
+	CHECK(spell.criticalDamage == 0);
+}
+
+TEST_CASE(resetting_stats_clears_perks_so_reequipping_does_not_accumulate)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+
+	// Equip, unequip and equip again: the perk must count once, not three times.
+	for (int i = 0; i < 3; ++i) {
+		proficiency.resetStats();
+		applyIcePerks(proficiency);
+	}
+
+	CombatDamage spell = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(spell);
+	CHECK(spell.criticalChance == 200);
+	CHECK(spell.criticalDamage == 1000);
+
+	proficiency.resetStats();
+	CombatDamage afterUnequip = makeInstantSpell(COMBAT_ICEDAMAGE);
+	proficiency.applyCriticalPerks(afterUnequip);
+	CHECK(afterUnequip.criticalChance == 0);
+	CHECK(afterUnequip.criticalDamage == 0);
+}
+
+TEST_CASE(leech_perks_are_added_and_fully_reverted_on_reset)
+{
+	ProficiencyEnabledGuard guard;
+	Player player(nullptr);
+	WeaponProficiency proficiency(player);
+
+	proficiency.applyPerk(static_cast<uint8_t>(LIFE_LEECH), 0.03);
+	proficiency.applyPerk(static_cast<uint8_t>(MANA_LEECH), 0.02);
+	CHECK(player.getSpecialSkill(SPECIALSKILL_LIFELEECHAMOUNT) == 300);
+	CHECK(player.getSpecialSkill(SPECIALSKILL_MANALEECHAMOUNT) == 200);
+
+	proficiency.resetStats();
+	CHECK(player.getSpecialSkill(SPECIALSKILL_LIFELEECHAMOUNT) == 0);
+	CHECK(player.getSpecialSkill(SPECIALSKILL_MANALEECHAMOUNT) == 0);
+}
+
+TFS_TEST_MAIN()

--- a/src/weapon_proficiency.cpp
+++ b/src/weapon_proficiency.cpp
@@ -15,6 +15,10 @@
 
 namespace {
 
+// Perk values come from JSON as decimal fractions (0.02 == 2%). Critical chance, critical extra
+// damage and leech are all consumed by combat as basis points out of 10000.
+constexpr double_t BASIS_POINTS = 10000.0;
+
 int32_t saturatingAddWeapon(int32_t value, int64_t increase)
 {
 	return static_cast<int32_t>(std::clamp<int64_t>(static_cast<int64_t>(value) + increase,
@@ -22,9 +26,31 @@ int32_t saturatingAddWeapon(int32_t value, int64_t increase)
 	                                               std::numeric_limits<int32_t>::max()));
 }
 
+int64_t toBasisPoints(double_t value)
+{
+	if (!std::isfinite(value)) {
+		return 0;
+	}
+	return std::llround(value * BASIS_POINTS);
+}
+
 bool isEnabled()
 {
 	return ConfigManager::getBoolean(ConfigManager::WEAPON_PROFICIENCY_SYSTEM_ENABLED);
+}
+
+// An auto attack is the weapon swing itself. Spells and runes both arrive as ORIGIN_SPELL and are
+// told apart by instantSpellName / runeSpell.
+bool isAutoAttack(const CombatDamage& damage)
+{
+	return damage.origin == ORIGIN_MELEE || damage.origin == ORIGIN_RANGED || damage.origin == ORIGIN_WAND;
+}
+
+// Crystal gates the elemental perk on "spells and runes": anything carrying an instant spell name
+// or produced by a rune, offensive or not.
+bool isSpellOrRune(const CombatDamage& damage)
+{
+	return !damage.instantSpellName.empty() || damage.runeSpell;
 }
 
 } // namespace
@@ -104,7 +130,7 @@ void WeaponProficiency::applyPerk(uint8_t perkType, double_t value, uint16_t /*s
 			SpecialSkills_t specialSkill = (perkType == static_cast<uint8_t>(LIFE_LEECH))
 			    ? SPECIALSKILL_LIFELEECHAMOUNT
 			    : SPECIALSKILL_MANALEECHAMOUNT;
-			int32_t amount = static_cast<int32_t>(std::llround(value * 10000.0));
+			int32_t amount = static_cast<int32_t>(toBasisPoints(value));
 			m_player.setVarSpecialSkill(specialSkill, amount);
 			if (perkType == static_cast<uint8_t>(LIFE_LEECH)) {
 				m_lifeLeechAdded += amount;
@@ -374,53 +400,41 @@ void WeaponProficiency::applySkillPercentageBonus(uint8_t perkType, skills_t ski
 
 // ---- Combat application methods ---- //
 
-void WeaponProficiency::applyAutoAttackCritical(CombatDamage& damage) const
+void WeaponProficiency::applyCriticalPerks(CombatDamage& damage) const
 {
-	if (damage.origin == ORIGIN_WAND) {
-		return;
+	int64_t chance = 0;
+	int64_t extraDamage = 0;
+
+	const auto accumulate = [&chance, &extraDamage](const WeaponProficiencyCriticalBonus& bonus) {
+		chance += toBasisPoints(bonus.chance);
+		extraDamage += toBasisPoints(bonus.damage);
+	};
+
+	// Crystal folds the unconditional perks into the player's critical skills, so they weigh on
+	// every hit.
+	accumulate(m_generalCritical);
+
+	if (isAutoAttack(damage)) {
+		accumulate(m_autoAttackCritical);
 	}
 
-	if (damage.origin == ORIGIN_MELEE || damage.origin == ORIGIN_RANGED) {
-		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
-		                                      static_cast<int64_t>(std::llround(m_autoAttackCritical.chance * 10000.0)));
-		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
-		                                      static_cast<int64_t>(std::llround(m_autoAttackCritical.damage * 10000.0)));
-	}
-}
+	if (isSpellOrRune(damage)) {
+		// Only runes of the attack group carry the rune-specific perk.
+		if (damage.offensiveRune) {
+			accumulate(m_runesCritical);
+		}
 
-void WeaponProficiency::applyGeneralCritical(CombatDamage& damage) const
-{
-	if (m_generalCritical.chance > 0 || m_generalCritical.damage > 0) {
-		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
-		                                      static_cast<int64_t>(std::llround(m_generalCritical.chance * 10000.0)));
-		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
-		                                      static_cast<int64_t>(std::llround(m_generalCritical.damage * 10000.0)));
-	}
-}
-
-void WeaponProficiency::applyRunesCritical(CombatDamage& damage, bool aggressive) const
-{
-	if (!aggressive) {
-		return;
+		const size_t index = combatTypeToIndex(damage.primary.type);
+		if (index < m_elementCritical.size()) {
+			accumulate(m_elementCritical[index]);
+		}
 	}
 
-	if (!damage.instantSpellName.empty() && damage.origin == ORIGIN_SPELL) {
-		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
-		                                      static_cast<int64_t>(std::llround(m_runesCritical.chance * 10000.0)));
-		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
-		                                      static_cast<int64_t>(std::llround(m_runesCritical.damage * 10000.0)));
+	if (chance != 0) {
+		damage.criticalChance = saturatingAddWeapon(damage.criticalChance, chance);
 	}
-}
-
-void WeaponProficiency::applyElementCritical(CombatDamage& damage) const
-{
-	const size_t index = combatTypeToIndex(damage.primary.type);
-	if (index < m_elementCritical.size()) {
-		const auto& ec = m_elementCritical[index];
-		damage.criticalChance = saturatingAddWeapon(damage.criticalChance,
-		                                      static_cast<int64_t>(std::llround(ec.chance * 10000.0)));
-		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage,
-		                                      static_cast<int64_t>(std::llround(ec.damage * 10000.0)));
+	if (extraDamage != 0) {
+		damage.criticalDamage = saturatingAddWeapon(damage.criticalDamage, extraDamage);
 	}
 }
 
@@ -460,18 +474,47 @@ void WeaponProficiency::applyDamageMultiplier(CombatDamage& damage, double_t mul
 	damage.secondary.value = static_cast<int32_t>(std::llround(damage.secondary.value * mult));
 }
 
-void WeaponProficiency::applySkillAutoAttackPercentage(CombatDamage& damage) const
+int32_t WeaponProficiency::getProficiencyStatLevel(skills_t skill) const
 {
-	if (damage.origin != ORIGIN_MELEE && damage.origin != ORIGIN_RANGED) {
+	if (skill == SKILL_MAGLEVEL) {
+		return static_cast<int32_t>(m_player.getMagicLevel());
+	}
+	return static_cast<int32_t>(m_player.getSkillLevel(skill));
+}
+
+void WeaponProficiency::addExtraValue(CombatDamage& damage, int32_t bonus, bool includeSecondary)
+{
+	if (bonus <= 0) {
 		return;
 	}
 
-	for (const auto& kv : m_skillPercentages) {
-		const auto& sp = kv.second;
+	if (damage.primary.value < 0) {
+		damage.primary.value = saturatingAddWeapon(damage.primary.value, -bonus);
+	} else if (damage.primary.value > 0) {
+		damage.primary.value = saturatingAddWeapon(damage.primary.value, bonus);
+	}
+
+	if (!includeSecondary) {
+		return;
+	}
+
+	if (damage.secondary.value < 0) {
+		damage.secondary.value = saturatingAddWeapon(damage.secondary.value, -bonus);
+	} else if (damage.secondary.value > 0) {
+		damage.secondary.value = saturatingAddWeapon(damage.secondary.value, bonus);
+	}
+}
+
+void WeaponProficiency::applySkillAutoAttackPercentage(CombatDamage& damage) const
+{
+	if (!isAutoAttack(damage)) {
+		return;
+	}
+
+	for (const auto& [skill, sp] : m_skillPercentages) {
 		if (sp.autoAttack > 0) {
-			const int32_t extra = static_cast<int32_t>(
-			    std::ceil(m_player.getSkillLevel(sp.skill) * sp.autoAttack));
-			damage.primary.value += extra;
+			addExtraValue(damage, static_cast<int32_t>(std::ceil(getProficiencyStatLevel(sp.skill) * sp.autoAttack)),
+			              true);
 		}
 	}
 }
@@ -482,14 +525,11 @@ void WeaponProficiency::applySkillSpellPercentage(CombatDamage& damage, bool hea
 		return;
 	}
 
-	for (const auto& kv : m_skillPercentages) {
-		const auto& sp = kv.second;
-		double_t value = healing ? sp.spellHealing : sp.spellDamage;
-
+	for (const auto& [skill, sp] : m_skillPercentages) {
+		const double_t value = healing ? sp.spellHealing : sp.spellDamage;
 		if (value > 0) {
-			const int32_t extra = static_cast<int32_t>(
-			    std::ceil(m_player.getSkillLevel(sp.skill) * value));
-			damage.primary.value += extra;
+			// Healing has no secondary component; only spell damage spills over to it.
+			addExtraValue(damage, static_cast<int32_t>(std::ceil(getProficiencyStatLevel(sp.skill) * value)), !healing);
 		}
 	}
 }

--- a/src/weapon_proficiency.h
+++ b/src/weapon_proficiency.h
@@ -46,10 +46,12 @@ enum class WeaponProficiencyBonus_t : uint8_t {
 	SKILL_PERCENTAGE_AUTO_ATTACK = 25,
 	SKILL_PERCENTAGE_SPELL_DAMAGE = 26,
 	SKILL_PERCENTAGE_SPELL_HEALING = 27,
-	ARMOR_PENETRATION = 28,
-	ELEMENTAL_PIERCE = 29,
-	DAMAGE_VS_FULL_HP = 30,
-	DAMAGE_VS_LOW_HP = 31,
+	// 28-31 follow the ids used by data/items/proficiencies.json (Crystal Server's numbering).
+	// They are parsed and stored but not consumed by combat yet.
+	ALPHA_STRIKE_EXTRA_DAMAGE = 28,
+	OMEGA_STRIKE_EXTRA_DAMAGE = 29,
+	ARMOR_PENETRATION = 30,
+	ELEMENTAL_PIERCE = 31,
 
 	BONUS_COUNT = 32
 };
@@ -124,10 +126,18 @@ public:
 	const SkillPercentage& getSkillPercentage(skills_t skill) const;
 
 	// Combat application — called from combat/game code when system is enabled
-	void applyAutoAttackCritical(CombatDamage& damage) const;
-	void applyGeneralCritical(CombatDamage& damage) const;
-	void applyRunesCritical(CombatDamage& damage, bool aggressive) const;
-	void applyElementCritical(CombatDamage& damage) const;
+
+	/**
+	 * Fold every critical perk that matches this hit into damage.criticalChance /
+	 * damage.criticalDamage, which the combat roll then consumes once.
+	 *
+	 * Which perks match follows Crystal Server:
+	 *  - general (8/12)          : every hit;
+	 *  - auto attack (11/15)     : melee, distance and wand/rod swings only;
+	 *  - offensive rune (10/14)  : runes whose spell group is "attack" only;
+	 *  - elemental (9/13)        : instant spells and runes only, matched on primary damage type.
+	 */
+	void applyCriticalPerks(CombatDamage& damage) const;
 	void applyBestiaryDamage(CombatDamage& damage, const std::shared_ptr<Monster>& monster) const;
 	void applyPowerfulFoeDamage(CombatDamage& damage, const std::shared_ptr<Monster>& monster) const;
 	void applySkillAutoAttackPercentage(CombatDamage& damage) const;
@@ -157,6 +167,12 @@ private:
 	void applyCriticalBonus(uint8_t perkType, CombatType_t element, double_t value);
 	void applySkillPercentageBonus(uint8_t perkType, skills_t skillId, double_t value);
 	void applyDamageMultiplier(CombatDamage& damage, double_t multiplier) const;
+
+	// SKILL_MAGLEVEL sits outside Player::skills[], so it has to be read as the magic level.
+	int32_t getProficiencyStatLevel(skills_t skill) const;
+	// Adds a flat bonus in the direction the value already points: damage is negative, healing
+	// positive (same convention as applyPerfectShotDamage in weapons.cpp).
+	static void addExtraValue(CombatDamage& damage, int32_t bonus, bool includeSecondary);
 
 	Player& m_player;
 


### PR DESCRIPTION
…Crystal

The elemental critical perks (types 9 and 13, "for <element> spells and runes") were applied to any damage whose primary type matched, with no check that the hit actually came from a spell or a rune. An ice rod therefore fed its ice perks into every wand swing, and into imbuement damage, which is what produced the inflated auto-attack criticals.

Runes were worse off: applyRunesCritical() tested for a non-empty instantSpellName, which is exactly an instant spell and never a rune, so the rune perks (10 and 14) landed on instant spells and never on runes. Runes carry no name and share ORIGIN_SPELL with instant spells, so there was nothing to test against; CombatDamage now carries runeSpell/offensiveRune, tagged by RuneSpell and threaded through LuaVariant and the new CombatSource.

The four apply*Critical entry points collapse into applyCriticalPerks(), so the classification happens once per hit instead of four times.

Also in the same area:
- auto-attack perks (11 and 15) skipped wands, leaving those perks dead on the 15 wand/rod proficiencies that carry them;
- the skill-percentage perks (25 and 26) added a positive bonus to a negative damage value, so they reduced damage instead of raising it, and read skills[SKILL_MAGLEVEL] out of bounds for magic-level perks;
- area spells applied the spell skill percentage twice, in getCombatDamage() and again in doAreaCombat();
- the JSON element code 1 (physical) mapped to COMBAT_NONE, dropping those perks;
- perk ids 28-31 did not match the ids used by proficiencies.json.

Perk scaling was verified against Crystal and is unchanged: a JSON value of 0.02 means 2% and becomes 200 basis points out of 10000.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved weapon proficiency effects across auto-attacks, spells, runes, elemental attacks, wand attacks, and secondary damage.
  * Added support for rune-specific critical, damage, and leech bonuses.
  * Preserved rune and instant-spell details through area and chained combat actions.
  * Improved Battle Pass mission tracking and completion handling.

* **Bug Fixes**
  * Corrected physical-damage element mapping.
  * Prevented incorrect depot locker insertions.
  * Fixed spell skill bonuses during area combat and improved healing, critical effects, and capped proficiency calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->