### PR TITLE
fix(inbox): preserve all items during save

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -949,6 +949,40 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result, bool deferWorl
 	return true;
 }
 
+void IOLoginData::collectInboxItems(const Player* player, ItemBlockList& itemList)
+{
+	// Each town locker holds one inbox, and its contents are keyed by that locker's depot id so
+	// the loader can put them back under the right town.
+	//
+	// There is deliberately no item cap here. The rows produced replace everything previously
+	// stored for this player, and the inbox legitimately receives whole houses at once through
+	// House::transferToDepot, which moves items with FLAG_NOLIMIT. Truncating here silently
+	// destroyed anything past the limit. How many entries a client can display is a separate
+	// concern, handled by container pagination in the protocol.
+	for (const auto& [depotId, locker] : player->depotLockerMap) {
+		if (!locker) {
+			continue;
+		}
+
+		for (const auto& item : locker->getItemList()) {
+			if (!item || item->getID() != ITEM_INBOX) {
+				continue;
+			}
+
+			const Container* inbox = item->getContainer();
+			if (!inbox) {
+				continue;
+			}
+
+			for (const auto& subItem : inbox->getItemList()) {
+				if (subItem) {
+					itemList.emplace_back(static_cast<int32_t>(depotId), subItem.get());
+				}
+			}
+		}
+	}
+}
+
 bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert,
                             PropWriteStream& propWriteStream)
 {
@@ -1344,22 +1378,7 @@ bool IOLoginData::savePlayerQueries(Player* player, const Player::BestiaryDirtyS
 	DBInsert inboxQuery(
 		    "INSERT INTO `player_inboxitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 		ItemBlockList itemList;
-
-		int inboxItemsCount = 0;
-		for (const auto& it : player->depotLockerMap) {
-			for (const auto& item : it.second->getItemList()) {
-				if (item->getID() == ITEM_INBOX) {
-					if (Container* container = item->getContainer()) {
-						for (const auto& subItem : container->getItemList()) {
-							if (++inboxItemsCount > 100) {
-								continue;
-							}
-							itemList.emplace_back(it.first, subItem.get());
-						}
-					}
-				}
-			}
-		}
+		collectInboxItems(player, itemList);
 
 		if (!saveItems(player, itemList, inboxQuery, propWriteStream)) {
 			return false;

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -64,6 +64,14 @@ public:
 	static std::optional<PlayerSaveSnapshot> buildPlayerSave(Player* player);
 	static bool flushPlayerSave(const PlayerSaveSnapshot& snapshot);
 	static bool addRewardItems(uint32_t playerId, const ItemBlockList& itemList, DBInsert& query_insert, PropWriteStream& propWriteStream);
+	// Gathers every inbox item of every town locker, keyed by depot id. Exposed so the
+	// persistence tests can assert on it without a database round trip.
+	static void collectInboxItems(const Player* player, ItemBlockList& itemList);
+	// Serializes an item list, expanding nested containers, into query_insert. Public alongside
+	// addRewardItems, which does the same job for the reward chest, so the persistence tests can
+	// drive a real save.
+	static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert,
+	                      PropWriteStream& propWriteStream);
 	static uint32_t getGuidByName(std::string_view name);
 	static bool getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name);
 	static bool saveAutoLootConfig(Player* player);
@@ -104,8 +112,6 @@ private:
 	static void loadPlayerGuild(Player* player);
 	static bool savePlayer(Player* player);
 	static bool savePlayerQueries(Player* player, const Player::BestiaryDirtySnapshot& bestiarySnapshot);
-	static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert,
-	                      PropWriteStream& propWriteStream);
 };
 
 #endif

--- a/src/tests/test_inbox_db_roundtrip.cpp
+++ b/src/tests/test_inbox_db_roundtrip.cpp
@@ -1,0 +1,251 @@
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../database.h"
+#include "../databasemanager.h"
+#include "../game.h"
+#include "../inbox.h"
+#include "../iologindata.h"
+#include "../item.h"
+#include "../player.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+
+#include "test_support.h"
+
+// Drives the real save path into a throwaway MySQL/MariaDB schema and reads the rows back, so the
+// "no truncation" claim is backed by an actual database round trip rather than only by the
+// in-memory collection test.
+//
+// Skipped unless TFS_TEST_DB_* is set, so it never touches a real server database:
+//
+//   TFS_TEST_DB_HOST=127.0.0.1 TFS_TEST_DB_USER=root TFS_TEST_DB_PASS=secret
+//   TFS_TEST_DB_NAME=tfs_inbox_test ./test_inbox_db_roundtrip
+//
+// The schema only needs player_inboxitems; see the test plan in the pull request.
+
+namespace {
+
+const char* envOrNull(const char* name)
+{
+	const char* value = std::getenv(name);
+	return (value && *value) ? value : nullptr;
+}
+
+bool configureTestDatabase()
+{
+	const char* host = envOrNull("TFS_TEST_DB_HOST");
+	const char* user = envOrNull("TFS_TEST_DB_USER");
+	const char* name = envOrNull("TFS_TEST_DB_NAME");
+	if (!host || !user || !name) {
+		return false;
+	}
+
+	const char* pass = std::getenv("TFS_TEST_DB_PASS");
+	const char* port = envOrNull("TFS_TEST_DB_PORT");
+
+	ConfigManager::setString(ConfigManager::MYSQL_HOST, host);
+	ConfigManager::setString(ConfigManager::MYSQL_USER, user);
+	ConfigManager::setString(ConfigManager::MYSQL_PASS, pass ? pass : "");
+	ConfigManager::setString(ConfigManager::MYSQL_DB, name);
+	ConfigManager::setString(ConfigManager::MYSQL_SOCK, "");
+	ConfigManager::setInteger(ConfigManager::SQL_PORT, port ? std::atoi(port) : 3306);
+	return true;
+}
+
+void ensureItemTypesLoaded()
+{
+	if (Item::items.size() != 0) {
+		return;
+	}
+
+	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+	                       "data/items/items.otb";
+	CHECK(Item::items.loadFromOtb(itemsPath.string()));
+}
+
+void giveGroup(Player& player)
+{
+	auto group = std::make_shared<Group>();
+	group->name = "test";
+	group->flags = 0;
+	group->maxDepotItems = 0;
+	group->maxVipEntries = 0;
+	group->id = 1;
+	group->access = false;
+	player.setGroup(group);
+}
+
+Inbox* attachInbox(Player& player, uint32_t depotId)
+{
+	CHECK(player.getDepotLocker(depotId) != nullptr);
+	Inbox* inbox = player.getInbox(depotId);
+	CHECK(inbox != nullptr);
+	return inbox;
+}
+
+void fillInbox(Inbox* inbox, size_t count)
+{
+	for (size_t i = 0; i < count; ++i) {
+		auto item = Item::CreateItem(ITEM_GOLD_COIN, 1);
+		CHECK(item != nullptr);
+		inbox->internalAddThing(item.get());
+	}
+}
+
+uint64_t countRows(Database& db, uint32_t guid)
+{
+	DBResult_ptr result = db.storeQuery(
+	    fmt::format("SELECT COUNT(*) AS `total` FROM `player_inboxitems` WHERE `player_id` = {:d}", guid));
+	if (!result) {
+		return 0;
+	}
+	return result->getNumber<uint64_t>("total");
+}
+
+// Runs the production save path for one player and returns how many rows reached the table.
+uint64_t saveAndCount(Database& db, Player& player, uint32_t guid, int64_t& elapsedMicros)
+{
+	CHECK(db.executeQuery(fmt::format("DELETE FROM `player_inboxitems` WHERE `player_id` = {:d}", guid)));
+
+	ItemBlockList itemList;
+	IOLoginData::collectInboxItems(&player, itemList);
+
+	DBInsert query(
+	    "INSERT INTO `player_inboxitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
+	PropWriteStream propWriteStream;
+
+	const auto started = std::chrono::steady_clock::now();
+	CHECK(IOLoginData::saveItems(&player, itemList, query, propWriteStream));
+	elapsedMicros =
+	    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - started).count();
+
+	return countRows(db, guid);
+}
+
+} // namespace
+
+TEST_CASE(inbox_rows_survive_a_real_database_round_trip)
+{
+	if (!configureTestDatabase()) {
+		std::cout << "[skip] TFS_TEST_DB_* not set; database round trip not exercised\n";
+		return;
+	}
+
+	ensureItemTypesLoaded();
+
+	Database& db = Database::getInstance();
+	if (!db.connect()) {
+		std::cout << "[skip] could not connect to the test database; round trip not exercised\n";
+		return;
+	}
+
+	std::cout << "[db] items | rows after save | rows after re-save | save ms\n";
+
+	for (const size_t count : {size_t{0}, size_t{1}, size_t{99}, size_t{100}, size_t{101}, size_t{255},
+	                           size_t{256}, size_t{500}, size_t{1000}, size_t{2500}, size_t{5000}}) {
+		Player player(nullptr);
+		giveGroup(player);
+		fillInbox(attachInbox(player, 1), count);
+
+		int64_t firstMicros = 0;
+		const uint64_t firstPass = saveAndCount(db, player, player.getGUID(), firstMicros);
+
+		// Saving twice must not drift: the delete-then-insert has to land on the same total.
+		int64_t secondMicros = 0;
+		const uint64_t secondPass = saveAndCount(db, player, player.getGUID(), secondMicros);
+
+		std::cout << "[db] " << count << " | " << firstPass << " | " << secondPass << " | "
+		          << (firstMicros / 1000.0) << "\n";
+
+		CHECK(firstPass == count);
+		CHECK(secondPass == count);
+	}
+}
+
+TEST_CASE(inbox_rows_keep_their_town_pid_in_the_database)
+{
+	if (!configureTestDatabase()) {
+		return;
+	}
+
+	ensureItemTypesLoaded();
+
+	Database& db = Database::getInstance();
+	if (!db.connect()) {
+		return;
+	}
+
+	Player player(nullptr);
+	giveGroup(player);
+	fillInbox(attachInbox(player, 1), 150);
+	fillInbox(attachInbox(player, 2), 200);
+	fillInbox(attachInbox(player, 3), 500);
+
+	int64_t micros = 0;
+	const uint32_t guid = player.getGUID();
+	CHECK(saveAndCount(db, player, guid, micros) == 850);
+
+	// pid carries the depot id for top level inbox items, which is how the loader routes them
+	// back to the right town.
+	for (const auto& [depotId, expected] : {std::pair<int, int>{1, 150}, {2, 200}, {3, 500}}) {
+		DBResult_ptr result = db.storeQuery(fmt::format(
+		    "SELECT COUNT(*) AS `total` FROM `player_inboxitems` WHERE `player_id` = {:d} AND `pid` = {:d}", guid,
+		    depotId));
+		CHECK(result != nullptr);
+		CHECK(result->getNumber<uint64_t>("total") == static_cast<uint64_t>(expected));
+	}
+}
+
+TEST_CASE(nested_inbox_containers_are_expanded_into_rows)
+{
+	if (!configureTestDatabase()) {
+		return;
+	}
+
+	ensureItemTypesLoaded();
+
+	Database& db = Database::getInstance();
+	if (!db.connect()) {
+		return;
+	}
+
+	Player player(nullptr);
+	giveGroup(player);
+	Inbox* inbox = attachInbox(player, 1);
+
+	// backpack -> bag -> 5 coins, plus 3 loose items: 10 rows in total.
+	auto backpack = Item::CreateItem(ITEM_BAG);
+	CHECK(backpack != nullptr);
+	Container* outer = backpack->getContainer();
+	CHECK(outer != nullptr);
+
+	auto innerBag = Item::CreateItem(ITEM_BAG);
+	CHECK(innerBag != nullptr);
+	Container* inner = innerBag->getContainer();
+	CHECK(inner != nullptr);
+
+	for (int i = 0; i < 5; ++i) {
+		auto coin = Item::CreateItem(ITEM_GOLD_COIN, 1);
+		CHECK(coin != nullptr);
+		inner->internalAddThing(coin.get());
+	}
+	outer->internalAddThing(innerBag.get());
+	inbox->internalAddThing(backpack.get());
+	fillInbox(inbox, 3);
+
+	int64_t micros = 0;
+	const uint32_t guid = player.getGUID();
+	CHECK(saveAndCount(db, player, guid, micros) == 10);
+
+	// The nested rows point at their parent's sid, which is always >= 100 so it can never be
+	// mistaken for a town id by the loader.
+	DBResult_ptr result = db.storeQuery(fmt::format(
+	    "SELECT COUNT(*) AS `total` FROM `player_inboxitems` WHERE `player_id` = {:d} AND `pid` >= 100", guid));
+	CHECK(result != nullptr);
+	CHECK(result->getNumber<uint64_t>("total") == 6); // the inner bag + its 5 coins
+}
+
+TFS_TEST_MAIN()

--- a/src/tests/test_inbox_persistence.cpp
+++ b/src/tests/test_inbox_persistence.cpp
@@ -1,0 +1,232 @@
+#include "../otpch.h"
+
+#include "../container.h"
+#include "../game.h"
+#include "../inbox.h"
+#include "../iologindata.h"
+#include "../item.h"
+#include "../player.h"
+
+#include <chrono>
+#include <iostream>
+#include <map>
+
+#include "test_support.h"
+
+namespace {
+
+void ensureItemTypesLoaded()
+{
+	if (Item::items.size() != 0) {
+		return;
+	}
+
+	const auto itemsPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+	                       "data/items/items.otb";
+	CHECK(Item::items.loadFromOtb(itemsPath.string()));
+}
+
+// A freshly constructed Player has no group, and getDepotLocker() reaches getMaxDepotItems(),
+// which dereferences it. Loading a player from the database normally supplies one.
+void giveGroup(Player& player)
+{
+	auto group = std::make_shared<Group>();
+	group->name = "test";
+	group->flags = 0;
+	group->maxDepotItems = 0; // 0 falls back to the configured depot limit
+	group->maxVipEntries = 0;
+	group->id = 1;
+	group->access = false;
+	player.setGroup(group);
+}
+
+// Goes through the same call the server uses, so the locker is built exactly as in production
+// (market, supply stash, inbox and depot chest).
+Inbox* attachInbox(Player& player, uint32_t depotId)
+{
+	DepotLocker* locker = player.getDepotLocker(depotId);
+	CHECK(locker != nullptr);
+
+	Inbox* inbox = player.getInbox(depotId);
+	CHECK(inbox != nullptr);
+	return inbox;
+}
+
+// Items are added with internalAddThing, the same call House::transferToDepot ends up using
+// through a FLAG_NOLIMIT move: the inbox is allowed to exceed its visible capacity.
+void fillInbox(Inbox* inbox, size_t count, uint16_t itemId = ITEM_GOLD_COIN)
+{
+	for (size_t i = 0; i < count; ++i) {
+		auto item = Item::CreateItem(itemId, 1);
+		CHECK(item != nullptr);
+		inbox->internalAddThing(item.get());
+	}
+}
+
+size_t countForDepot(const ItemBlockList& itemList, int32_t depotId)
+{
+	size_t total = 0;
+	for (const auto& [pid, item] : itemList) {
+		if (pid == depotId) {
+			++total;
+		}
+	}
+	return total;
+}
+
+} // namespace
+
+TEST_CASE(inbox_persists_every_item_regardless_of_count)
+{
+	ensureItemTypesLoaded();
+
+	// The bug truncated at 100. These bracket that boundary and go well past it.
+	for (const size_t count : {size_t{0}, size_t{1}, size_t{99}, size_t{100}, size_t{101}, size_t{255},
+	                           size_t{256}, size_t{500}, size_t{1000}, size_t{2500}, size_t{5000}}) {
+		Player player(nullptr);
+		giveGroup(player);
+		Inbox* inbox = attachInbox(player, 1);
+		fillInbox(inbox, count);
+
+		ItemBlockList itemList;
+		IOLoginData::collectInboxItems(&player, itemList);
+
+		CHECK(itemList.size() == count);
+		CHECK(countForDepot(itemList, 1) == count);
+	}
+}
+
+TEST_CASE(inbox_count_is_per_town_not_shared)
+{
+	ensureItemTypesLoaded();
+
+	// The old counter was global across depotLockerMap, so 80 + 80 persisted only 100 total.
+	Player player(nullptr);
+	giveGroup(player);
+	fillInbox(attachInbox(player, 1), 80);
+	fillInbox(attachInbox(player, 2), 80);
+
+	ItemBlockList itemList;
+	IOLoginData::collectInboxItems(&player, itemList);
+
+	CHECK(itemList.size() == 160);
+	CHECK(countForDepot(itemList, 1) == 80);
+	CHECK(countForDepot(itemList, 2) == 80);
+}
+
+TEST_CASE(inbox_keeps_each_town_separate_at_scale)
+{
+	ensureItemTypesLoaded();
+
+	Player player(nullptr);
+	giveGroup(player);
+	fillInbox(attachInbox(player, 1), 150);
+	fillInbox(attachInbox(player, 2), 200);
+	fillInbox(attachInbox(player, 3), 500);
+
+	ItemBlockList itemList;
+	IOLoginData::collectInboxItems(&player, itemList);
+
+	CHECK(itemList.size() == 850);
+	CHECK(countForDepot(itemList, 1) == 150);
+	CHECK(countForDepot(itemList, 2) == 200);
+	CHECK(countForDepot(itemList, 3) == 500);
+}
+
+TEST_CASE(inbox_handles_three_thousand_across_three_towns)
+{
+	ensureItemTypesLoaded();
+
+	Player player(nullptr);
+	giveGroup(player);
+	fillInbox(attachInbox(player, 1), 1000);
+	fillInbox(attachInbox(player, 2), 1000);
+	fillInbox(attachInbox(player, 3), 1000);
+
+	ItemBlockList itemList;
+	IOLoginData::collectInboxItems(&player, itemList);
+
+	CHECK(itemList.size() == 3000);
+	for (int32_t depotId = 1; depotId <= 3; ++depotId) {
+		CHECK(countForDepot(itemList, depotId) == 1000);
+	}
+}
+
+TEST_CASE(inbox_collects_top_level_containers_and_saveitems_walks_their_contents)
+{
+	ensureItemTypesLoaded();
+
+	// collectInboxItems only lists the inbox's direct children; nested contents are expanded
+	// later by saveItems, which follows every Container it is handed. This pins that split so a
+	// future change cannot start double counting the children.
+	Player player(nullptr);
+	giveGroup(player);
+	Inbox* inbox = attachInbox(player, 1);
+
+	auto backpack = Item::CreateItem(ITEM_BAG);
+	CHECK(backpack != nullptr);
+	Container* outer = backpack->getContainer();
+	CHECK(outer != nullptr);
+
+	auto innerBag = Item::CreateItem(ITEM_BAG);
+	CHECK(innerBag != nullptr);
+	Container* inner = innerBag->getContainer();
+	CHECK(inner != nullptr);
+
+	for (int i = 0; i < 5; ++i) {
+		auto item = Item::CreateItem(ITEM_GOLD_COIN, 1);
+		CHECK(item != nullptr);
+		inner->internalAddThing(item.get());
+	}
+
+	outer->internalAddThing(innerBag.get());
+	inbox->internalAddThing(backpack.get());
+	fillInbox(inbox, 3);
+
+	ItemBlockList itemList;
+	IOLoginData::collectInboxItems(&player, itemList);
+
+	// 3 loose items + the backpack itself; the bag and its 5 coins hang off the backpack.
+	CHECK(itemList.size() == 4);
+	CHECK(outer->getItemList().size() == 1);
+	CHECK(inner->getItemList().size() == 5);
+}
+
+TEST_CASE(inbox_collection_stays_linear)
+{
+	ensureItemTypesLoaded();
+
+	// A single pass over a few thousand items is far too fast to time reliably, so each size is
+	// collected repeatedly and the per-run average reported in nanoseconds.
+	constexpr int repeats = 50;
+
+	const auto measure = [](size_t count) {
+		Player player(nullptr);
+		giveGroup(player);
+		fillInbox(attachInbox(player, 1), count);
+
+		const auto started = std::chrono::steady_clock::now();
+		for (int i = 0; i < repeats; ++i) {
+			ItemBlockList itemList;
+			IOLoginData::collectInboxItems(&player, itemList);
+			CHECK(itemList.size() == count);
+		}
+		const auto elapsed = std::chrono::steady_clock::now() - started;
+
+		return std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count() / repeats;
+	};
+
+	measure(1000); // warm up, result intentionally discarded
+
+	const auto small = std::max<int64_t>(1, measure(1000));
+	const auto large = measure(10000);
+
+	std::cout << "[perf] collectInboxItems  1000 items: " << small << " ns/run\n"
+	          << "[perf] collectInboxItems 10000 items: " << large << " ns/run\n";
+
+	// Ten times the items should cost roughly ten times the work. The bound is deliberately loose
+	// so a busy machine cannot make it flake, while an accidental O(n^2) rewrite still trips it.
+	CHECK(large < small * 30);
+}
+
+TFS_TEST_MAIN()


### PR DESCRIPTION
savePlayerQueries collected inbox contents behind a counter that stopped at 100, and the rows it produces replace everything previously stored for the player: the surrounding block deletes from player_inboxitems first. Anything past the hundredth item was therefore dropped permanently on the next save.

The counter was also shared across depotLockerMap rather than per locker, so two towns holding 80 items each persisted 100 in total instead of 160.

This mattered most for house loss. House::transferToDepot moves an entire house into the owner's inbox with FLAG_NOLIMIT, deliberately bypassing the visible container capacity, so the inbox routinely holds far more than a hundred items.

The truncation is removed rather than raised: how many entries a client can display is a separate concern, already handled by container pagination in the protocol, and the depot save path directly above never had such a cap.

The collection loop moves into IOLoginData::collectInboxItems so it can be tested without a database, and saveItems joins addRewardItems in the public section for the same reason.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inbox items are now saved without a 100-item limit.
  * Items retain their correct town/depot association during persistence.
  * Nested containers and their contents are saved with the proper relationships.

* **Tests**
  * Added coverage for varied inbox sizes, multiple towns, repeated saves, and database round trips.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->