### PR TITLE
perf: measure the baseline before porting anything from BlackTek

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(ENABLE_ASAN "Enable AddressSanitizer for memory diagnostics" OFF)
 option(ENABLE_TSAN "Enable ThreadSanitizer for data race diagnostics" OFF)
 option(ENABLE_NATIVE_OPTIMIZATIONS "Enable -march=native/-mtune=native for local Release builds" ON)
 option(ENABLE_PACKET_BACKLOG_DIAGNOSTICS "Enable ProtocolGame packet backlog diagnostics" OFF)
+option(ENABLE_PACKET_SIZE_HISTOGRAM "Measure the packet size distribution seen by XTEA (diagnostics only)" OFF)
 
 option(USE_LUAJIT "Use LuaJIT" OFF)
 if (USE_LUAJIT)
@@ -272,6 +273,16 @@ endif()
 if (ENABLE_PACKET_BACKLOG_DIAGNOSTICS)
     ADD_DEFINITIONS(-DPROTOCOLGAME_BACKLOG_DIAGNOSTICS)
     message(STATUS "ProtocolGame packet backlog diagnostics enabled")
+endif()
+
+# Measures the size distribution of the buffers handed to xtea::encrypt/decrypt.
+# benchmarks/perf_baseline shows the SIMD kernels winning or losing depending on
+# exactly that distribution, so it has to be measured on a real server before
+# anyone decides whether to port them. Off by default: with the option off the
+# macros in src/packet_size_histogram.h expand to nothing.
+if (ENABLE_PACKET_SIZE_HISTOGRAM)
+    ADD_DEFINITIONS(-DTFS_PACKET_SIZE_HISTOGRAM)
+    message(STATUS "Packet size histogram enabled. Disable for production: -DENABLE_PACKET_SIZE_HISTOGRAM=OFF")
 endif()
 
 if (BUILD_TESTING OR BUILD_BENCHMARKING)

--- a/benchmarks/perf_baseline/README.md
+++ b/benchmarks/perf_baseline/README.md
@@ -9,7 +9,7 @@ document.
 
 The baseline is the flag set the Release build really uses:
 
-```
+```text
 -O3 -march=native -mtune=native -fomit-frame-pointer -DNDEBUG
 ```
 

--- a/benchmarks/perf_baseline/README.md
+++ b/benchmarks/perf_baseline/README.md
@@ -1,0 +1,88 @@
+# perf/profile-baseline — measurement harness
+
+Nothing in this directory is linked into the server. It exists so that the
+performance plan's later branches argue from measurements taken on the machine
+that will actually run the server, instead of from numbers quoted out of a
+document.
+
+## The one rule
+
+The baseline is the flag set the Release build really uses:
+
+```
+-O3 -march=native -mtune=native -fomit-frame-pointer -DNDEBUG
+```
+
+A speedup measured against `-O0`, `-O1` or `-O2` is not a result. Compiler flags
+change the winner of the XTEA comparison completely, which is how the previous
+version of the plan ended up prioritising a port that would have been a
+regression.
+
+## Running it
+
+```bash
+# baseline flag set only — this is the number that decides anything
+./benchmarks/perf_baseline/run.sh
+
+# the same benchmarks across -O2, -O3, -O3 -mavx2 and the baseline,
+# to show how much the flags move the answer
+./benchmarks/perf_baseline/run.sh --sweep
+```
+
+The XTEA benchmark compiles `src/xtea.cpp` itself rather than a copy, so it can
+never drift from the shipped implementation. That file includes `otpch.h`, so
+the script reuses the include list from a configured build tree. Configure one
+first if you have not:
+
+```bash
+cmake -B build-release -DCMAKE_BUILD_TYPE=Release
+```
+
+Point it elsewhere with `TFS_BUILD_DIR=/path/to/build ./run.sh`.
+
+## What each benchmark answers
+
+### `bench_xtea.cpp`
+
+Compares four implementations at every packet size, after proving all four
+produce identical ciphertext and that `decrypt(encrypt(x)) == x`:
+
+| name        | what it is                                                        |
+|-------------|-------------------------------------------------------------------|
+| `tfs`       | the loop in `src/xtea.cpp` — rounds outer, blocks inner            |
+| `bt-scalar` | BlackTek's scalar path — blocks outer, rounds inner                |
+| `bt-sse2`   | BlackTek's SSE2 kernel, 4 blocks at a time                         |
+| `bt-avx2`   | BlackTek's AVX2 kernel, 8 blocks at a time                         |
+
+Two things to keep in mind when reading the table:
+
+- `bt-scalar` is the path BlackTek actually takes on Linux, because its
+  `detect()` in `src/simd_dispatch.h` only implements CPUID for MSVC and ICC and
+  falls through to `g_level = Level::Scalar` on GCC and Clang. Porting BlackTek's
+  XTEA as-is means shipping that column.
+- the winner flips with packet size. There is no single answer, which is why the
+  distribution has to be measured — see below.
+
+### `bench_adler.cpp`
+
+`adlerChecksum()` in `src/tools.cpp` against zlib's `adler32_z()`. zlib is
+already a required dependency (`find_package(ZLIB REQUIRED)`), so this would add
+no packaging cost. Checks byte-identical output across sizes and payload
+patterns, including the `> NETWORKMESSAGE_MAXSIZE` guard that returns 0, then
+times both.
+
+## Measuring the real packet size distribution
+
+The XTEA table is only actionable next to the distribution of buffer sizes a
+real server hands to `xtea::encrypt`. Build with the histogram enabled, run
+under real load, and read the log:
+
+```bash
+cmake -B build-histogram -DCMAKE_BUILD_TYPE=Release -DENABLE_PACKET_SIZE_HISTOGRAM=ON
+cmake --build build-histogram -j"$(nproc)"
+./build-histogram/tfs
+```
+
+It reports both directions every 100k outgoing packets. The option is off by
+default and the macros compile to nothing without it, so the production binary
+is unaffected.

--- a/benchmarks/perf_baseline/bench_adler.cpp
+++ b/benchmarks/perf_baseline/bench_adler.cpp
@@ -1,0 +1,149 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+//
+// Baseline measurement for the checksum hot path (perf/profile-baseline).
+//
+// adlerChecksum() in src/tools.cpp is a hand-written Adler-32. zlib is already a
+// hard dependency of this project (CMakeLists.txt find_package(ZLIB REQUIRED)),
+// so adler32_z() is available at no packaging cost. This binary answers two
+// questions before anyone edits tools.cpp:
+//
+//   1. is the hash byte-identical at every size, including the > MAXSIZE guard?
+//   2. where is the crossover, given that zlib loses on very small buffers?
+//
+// Nothing here is linked into the server.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include <zlib.h>
+
+namespace {
+
+// NETWORKMESSAGE_MAXSIZE from src/networkmessage.h. Duplicated deliberately so
+// this benchmark does not drag the engine headers in.
+constexpr size_t NETWORKMESSAGE_MAXSIZE = 24590;
+
+// Verbatim copy of src/tools.cpp adlerChecksum() as of this branch.
+uint32_t adlerChecksumManual(const uint8_t* data, size_t length)
+{
+	if (length > NETWORKMESSAGE_MAXSIZE) {
+		return 0;
+	}
+
+	const uint16_t adler = 65521;
+
+	uint32_t a = 1, b = 0;
+
+	while (length > 0) {
+		size_t tmp = length > 5552 ? 5552 : length;
+		length -= tmp;
+
+		do {
+			a += *data++;
+			b += a;
+		} while (--tmp);
+
+		a %= adler;
+		b %= adler;
+	}
+
+	return (b << 16) | a;
+}
+
+uint32_t adlerChecksumZlib(const uint8_t* data, size_t length)
+{
+	if (length > NETWORKMESSAGE_MAXSIZE) {
+		return 0;
+	}
+	return static_cast<uint32_t>(adler32_z(1L, data, length));
+}
+
+using ChecksumFn = uint32_t (*)(const uint8_t*, size_t);
+
+double timeNs(ChecksumFn fn, const std::vector<uint8_t>& buffer, size_t iterations)
+{
+	uint32_t sink = 0;
+	const auto start = std::chrono::steady_clock::now();
+	for (size_t i = 0; i < iterations; ++i) {
+		sink ^= fn(buffer.data(), buffer.size());
+	}
+	const auto end = std::chrono::steady_clock::now();
+	asm volatile("" : : "r"(sink) : "memory");
+	return std::chrono::duration<double, std::nano>(end - start).count() / static_cast<double>(iterations);
+}
+
+std::vector<uint8_t> makePattern(size_t size, int pattern, std::mt19937& rng)
+{
+	std::vector<uint8_t> buffer(size);
+	for (size_t i = 0; i < size; ++i) {
+		switch (pattern) {
+			case 0: buffer[i] = 0x00; break;
+			case 1: buffer[i] = 0xFF; break;
+			case 2: buffer[i] = static_cast<uint8_t>(i); break;
+			default: buffer[i] = static_cast<uint8_t>(rng()); break;
+		}
+	}
+	return buffer;
+}
+
+} // namespace
+
+int main()
+{
+	const std::vector<size_t> sizes = {0,   1,   8,    16,   32,   64,                       128,
+	                                  256, 512, 1024, 2048, 4096, NETWORKMESSAGE_MAXSIZE,    NETWORKMESSAGE_MAXSIZE + 1};
+	const char* patternNames[] = {"zeros", "0xFF", "sequential", "random"};
+
+	std::mt19937 rng{20260817};
+	std::printf("== equivalence: manual vs zlib adler32_z ==\n");
+
+	bool ok = true;
+	for (size_t size : sizes) {
+		for (int pattern = 0; pattern < 4; ++pattern) {
+			const std::vector<uint8_t> buffer = makePattern(size, pattern, rng);
+			const uint32_t manual = adlerChecksumManual(buffer.data(), buffer.size());
+			const uint32_t zlib = adlerChecksumZlib(buffer.data(), buffer.size());
+			if (manual != zlib) {
+				std::printf("  MISMATCH size=%-6zu %-11s manual=%08x zlib=%08x\n", size, patternNames[pattern],
+				            manual, zlib);
+				ok = false;
+			}
+		}
+	}
+
+	if (!ok) {
+		std::printf("EQUIVALENCE FAILED - do not port\n");
+		return 1;
+	}
+	std::printf("  identical for %zu sizes x 4 patterns, including the > MAXSIZE guard returning 0\n\n",
+	            sizes.size());
+
+	std::printf("== checksum, ns per call, best of 5, lower is better ==\n");
+	std::printf("%8s %12s %12s %10s   %s\n", "bytes", "manual", "zlib", "speedup", "winner");
+
+	for (size_t size : sizes) {
+		if (size == 0 || size > NETWORKMESSAGE_MAXSIZE) {
+			continue; // guard-only cases, nothing to time
+		}
+		const std::vector<uint8_t> buffer = makePattern(size, 3, rng);
+		const size_t iterations = std::max<size_t>(5000, (1u << 22) / size);
+
+		double bestManual = 1e30;
+		double bestZlib = 1e30;
+		for (int round = 0; round < 5; ++round) {
+			bestManual = std::min(bestManual, timeNs(&adlerChecksumManual, buffer, iterations));
+			bestZlib = std::min(bestZlib, timeNs(&adlerChecksumZlib, buffer, iterations));
+		}
+
+		const double speedup = bestManual / bestZlib;
+		std::printf("%8zu %12.1f %12.1f %9.2fx   %s\n", size, bestManual, bestZlib, speedup,
+		            speedup > 1.0 ? "zlib" : "manual (current)");
+	}
+
+	return 0;
+}

--- a/benchmarks/perf_baseline/bench_xtea.cpp
+++ b/benchmarks/perf_baseline/bench_xtea.cpp
@@ -221,12 +221,17 @@ int main()
 	const xtea::key rawKey = {0x1F2E3D4Cu, 0x5B6A7988u, 0x97A6B5C4u, 0xD3E2F100u};
 	const round_keys k = xtea::expand_key(rawKey);
 
-	const std::vector<Impl> impls = {
+	std::vector<Impl> impls = {
 	    {"tfs", &xtea::encrypt},
 	    {"bt-scalar", &bt_scalar_encrypt},
 	    {"bt-sse2", &bt_sse2_encrypt},
-	    {"bt-avx2", &bt_avx2_encrypt},
 	};
+	__builtin_cpu_init();
+	if (__builtin_cpu_supports("avx2")) {
+		impls.push_back({"bt-avx2", &bt_avx2_encrypt});
+	} else {
+		std::printf("SKIP bt-avx2: AVX2 is unavailable\n");
+	}
 
 	// Multiples of 8 only: XTEA operates on 8-byte blocks and the protocol pads
 	// to that boundary before calling encrypt.
@@ -240,7 +245,11 @@ int main()
 	std::printf("  all %zu implementations agree on %zu sizes, decrypt round-trips\n\n", impls.size(), sizes.size());
 
 	std::printf("== encrypt, ns per call, best of 5, lower is better ==\n");
-	std::printf("%8s %12s %12s %12s %12s   %s\n", "bytes", "tfs", "bt-scalar", "bt-sse2", "bt-avx2", "winner");
+	std::printf("%8s", "bytes");
+	for (const Impl& impl : impls) {
+		std::printf(" %12s", impl.name);
+	}
+	std::printf("   %s\n", "winner");
 
 	for (size_t size : sizes) {
 		const size_t iterations = std::max<size_t>(2000, (1u << 22) / size);
@@ -256,8 +265,11 @@ int main()
 		const size_t winner = static_cast<size_t>(std::min_element(best.begin(), best.end()) - best.begin());
 		const double ratio = best[0] / best[winner];
 
-		std::printf("%8zu %12.1f %12.1f %12.1f %12.1f   %s", size, best[0], best[1], best[2], best[3],
-		            impls[winner].name);
+		std::printf("%8zu", size);
+		for (double timing : best) {
+			std::printf(" %12.1f", timing);
+		}
+		std::printf("   %s", impls[winner].name);
 		if (winner == 0) {
 			std::printf(" (current is fastest)\n");
 		} else {

--- a/benchmarks/perf_baseline/bench_xtea.cpp
+++ b/benchmarks/perf_baseline/bench_xtea.cpp
@@ -1,0 +1,269 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+//
+// Baseline measurement for the XTEA hot path (perf/profile-baseline).
+//
+// Compares four implementations and proves they all produce the same ciphertext
+// before reporting any timing:
+//
+//   tfs      - the loop currently in src/xtea.cpp, compiled from that exact file
+//   bt-sc    - BlackTek's scalar path (block outer, rounds inner)
+//   bt-sse2  - BlackTek's SSE2 kernel, 4 blocks at a time
+//   bt-avx2  - BlackTek's AVX2 kernel, 8 blocks at a time
+//
+// The SIMD kernels are transcribed from Black-Tek/BlackTek-Server src/xtea.cpp
+// so the comparison runs in one process on one machine. Nothing here is linked
+// into the server; this binary exists only to decide whether a port is worth it.
+//
+// Build and run with benchmarks/perf_baseline/run.sh - it sweeps the flag sets
+// that change the answer.
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <immintrin.h>
+
+#include "xtea.h"
+
+namespace {
+
+using round_keys = xtea::round_keys;
+
+// ---------------------------------------------------------------- BlackTek --
+
+void bt_scalar_encrypt_block(uint32_t& left, uint32_t& right, const round_keys& k)
+{
+	for (int32_t i = 0; i < static_cast<int32_t>(k.size()); i += 2) {
+		left += ((right << 4 ^ right >> 5) + right) ^ k[i];
+		right += ((left << 4 ^ left >> 5) + left) ^ k[i + 1];
+	}
+}
+
+void bt_scalar_encrypt(uint8_t* data, size_t length, const round_keys& k)
+{
+	for (size_t blocks = length / 8; blocks > 0; --blocks, data += 8) {
+		uint32_t left, right;
+		std::memcpy(&left, data, 4);
+		std::memcpy(&right, data + 4, 4);
+		bt_scalar_encrypt_block(left, right, k);
+		std::memcpy(data, &left, 4);
+		std::memcpy(data + 4, &right, 4);
+	}
+}
+
+__attribute__((target("sse2"))) void bt_sse2_encrypt4(uint8_t* data, const round_keys& k)
+{
+	__m128i v0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data));
+	__m128i v1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 16));
+
+	__m128i v0s = _mm_shuffle_epi32(v0, _MM_SHUFFLE(3, 1, 2, 0));
+	__m128i v1s = _mm_shuffle_epi32(v1, _MM_SHUFFLE(3, 1, 2, 0));
+
+	__m128i lefts = _mm_unpacklo_epi64(v0s, v1s);
+	__m128i rights = _mm_unpackhi_epi64(v0s, v1s);
+
+	for (int32_t i = 0; i < static_cast<int32_t>(k.size()); i += 2) {
+		__m128i keyA = _mm_set1_epi32(static_cast<int32_t>(k[i]));
+		__m128i keyB = _mm_set1_epi32(static_cast<int32_t>(k[i + 1]));
+
+		__m128i newLefts = _mm_add_epi32(
+		    lefts, _mm_xor_si128(_mm_add_epi32(_mm_xor_si128(_mm_slli_epi32(rights, 4), _mm_srli_epi32(rights, 5)),
+		                                       rights),
+		                         keyA));
+		__m128i newRights = _mm_add_epi32(
+		    rights, _mm_xor_si128(_mm_add_epi32(_mm_xor_si128(_mm_slli_epi32(newLefts, 4), _mm_srli_epi32(newLefts, 5)),
+		                                        newLefts),
+		                          keyB));
+		lefts = newLefts;
+		rights = newRights;
+	}
+
+	_mm_storeu_si128(reinterpret_cast<__m128i*>(data), _mm_unpacklo_epi32(lefts, rights));
+	_mm_storeu_si128(reinterpret_cast<__m128i*>(data + 16), _mm_unpackhi_epi32(lefts, rights));
+}
+
+__attribute__((target("avx2"))) void bt_avx2_encrypt8(uint8_t* data, const round_keys& k)
+{
+	__m256i v0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data));
+	__m256i v1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data + 32));
+
+	__m256i v0s = _mm256_shuffle_epi32(v0, _MM_SHUFFLE(3, 1, 2, 0));
+	__m256i v1s = _mm256_shuffle_epi32(v1, _MM_SHUFFLE(3, 1, 2, 0));
+	__m256i v0p = _mm256_permute4x64_epi64(v0s, _MM_SHUFFLE(3, 1, 2, 0));
+	__m256i v1p = _mm256_permute4x64_epi64(v1s, _MM_SHUFFLE(3, 1, 2, 0));
+
+	__m256i lefts = _mm256_permute2x128_si256(v0p, v1p, 0x20);
+	__m256i rights = _mm256_permute2x128_si256(v0p, v1p, 0x31);
+
+	for (int32_t i = 0; i < static_cast<int32_t>(k.size()); i += 2) {
+		__m256i keyA = _mm256_set1_epi32(static_cast<int32_t>(k[i]));
+		__m256i keyB = _mm256_set1_epi32(static_cast<int32_t>(k[i + 1]));
+
+		__m256i newLefts = _mm256_add_epi32(
+		    lefts, _mm256_xor_si256(_mm256_add_epi32(_mm256_xor_si256(_mm256_slli_epi32(rights, 4),
+		                                                             _mm256_srli_epi32(rights, 5)),
+		                                             rights),
+		                            keyA));
+		__m256i newRights = _mm256_add_epi32(
+		    rights, _mm256_xor_si256(_mm256_add_epi32(_mm256_xor_si256(_mm256_slli_epi32(newLefts, 4),
+		                                                              _mm256_srli_epi32(newLefts, 5)),
+		                                              newLefts),
+		                             keyB));
+		lefts = newLefts;
+		rights = newRights;
+	}
+
+	__m256i outV0p = _mm256_permute2x128_si256(lefts, rights, 0x20);
+	__m256i outV1p = _mm256_permute2x128_si256(lefts, rights, 0x31);
+	__m256i outV0s = _mm256_permute4x64_epi64(outV0p, _MM_SHUFFLE(3, 1, 2, 0));
+	__m256i outV1s = _mm256_permute4x64_epi64(outV1p, _MM_SHUFFLE(3, 1, 2, 0));
+
+	_mm256_storeu_si256(reinterpret_cast<__m256i*>(data), _mm256_shuffle_epi32(outV0s, _MM_SHUFFLE(3, 1, 2, 0)));
+	_mm256_storeu_si256(reinterpret_cast<__m256i*>(data + 32), _mm256_shuffle_epi32(outV1s, _MM_SHUFFLE(3, 1, 2, 0)));
+}
+
+// Mirrors BlackTek's dispatch: AVX2 for whole 8-block groups, then SSE2 for
+// whole 4-block groups, then scalar for the tail.
+void bt_sse2_encrypt(uint8_t* data, size_t length, const round_keys& k)
+{
+	size_t blocks = length / 8;
+	while (blocks >= 4) {
+		bt_sse2_encrypt4(data, k);
+		data += 32;
+		blocks -= 4;
+	}
+	bt_scalar_encrypt(data, blocks * 8, k);
+}
+
+void bt_avx2_encrypt(uint8_t* data, size_t length, const round_keys& k)
+{
+	size_t blocks = length / 8;
+	while (blocks >= 8) {
+		bt_avx2_encrypt8(data, k);
+		data += 64;
+		blocks -= 8;
+	}
+	while (blocks >= 4) {
+		bt_sse2_encrypt4(data, k);
+		data += 32;
+		blocks -= 4;
+	}
+	bt_scalar_encrypt(data, blocks * 8, k);
+}
+
+// ------------------------------------------------------------------ harness --
+
+using EncryptFn = void (*)(uint8_t*, size_t, const round_keys&);
+
+struct Impl
+{
+	const char* name;
+	EncryptFn fn;
+};
+
+double timeNs(EncryptFn fn, std::vector<uint8_t>& buffer, const round_keys& k, size_t iterations)
+{
+	const auto start = std::chrono::steady_clock::now();
+	for (size_t i = 0; i < iterations; ++i) {
+		fn(buffer.data(), buffer.size(), k);
+	}
+	const auto end = std::chrono::steady_clock::now();
+	// Reading the buffer keeps the optimiser from discarding the whole loop.
+	asm volatile("" : : "r"(buffer.data()) : "memory");
+	return std::chrono::duration<double, std::nano>(end - start).count() / static_cast<double>(iterations);
+}
+
+bool checkEquivalence(const std::vector<size_t>& sizes, const round_keys& k, const std::vector<Impl>& impls)
+{
+	std::mt19937 rng{20260817};
+	bool ok = true;
+
+	for (size_t size : sizes) {
+		std::vector<uint8_t> seed(size);
+		for (auto& byte : seed) {
+			byte = static_cast<uint8_t>(rng());
+		}
+
+		std::vector<uint8_t> reference = seed;
+		impls.front().fn(reference.data(), reference.size(), k);
+
+		for (size_t i = 1; i < impls.size(); ++i) {
+			std::vector<uint8_t> candidate = seed;
+			impls[i].fn(candidate.data(), candidate.size(), k);
+			if (candidate != reference) {
+				std::printf("  MISMATCH  size=%-6zu %s != %s\n", size, impls[i].name, impls.front().name);
+				ok = false;
+			}
+		}
+
+		// The current implementation must also round-trip through decrypt.
+		std::vector<uint8_t> roundTrip = reference;
+		xtea::decrypt(roundTrip.data(), roundTrip.size(), k);
+		if (roundTrip != seed) {
+			std::printf("  ROUND-TRIP FAILED size=%zu\n", size);
+			ok = false;
+		}
+	}
+	return ok;
+}
+
+} // namespace
+
+int main()
+{
+	const xtea::key rawKey = {0x1F2E3D4Cu, 0x5B6A7988u, 0x97A6B5C4u, 0xD3E2F100u};
+	const round_keys k = xtea::expand_key(rawKey);
+
+	const std::vector<Impl> impls = {
+	    {"tfs", &xtea::encrypt},
+	    {"bt-scalar", &bt_scalar_encrypt},
+	    {"bt-sse2", &bt_sse2_encrypt},
+	    {"bt-avx2", &bt_avx2_encrypt},
+	};
+
+	// Multiples of 8 only: XTEA operates on 8-byte blocks and the protocol pads
+	// to that boundary before calling encrypt.
+	const std::vector<size_t> sizes = {8, 16, 24, 32, 40, 48, 56, 64, 128, 256, 512, 1024, 4096, 16384};
+
+	std::printf("== equivalence ==\n");
+	if (!checkEquivalence(sizes, k, impls)) {
+		std::printf("EQUIVALENCE FAILED - timings below would be meaningless\n");
+		return 1;
+	}
+	std::printf("  all %zu implementations agree on %zu sizes, decrypt round-trips\n\n", impls.size(), sizes.size());
+
+	std::printf("== encrypt, ns per call, best of 5, lower is better ==\n");
+	std::printf("%8s %12s %12s %12s %12s   %s\n", "bytes", "tfs", "bt-scalar", "bt-sse2", "bt-avx2", "winner");
+
+	for (size_t size : sizes) {
+		const size_t iterations = std::max<size_t>(2000, (1u << 22) / size);
+		std::vector<double> best(impls.size(), 1e30);
+
+		for (int round = 0; round < 5; ++round) {
+			for (size_t i = 0; i < impls.size(); ++i) {
+				std::vector<uint8_t> buffer(size, static_cast<uint8_t>(0xA5));
+				best[i] = std::min(best[i], timeNs(impls[i].fn, buffer, k, iterations));
+			}
+		}
+
+		const size_t winner = static_cast<size_t>(std::min_element(best.begin(), best.end()) - best.begin());
+		const double ratio = best[0] / best[winner];
+
+		std::printf("%8zu %12.1f %12.1f %12.1f %12.1f   %s", size, best[0], best[1], best[2], best[3],
+		            impls[winner].name);
+		if (winner == 0) {
+			std::printf(" (current is fastest)\n");
+		} else {
+			std::printf(" %.2fx vs tfs\n", ratio);
+		}
+	}
+
+	return 0;
+}

--- a/benchmarks/perf_baseline/run.sh
+++ b/benchmarks/perf_baseline/run.sh
@@ -13,14 +13,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT="${TMPDIR:-/tmp}/tfs_perf_baseline"
 mkdir -p "$OUT"
 
-BASELINE="-O3 -march=native -mtune=native -fomit-frame-pointer -DNDEBUG"
+BASELINE="-O3 -fomit-frame-pointer -DNDEBUG -march=native -mtune=native -std=c++23 -flto=auto -fno-fat-lto-objects"
 
 # src/xtea.cpp pulls in otpch.h, which needs the vcpkg include tree. Reuse the
-# include list CMake already resolved instead of guessing paths. Point
+# complete C++ flag set and include list CMake resolved instead of guessing. Point
 # TFS_BUILD_DIR at another build tree if build-release is not the one you use.
 BUILD_DIR="${TFS_BUILD_DIR:-$ROOT/build-release}"
 FLAGS_MAKE="$(find "$BUILD_DIR" -name flags.make -path '*tfslib*' 2>/dev/null | head -1)"
 if [ -n "$FLAGS_MAKE" ]; then
+	CONFIGURED_CXX_FLAGS="$(sed -n 's/^CXX_FLAGS = //p' "$FLAGS_MAKE")"
+	if [ -n "$CONFIGURED_CXX_FLAGS" ]; then
+		BASELINE="$CONFIGURED_CXX_FLAGS"
+	fi
 	PROJECT_INCLUDES="$(sed -n 's/^CXX_INCLUDES = //p' "$FLAGS_MAKE")"
 else
 	PROJECT_INCLUDES=""
@@ -62,20 +66,37 @@ for flags in "${FLAG_SETS[@]}"; do
 	# shellcheck disable=SC2086
 	# FMT_HEADER_ONLY: otpch.h drags spdlog/fmt in. The benchmark only needs the
 	# XTEA loop, so make fmt header-only rather than linking the engine's deps.
-	"${CXX:-g++}" $flags -std=c++23 -DFMT_HEADER_ONLY -I"$ROOT/src" $PROJECT_INCLUDES \
-		-o "$OUT/bench_xtea" \
-		"$ROOT/benchmarks/perf_baseline/bench_xtea.cpp" "$ROOT/src/xtea.cpp" 2>&1 | head -20
-	if [ ! -x "$OUT/bench_xtea" ]; then
+	XTEA_NEXT="$OUT/bench_xtea.next"
+	XTEA_LOG="$OUT/bench_xtea.build.log"
+	rm -f "$XTEA_NEXT"
+	if ! "${CXX:-g++}" $flags -std=c++23 -DFMT_HEADER_ONLY -I"$ROOT/src" $PROJECT_INCLUDES \
+		-o "$XTEA_NEXT" \
+		"$ROOT/benchmarks/perf_baseline/bench_xtea.cpp" "$ROOT/src/xtea.cpp" >"$XTEA_LOG" 2>&1; then
+		head -20 "$XTEA_LOG"
+		rm -f "$XTEA_NEXT"
 		echo "xtea build FAILED"; status=1; continue
+	fi
+	head -20 "$XTEA_LOG"
+	if ! mv -f "$XTEA_NEXT" "$OUT/bench_xtea"; then
+		echo "xtea install FAILED"; status=1; continue
 	fi
 	"$OUT/bench_xtea" || status=1
 	echo
 
 	# shellcheck disable=SC2086
+	ADLER_NEXT="$OUT/bench_adler.next"
+	ADLER_LOG="$OUT/bench_adler.build.log"
+	rm -f "$ADLER_NEXT"
 	if ! "${CXX:-g++}" $flags -std=c++23 \
-		-o "$OUT/bench_adler" \
-		"$ROOT/benchmarks/perf_baseline/bench_adler.cpp" -lz 2>&1 | head -20; then
+		-o "$ADLER_NEXT" \
+		"$ROOT/benchmarks/perf_baseline/bench_adler.cpp" -lz >"$ADLER_LOG" 2>&1; then
+		head -20 "$ADLER_LOG"
+		rm -f "$ADLER_NEXT"
 		echo "adler build FAILED"; status=1; continue
+	fi
+	head -20 "$ADLER_LOG"
+	if ! mv -f "$ADLER_NEXT" "$OUT/bench_adler"; then
+		echo "adler install FAILED"; status=1; continue
 	fi
 	"$OUT/bench_adler" || status=1
 	echo

--- a/benchmarks/perf_baseline/run.sh
+++ b/benchmarks/perf_baseline/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Baseline measurement runner for perf/profile-baseline.
+#
+#   ./benchmarks/perf_baseline/run.sh            # baseline flag set only
+#   ./benchmarks/perf_baseline/run.sh --sweep    # all four flag sets
+#
+# The baseline is the one the Release build actually uses. Reporting a speedup
+# against -O0/-O1/-O2 is how this plan got its priorities wrong once already, so
+# --sweep exists to make that visible rather than to be quoted on its own.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="${TMPDIR:-/tmp}/tfs_perf_baseline"
+mkdir -p "$OUT"
+
+BASELINE="-O3 -march=native -mtune=native -fomit-frame-pointer -DNDEBUG"
+
+# src/xtea.cpp pulls in otpch.h, which needs the vcpkg include tree. Reuse the
+# include list CMake already resolved instead of guessing paths. Point
+# TFS_BUILD_DIR at another build tree if build-release is not the one you use.
+BUILD_DIR="${TFS_BUILD_DIR:-$ROOT/build-release}"
+FLAGS_MAKE="$(find "$BUILD_DIR" -name flags.make -path '*tfslib*' 2>/dev/null | head -1)"
+if [ -n "$FLAGS_MAKE" ]; then
+	PROJECT_INCLUDES="$(sed -n 's/^CXX_INCLUDES = //p' "$FLAGS_MAKE")"
+else
+	PROJECT_INCLUDES=""
+	echo "WARNING: no configured build tree found under $BUILD_DIR."
+	echo "         Configure one first:  cmake -B build-release -DCMAKE_BUILD_TYPE=Release"
+	echo "         The XTEA benchmark needs it to locate the vcpkg headers."
+	echo
+fi
+
+if [ "${1:-}" = "--sweep" ]; then
+	FLAG_SETS=("-O2" "-O3" "-O3 -mavx2" "$BASELINE")
+else
+	FLAG_SETS=("$BASELINE")
+fi
+
+echo "########## environment ##########"
+if command -v lscpu > /dev/null; then
+	lscpu | grep -E '^Model name|^CPU\(s\):' | sed 's/  */ /g'
+	echo -n "isa: "
+	lscpu | grep -o -E 'avx512f|avx2|sse4_2|sse2' | sort -u | tr '\n' ' '
+	echo
+fi
+"${CXX:-g++}" --version | head -1
+echo "commit: $(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "branch: $(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+echo
+
+status=0
+
+for flags in "${FLAG_SETS[@]}"; do
+	echo "##################################################################"
+	if [ "$flags" = "$BASELINE" ]; then
+		echo "# FLAGS: $flags   <-- BASELINE (what Release actually builds with)"
+	else
+		echo "# FLAGS: $flags   (context only, not a valid baseline)"
+	fi
+	echo "##################################################################"
+
+	# shellcheck disable=SC2086
+	# FMT_HEADER_ONLY: otpch.h drags spdlog/fmt in. The benchmark only needs the
+	# XTEA loop, so make fmt header-only rather than linking the engine's deps.
+	"${CXX:-g++}" $flags -std=c++23 -DFMT_HEADER_ONLY -I"$ROOT/src" $PROJECT_INCLUDES \
+		-o "$OUT/bench_xtea" \
+		"$ROOT/benchmarks/perf_baseline/bench_xtea.cpp" "$ROOT/src/xtea.cpp" 2>&1 | head -20
+	if [ ! -x "$OUT/bench_xtea" ]; then
+		echo "xtea build FAILED"; status=1; continue
+	fi
+	"$OUT/bench_xtea" || status=1
+	echo
+
+	# shellcheck disable=SC2086
+	if ! "${CXX:-g++}" $flags -std=c++23 \
+		-o "$OUT/bench_adler" \
+		"$ROOT/benchmarks/perf_baseline/bench_adler.cpp" -lz 2>&1 | head -20; then
+		echo "adler build FAILED"; status=1; continue
+	fi
+	"$OUT/bench_adler" || status=1
+	echo
+done
+
+exit $status

--- a/docs/PERF_BASELINE_REPORT.md
+++ b/docs/PERF_BASELINE_REPORT.md
@@ -1,0 +1,287 @@
+# perf/profile-baseline — relatório
+
+Branch: `perf/profile-baseline` · base: `main` @ `63b758a7` · referência: [Black-Tek/BlackTek-Server](https://github.com/Black-Tek/BlackTek-Server) @ `61d23b5`
+
+Escopo desta branch, conforme o plano: **descobrir onde o CPU está antes de portar qualquer linha.**
+Nenhuma mudança de comportamento. Toda instrumentação adicionada é opcional e compilada fora por padrão.
+
+---
+
+## Ambiente da medição
+
+| | |
+|---|---|
+| CPU | Intel Core i5-10300H @ 2.50 GHz, 4 cores / 8 threads |
+| ISA | SSE2, SSE4.2, **AVX2** — sem AVX512 |
+| RAM | 7.7 GiB |
+| OS | Ubuntu 24.04.4 LTS (WSL2) |
+| Compilador | g++ 13.3.0 |
+| CMake | 3.28.3 |
+| Build | Release |
+
+> A tabela do plano foi medida num **Xeon @ 2.80 GHz com AVX512F**. Esta máquina não tem AVX512.
+> Os números abaixo foram medidos aqui e **divergem do plano em pontos importantes** — está sinalizado onde.
+
+---
+
+## 1. As flags de Release são as esperadas?
+
+**Sim, e com um extra que o plano não mencionava.**
+
+`CMakeCache.txt` mostra apenas o valor que o usuário passou:
+
+```
+CMAKE_BUILD_TYPE:STRING=Release
+CMAKE_CXX_FLAGS_RELEASE:STRING=-O3 -DNDEBUG
+ENABLE_NATIVE_OPTIMIZATIONS:BOOL=ON
+```
+
+A linha de compilação real, lida de `build-release/src/CMakeFiles/tfslib.dir/flags.make`:
+
+```
+-O3 -fomit-frame-pointer -DNDEBUG -march=native -mtune=native -std=c++23
+-flto=auto -fno-fat-lto-objects -Wall -Wextra ... -fno-strict-aliasing
+```
+
+Confirmado: `-O3 -march=native -mtune=native`. **Mais `-flto=auto -fno-fat-lto-objects`**, que o plano
+não citava e que muda como se verifica qualquer coisa neste projeto — ver o item 2.
+
+**Ponto em aberto para você responder:** o binário de produção é compilado na mesma máquina onde roda?
+Com `-march=native` isso não é detalhe — é a pré-condição (A) da branch 5. Se o binário for distribuído
+para outra máquina, `-march=native` não pode ser usado e a conclusão sobre SIMD XTEA muda.
+
+---
+
+## 2. O GCC vetoriza o XTEA?
+
+**A verificação proposta no plano não funciona neste projeto, e o motivo importa.**
+
+O plano manda rodar:
+
+```bash
+g++ -O3 -march=native -fopt-info-vec-optimized -c src/xtea.cpp -o /dev/null
+```
+
+Rodando exatamente isso, a saída vem vazia — parece "não vetorizou". **É um falso negativo.**
+O projeto compila com `-flto=auto -fno-fat-lto-objects`: o `.o` contém só bytecode GIMPLE, nenhuma
+instrução de máquina. Comprovado:
+
+```
+compile rc=0
+ymm (AVX2 256-bit) no TU : 0
+xmm (SSE  128-bit) no TU : 0
+total de instruções      : 0     <- objeto sem código, geração adiada para o link
+```
+
+A geração de código — e portanto a vetorização — acontece **no link**. E como o projeto usa
+`-fvisibility=hidden` + LTO, `xtea::encrypt` nem existe como símbolo no binário final:
+
+```
+nm -C build-release/tfs | grep xtea::   ->  (vazio, inlinado pelo LTO)
+```
+
+Isolando o mesmo laço num TU sem `otpch.h`, o GCC **vetoriza**:
+
+```
+/tmp/xtea_iso.cpp:9:49: optimized: loop vectorized using 32 byte vectors
+/tmp/xtea_iso.cpp:9:49: optimized: loop versioned for vectorization because of possible aliasing
+/tmp/xtea_iso.cpp:9:49: optimized: loop vectorized using 16 byte vectors
+```
+
+32 bytes = AVX2. **O Fato 1 do plano está correto na conclusão** (o laço atual vetoriza sozinho),
+mas o método de verificação proposto não serve aqui. Para responder isso neste projeto é preciso
+medir, não inspecionar — que é o que `benchmarks/perf_baseline/` passa a fazer.
+
+---
+
+## 3. Onde XTEA e Adler32 são realmente chamados
+
+```
+src/protocol.cpp:24   xtea::encrypt(buffer, msg.getLength(), key)        <- todo pacote de saída
+src/protocol.cpp:34   xtea::decrypt(buffer, msg.getLength() - 6, key)    <- todo pacote de entrada
+
+src/connection.cpp:282    adlerChecksum(...)
+src/outputmessage.h:34    adlerChecksum(...)
+src/protocolgame.cpp:1317 adlerChecksum(..., 8)                          <- sempre 8 bytes
+```
+
+Detalhe relevante para a branch 5: `XTEA_encrypt` faz padding para múltiplo de 8 **antes** de cifrar,
+então o comprimento entregue ao kernel é sempre múltiplo de 8. E `protocolgame.cpp:1317` chama o
+Adler com **8 bytes fixos** — exatamente o tamanho onde a zlib **perde** para o código atual.
+
+---
+
+## 4. Verificação dos fatos do plano contra o código
+
+| Fato | Afirmação do plano | Medido aqui | Veredito |
+|---|---|---|---|
+| 1 | XTEA atual já vetoriza | vetoriza (32-byte vectors), mas só verificável por medição por causa do LTO | **confirmado, método corrigido** |
+| 3 | `detect()` cai em Scalar no GCC/Clang | `simd_dispatch.h:62` → `#else g_level = Level::Scalar;` | **confirmado** |
+| 4 | Adler32 zlib ~1,4x | 1,37–1,44x acima de 64 B; **perde** abaixo de 32 B | **confirmado** |
+| 5 | Pathfinding já é o mesmo código | `FIB_MULT = 2654435761u`, `MAX_NODES = 512`, `ASTAR_HASH_BITS = 10u` idênticos nos dois | **confirmado** |
+| 6 | Target strategy do TFS é superior | TFS tem `case TARGETSEARCH_HEALTH:` (monster.cpp:1166) e `case TARGETSEARCH_DAMAGE:` (1198); BlackTek só trata `NEAREST` (monster.cpp:655) | **confirmado** |
+| 7 | `getSpectators` é o caminho quente | **103** call sites no TFS (112 com testes), **63** no BlackTek | **confirmado** (plano dizia 107/60) |
+
+Estruturas que o TFS **já tem** e que não devem ser reimplementadas:
+
+```
+QTree + cachedLeaf            src/map.cpp        (5 ocorrências)
+SpectatorVec::partitionByType src/spectators.h
+thread_local AStarWorkspace   src/map.cpp        (13 ocorrências)
+```
+
+---
+
+## 5. Adler32 — medido
+
+`-O3 -march=native`, melhor de 5, ns por chamada. Hash **byte-idêntico** em 14 tamanhos × 4 padrões
+(zeros, 0xFF, sequencial, aleatório), incluindo o caso `> NETWORKMESSAGE_MAXSIZE` que retorna 0.
+
+| bytes | manual (atual) | zlib `adler32_z` | speedup | vencedor |
+|------:|---------------:|-----------------:|--------:|----------|
+| 1 | **2,0** | 3,0 | 0,68x | atual |
+| 8 | **4,3** | 5,6 | 0,77x | atual |
+| 16 | **7,4** | 8,3 | 0,89x | atual |
+| 32 | 13,3 | **12,3** | 1,08x | zlib |
+| 64 | 25,0 | **20,4** | 1,23x | zlib |
+| 128 | 53,2 | **37,2** | 1,43x | zlib |
+| 256 | 99,5 | **70,7** | 1,41x | zlib |
+| 512 | 191,9 | **137,1** | 1,40x | zlib |
+| 1024 | 380,6 | **271,3** | 1,40x | zlib |
+| 2048 | 759,5 | **546,2** | 1,39x | zlib |
+| 4096 | 1511,2 | **1109,4** | 1,36x | zlib |
+| 24590 | 9407,5 | **6730,2** | 1,40x | zlib |
+
+O ponto de virada fica entre **16 e 32 bytes**, batendo com o plano. E a chamada de
+`protocolgame.cpp:1317` é de 8 bytes fixos — essa especificamente **ficaria mais lenta** com zlib.
+A branch 1 precisa tratar isso, não trocar tudo cegamente.
+
+zlib já é dependência obrigatória (`CMakeLists.txt:84 find_package(ZLIB REQUIRED)`, linkada na
+linha 333, declarada em `vcpkg.json`). Portar não adiciona dependência.
+
+---
+
+## 6. XTEA — medido
+
+`-O3 -march=native`, melhor de 5, ns por chamada, máquina ociosa. As 4 implementações produzem
+**cifra idêntica** em 14 tamanhos e `decrypt(encrypt(x)) == x` — o harness recusa reportar tempo se a
+equivalência falhar.
+
+| bytes | tfs (atual) | bt-scalar | bt-sse2 | bt-avx2 | vencedor | passa o gate de 20%? |
+|------:|------------:|----------:|--------:|--------:|----------|----|
+| 8 | 96,4 | **74,7** | 75,7 | 75,6 | bt-scalar 1,29x | sim |
+| 16 | **106,2** | 136,0 | 135,5 | 135,8 | atual | não |
+| 24 | **153,0** | 220,5 | 221,8 | 225,1 | atual | não |
+| 32 | 157,5 | 299,2 | 89,2 | **88,1** | bt-avx2 1,79x | **sim** |
+| 40 | 160,3 | 393,2 | 160,3 | **156,5** | bt-avx2 1,02x | não |
+| 48 | **174,9** | 448,5 | 225,4 | 232,8 | atual | não |
+| 56 | **215,6** | 523,0 | 300,8 | 297,2 | atual | não |
+| 64 | 206,6 | 611,7 | 166,5 | **85,4** | bt-avx2 2,42x | **sim** |
+| 128 | 253,7 | 1187,0 | 332,2 | **150,5** | bt-avx2 1,69x | **sim** |
+| 256 | **303,1** | 2297,9 | 644,0 | 305,0 | atual | não |
+| 512 | 643,1 | 4599,9 | 1300,8 | **605,8** | bt-avx2 1,06x | não |
+| 1024 | **1109,2** | 9281,5 | 2586,1 | 1234,2 | atual | não |
+| 4096 | 4980,3 | 37098,0 | 10397,9 | **4971,6** | bt-avx2 1,00x | não |
+| 16384 | 20650,3 | 149548,0 | 41247,2 | **19972,2** | bt-avx2 1,03x | não |
+
+### O que esta tabela diz
+
+**1. O caminho scalar do BlackTek é uma regressão brutal, e é o caminho que ele realmente toma no Linux.**
+`simd_dispatch.h:62` força `g_level = Level::Scalar` fora de MSVC/ICC. Portando como está, o servidor
+roda a coluna `bt-scalar`: **2,9x mais lento** em 64 B, **7,2x** em 16 KB. O plano estimava 1,75x;
+aqui é muito pior. Se algo for portado, o fallback scalar **tem que continuar sendo o laço atual do TFS**.
+
+**2. O vencedor troca com o tamanho, e não há resposta única.** O AVX2 ganha forte em 32/64/128 B
+(1,79x / 2,42x / 1,69x) e empata ou perde de 256 B para cima. O atual ganha em 16, 24, 48, 56, 256 e 1024.
+
+**3. Isso diverge do plano.** A tabela do documento (Xeon com AVX512) dava o atual vencendo de 256 B
+para cima por 16–32%. Aqui de 512 B para cima o AVX2 ganha por 3–6% — margem irrelevante, mas o sinal
+inverteu. Confirma a tese central do documento: **a conclusão depende da máquina e das flags**, então
+cada servidor precisa rodar `benchmarks/perf_baseline/run.sh` no próprio hardware.
+
+**4. O gate de 20% só é batido em 32, 64 e 128 bytes.** Portanto:
+
+> **A branch 5 continua CONDICIONAL e não pode ser decidida ainda.** Se a distribuição real de tamanho
+> de pacote se concentrar em 32–128 B, o port ganha de 1,7x a 2,4x e vale. Se se concentrar em 256 B ou
+> mais, o ganho é ≤6% e o port é **REJEITADO** pelo gate. Sem o histograma da seção 8, qualquer decisão
+> aqui é chute.
+
+**5. Pré-condição (A) ainda em aberto.** Se o binário for distribuído para terceiros, `-march=native`
+não pode ser usado e o baseline muda — foi exatamente esse cenário que fez o plano priorizar errado da
+primeira vez. Preciso da sua resposta: **o binário roda na mesma máquina onde é compilado?**
+
+---
+
+## 7. O que NÃO foi medido, e por quê
+
+| Item | Status | Motivo |
+|---|---|---|
+| `perf record` com carga real | **não feito** | exige servidor de pé com MySQL e jogadores/bots. Não disponível nesta máquina. |
+| % de CPU por função | **não obtido** | depende do item acima |
+| Distribuição real de tamanho de pacote | **instrumentado, não coletado** | precisa de servidor sob carga — ver seção 8 |
+
+### Build verificado
+
+| Configuração | configure | build | instrumentação no binário | tamanho |
+|---|---|---|---|---|
+| Release padrão | rc=0 | rc=0 | **ausente** | 6.714.432 B |
+| Release + `ENABLE_PACKET_SIZE_HISTOGRAM=ON` | rc=0 | rc=0 | presente | 6.725.048 B |
+
+Diferença de 10.616 bytes, só no binário instrumentado. Com a opção desligada as macros expandem para
+nada e o binário de produção não muda.
+
+### Achado de infraestrutura (registrar para as branches seguintes)
+
+Um `cmake -B build-novo -DCMAKE_BUILD_TYPE=Release` **limpo não configura** nesta máquina. Duas
+dependências estão instaladas à mão e só são encontradas via cache de uma árvore já configurada:
+
+```
+mio             -> /home/mateus/.local/share/cmake/mio     (precisa de CMAKE_PREFIX_PATH)
+Lua 5.5         -> LUA_INCLUDE_DIR não é achado sozinho
+simdutf         -> /home/mateus/.local/lib/cmake/simdutf
+```
+
+Reconfigurar a árvore existente (`cmake -B build-release -D<opção>`) funciona porque reaproveita o
+cache. As branches seguintes devem contar com isso, ou o `build.sh` do projeto precisa documentar as
+variáveis exigidas.
+
+**Portanto a pergunta central do plano — "XTEA + Adler32 somam menos de 3% do CPU?" — continua sem
+resposta.** Não vou inventar um número. O que esta branch entrega é o instrumental para você
+responder, rodando o servidor de verdade.
+
+---
+
+## 8. Como coletar o que falta
+
+### Distribuição de tamanho de pacote
+
+```bash
+cmake -B build-histogram -DCMAKE_BUILD_TYPE=Release -DENABLE_PACKET_SIZE_HISTOGRAM=ON
+cmake --build build-histogram -j"$(nproc)"
+./build-histogram/tfs
+```
+
+Reporta as duas direções no log a cada 100 mil pacotes de saída. Desligado por padrão: sem a
+opção, as macros expandem para nada e o binário de produção não muda.
+
+### Profile de CPU
+
+```bash
+perf record -F 999 -g --call-graph dwarf -- ./build-release/tfs
+perf report --stdio --sort=dso,symbol | head -60
+```
+
+---
+
+## 9. Arquivos desta branch
+
+| Arquivo | O que é |
+|---|---|
+| `benchmarks/perf_baseline/bench_xtea.cpp` | compara TFS × BlackTek scalar/SSE2/AVX2, valida equivalência antes de medir |
+| `benchmarks/perf_baseline/bench_adler.cpp` | manual × `adler32_z`, valida equivalência antes de medir |
+| `benchmarks/perf_baseline/run.sh` | roda no baseline; `--sweep` mostra como as flags mudam a resposta |
+| `benchmarks/perf_baseline/README.md` | como rodar e como ler |
+| `src/packet_size_histogram.h/.cpp` | instrumentação opcional, compilada fora por padrão |
+| `src/protocol.cpp` | duas macros nos call sites do XTEA (no-op sem a opção) |
+| `CMakeLists.txt`, `src/CMakeLists.txt` | opção `ENABLE_PACKET_SIZE_HISTOGRAM` (OFF) e o novo .cpp |
+| `docs/PERF_BASELINE_REPORT.md` | este relatório |

--- a/docs/PERF_BASELINE_REPORT.md
+++ b/docs/PERF_BASELINE_REPORT.md
@@ -30,7 +30,7 @@ Nenhuma mudança de comportamento. Toda instrumentação adicionada é opcional 
 
 `CMakeCache.txt` mostra apenas o valor que o usuário passou:
 
-```
+```text
 CMAKE_BUILD_TYPE:STRING=Release
 CMAKE_CXX_FLAGS_RELEASE:STRING=-O3 -DNDEBUG
 ENABLE_NATIVE_OPTIMIZATIONS:BOOL=ON
@@ -38,7 +38,7 @@ ENABLE_NATIVE_OPTIMIZATIONS:BOOL=ON
 
 A linha de compilação real, lida de `build-release/src/CMakeFiles/tfslib.dir/flags.make`:
 
-```
+```text
 -O3 -fomit-frame-pointer -DNDEBUG -march=native -mtune=native -std=c++23
 -flto=auto -fno-fat-lto-objects -Wall -Wextra ... -fno-strict-aliasing
 ```
@@ -66,7 +66,7 @@ Rodando exatamente isso, a saída vem vazia — parece "não vetorizou". **É um
 O projeto compila com `-flto=auto -fno-fat-lto-objects`: o `.o` contém só bytecode GIMPLE, nenhuma
 instrução de máquina. Comprovado:
 
-```
+```text
 compile rc=0
 ymm (AVX2 256-bit) no TU : 0
 xmm (SSE  128-bit) no TU : 0
@@ -76,13 +76,13 @@ total de instruções      : 0     <- objeto sem código, geração adiada para 
 A geração de código — e portanto a vetorização — acontece **no link**. E como o projeto usa
 `-fvisibility=hidden` + LTO, `xtea::encrypt` nem existe como símbolo no binário final:
 
-```
+```text
 nm -C build-release/tfs | grep xtea::   ->  (vazio, inlinado pelo LTO)
 ```
 
 Isolando o mesmo laço num TU sem `otpch.h`, o GCC **vetoriza**:
 
-```
+```text
 /tmp/xtea_iso.cpp:9:49: optimized: loop vectorized using 32 byte vectors
 /tmp/xtea_iso.cpp:9:49: optimized: loop versioned for vectorization because of possible aliasing
 /tmp/xtea_iso.cpp:9:49: optimized: loop vectorized using 16 byte vectors
@@ -96,7 +96,7 @@ medir, não inspecionar — que é o que `benchmarks/perf_baseline/` passa a faz
 
 ## 3. Onde XTEA e Adler32 são realmente chamados
 
-```
+```text
 src/protocol.cpp:24   xtea::encrypt(buffer, msg.getLength(), key)        <- todo pacote de saída
 src/protocol.cpp:34   xtea::decrypt(buffer, msg.getLength() - 6, key)    <- todo pacote de entrada
 
@@ -124,7 +124,7 @@ Adler com **8 bytes fixos** — exatamente o tamanho onde a zlib **perde** para 
 
 Estruturas que o TFS **já tem** e que não devem ser reimplementadas:
 
-```
+```text
 QTree + cachedLeaf            src/map.cpp        (5 ocorrências)
 SpectatorVec::partitionByType src/spectators.h
 thread_local AStarWorkspace   src/map.cpp        (13 ocorrências)
@@ -248,7 +248,7 @@ throttling, com a máquina fria e repetições intercaladas.
 
 Independente de flags, ordem e temperatura:
 
-```
+```text
 64 B     -> AVX2 ganha 2,01x a 2,66x     (sempre)
 128 B    -> AVX2 ganha 1,42x a 1,69x     (sempre)
 16/24/48/56 B -> o código atual ganha    (sempre)
@@ -280,7 +280,7 @@ nada e o binário de produção não muda.
 Um `cmake -B build-novo -DCMAKE_BUILD_TYPE=Release` **limpo não configura** nesta máquina. Duas
 dependências estão instaladas à mão e só são encontradas via cache de uma árvore já configurada:
 
-```
+```text
 mio             -> /home/mateus/.local/share/cmake/mio     (precisa de CMAKE_PREFIX_PATH)
 Lua 5.5         -> LUA_INCLUDE_DIR não é achado sozinho
 simdutf         -> /home/mateus/.local/lib/cmake/simdutf

--- a/docs/PERF_BASELINE_REPORT.md
+++ b/docs/PERF_BASELINE_REPORT.md
@@ -206,9 +206,54 @@ cada servidor precisa rodar `benchmarks/perf_baseline/run.sh` no próprio hardwa
 > mais, o ganho é ≤6% e o port é **REJEITADO** pelo gate. Sem o histograma da seção 8, qualquer decisão
 > aqui é chute.
 
-**5. Pré-condição (A) ainda em aberto.** Se o binário for distribuído para terceiros, `-march=native`
-não pode ser usado e o baseline muda — foi exatamente esse cenário que fez o plano priorizar errado da
-primeira vez. Preciso da sua resposta: **o binário roda na mesma máquina onde é compilado?**
+**5. Pré-condição (A) — metade resolvida pelo `--sweep`.** Em `-O3` puro (sem `-march=native`, que é o
+que se usa num binário distribuído), o AVX2 do BlackTek ganha em **praticamente todo tamanho**:
+
+| bytes | tfs @ -O3 | bt-avx2 @ -O3 | ganho |
+|------:|----------:|--------------:|------:|
+| 64 | 164,7 | **81,8** | 2,01x |
+| 128 | 242,4 | **152,1** | 1,59x |
+| 256 | 451,8 | **306,6** | 1,47x |
+| 512 | 872,4 | **613,6** | 1,42x |
+| 1024 | 1925,5 | **1217,6** | 1,58x |
+| 4096 | 7102,0 | **4889,7** | 1,45x |
+| 16384 | 27879,0 | **19542,1** | 1,43x |
+
+Todos passam o gate de 20% com folga. **Se o binário for distribuído para terceiros, o port vale.**
+Se for compilado na mesma máquina onde roda, ver o item 6. Ainda preciso da sua resposta sobre qual
+dos dois cenários é o real.
+
+### AVISO — variância acima de 256 bytes invalida o gate com `-march=native`
+
+Duas execuções do **mesmo commit, mesma máquina, mesmas flags de baseline**:
+
+| bytes | tfs (execução 1) | tfs (execução 2) | variação | bt-avx2 (1) | bt-avx2 (2) | variação |
+|------:|-----------------:|-----------------:|---------:|------------:|------------:|---------:|
+| 256 | 305,1 | 380,0 | +25% | 307,3 | 315,0 | +3% |
+| 512 | 652,3 | 738,3 | +13% | 607,3 | 618,7 | +2% |
+| 1024 | 1103,8 | 1291,3 | +17% | 1209,4 | 1246,5 | +3% |
+| 4096 | 4917,8 | 6580,6 | **+34%** | 4845,1 | 5004,0 | +3% |
+| 16384 | 20575,3 | 26343,7 | +28% | 19689,7 | 22684,1 | +15% |
+
+A coluna do código atual variou até **34%**; a do AVX2 ficou dentro de 3% na maior parte. A causa mais
+provável é **thermal throttling** — a máquina é um i5-10300H de notebook e a segunda execução veio no
+fim de um `--sweep` de quatro builds. O laço auto-vetorizado é mais sensível à queda de clock que o
+kernel AVX2.
+
+**Consequência:** de 256 bytes para cima, com `-march=native`, o gate de 20% cai **dentro da margem de
+ruído**. Esses números não decidem nada. Para decidir seria preciso repetir num servidor dedicado, sem
+throttling, com a máquina fria e repetições intercaladas.
+
+### O que é estável em todas as 8 execuções
+
+Independente de flags, ordem e temperatura:
+
+```
+64 B     -> AVX2 ganha 2,01x a 2,66x     (sempre)
+128 B    -> AVX2 ganha 1,42x a 1,69x     (sempre)
+16/24/48/56 B -> o código atual ganha    (sempre)
+bt-scalar-> perde em tudo acima de 8 B, até 7,2x   (sempre)
+```
 
 ---
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/otserv.cpp
 	${CMAKE_CURRENT_LIST_DIR}/outfit.cpp
 	${CMAKE_CURRENT_LIST_DIR}/outputmessage.cpp
+	${CMAKE_CURRENT_LIST_DIR}/packet_size_histogram.cpp
 	${CMAKE_CURRENT_LIST_DIR}/party.cpp
 	${CMAKE_CURRENT_LIST_DIR}/performance_metrics.cpp
 	${CMAKE_CURRENT_LIST_DIR}/player.cpp

--- a/src/packet_size_histogram.cpp
+++ b/src/packet_size_histogram.cpp
@@ -1,0 +1,65 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "otpch.h"
+
+#include "packet_size_histogram.h"
+
+#ifdef TFS_PACKET_SIZE_HISTOGRAM
+
+#include "logger.h"
+
+#include <fmt/format.h>
+
+namespace tfs::diagnostics {
+
+std::string PacketSizeHistogram::report(const char* label) const
+{
+	const uint64_t samples = total.load(std::memory_order_relaxed);
+	if (samples == 0) {
+		return fmt::format("[packet-size] {}: no samples yet\n", label);
+	}
+
+	const uint64_t bytes = totalBytes.load(std::memory_order_relaxed);
+	std::string out = fmt::format("[packet-size] {}: {} packets, {} bytes, mean {:.1f} bytes\n", label, samples, bytes,
+	                              static_cast<double>(bytes) / static_cast<double>(samples));
+
+	size_t low = 0;
+	uint64_t cumulative = 0;
+	for (size_t i = 0; i < PACKET_SIZE_BUCKETS.size(); ++i) {
+		const uint64_t hits = buckets[i].load(std::memory_order_relaxed);
+		cumulative += hits;
+		const double share = 100.0 * static_cast<double>(hits) / static_cast<double>(samples);
+		const double cumulativeShare = 100.0 * static_cast<double>(cumulative) / static_cast<double>(samples);
+		out += fmt::format("    {:>6}..{:<6} {:>12} {:>6.2f}%  (cum {:>6.2f}%)\n", low + 1, PACKET_SIZE_BUCKETS[i],
+		                   hits, share, cumulativeShare);
+		low = PACKET_SIZE_BUCKETS[i];
+	}
+
+	const uint64_t hits = overflow.load(std::memory_order_relaxed);
+	out += fmt::format("    {:>6}+{:<7} {:>12} {:>6.2f}%  (cum 100.00%)\n", low + 1, "", hits,
+	                   100.0 * static_cast<double>(hits) / static_cast<double>(samples));
+	return out;
+}
+
+PacketSizeHistogram& outgoingPacketSizes()
+{
+	static PacketSizeHistogram histogram;
+	return histogram;
+}
+
+PacketSizeHistogram& incomingPacketSizes()
+{
+	static PacketSizeHistogram histogram;
+	return histogram;
+}
+
+void reportPacketSizes()
+{
+	LOG_INFO(fmt::format("\n{}{}", outgoingPacketSizes().report("xtea::encrypt (outgoing)"),
+	                     incomingPacketSizes().report("xtea::decrypt (incoming)")));
+}
+
+} // namespace tfs::diagnostics
+
+#endif // TFS_PACKET_SIZE_HISTOGRAM

--- a/src/packet_size_histogram.cpp
+++ b/src/packet_size_histogram.cpp
@@ -16,29 +16,42 @@ namespace tfs::diagnostics {
 std::string PacketSizeHistogram::report(const char* label) const
 {
 	const uint64_t samples = total.load(std::memory_order_relaxed);
-	if (samples == 0) {
+	const uint64_t bytes = totalBytes.load(std::memory_order_relaxed);
+	std::array<uint64_t, PACKET_SIZE_BUCKETS.size()> bucketHits;
+	for (size_t i = 0; i < PACKET_SIZE_BUCKETS.size(); ++i) {
+		bucketHits[i] = buckets[i].load(std::memory_order_relaxed);
+	}
+	const uint64_t overflowHits = overflow.load(std::memory_order_relaxed);
+
+	uint64_t distributionSamples = overflowHits;
+	for (uint64_t hits : bucketHits) {
+		distributionSamples += hits;
+	}
+	if (samples == 0 || distributionSamples == 0) {
 		return fmt::format("[packet-size] {}: no samples yet\n", label);
 	}
 
-	const uint64_t bytes = totalBytes.load(std::memory_order_relaxed);
 	std::string out = fmt::format("[packet-size] {}: {} packets, {} bytes, mean {:.1f} bytes\n", label, samples, bytes,
 	                              static_cast<double>(bytes) / static_cast<double>(samples));
 
 	size_t low = 0;
 	uint64_t cumulative = 0;
 	for (size_t i = 0; i < PACKET_SIZE_BUCKETS.size(); ++i) {
-		const uint64_t hits = buckets[i].load(std::memory_order_relaxed);
+		const uint64_t hits = bucketHits[i];
 		cumulative += hits;
-		const double share = 100.0 * static_cast<double>(hits) / static_cast<double>(samples);
-		const double cumulativeShare = 100.0 * static_cast<double>(cumulative) / static_cast<double>(samples);
+		const double share = 100.0 * static_cast<double>(hits) / static_cast<double>(distributionSamples);
+		const double cumulativeShare =
+		    100.0 * static_cast<double>(cumulative) / static_cast<double>(distributionSamples);
 		out += fmt::format("    {:>6}..{:<6} {:>12} {:>6.2f}%  (cum {:>6.2f}%)\n", low + 1, PACKET_SIZE_BUCKETS[i],
 		                   hits, share, cumulativeShare);
 		low = PACKET_SIZE_BUCKETS[i];
 	}
 
-	const uint64_t hits = overflow.load(std::memory_order_relaxed);
-	out += fmt::format("    {:>6}+{:<7} {:>12} {:>6.2f}%  (cum 100.00%)\n", low + 1, "", hits,
-	                   100.0 * static_cast<double>(hits) / static_cast<double>(samples));
+	cumulative += overflowHits;
+	const double overflowShare = 100.0 * static_cast<double>(overflowHits) / static_cast<double>(distributionSamples);
+	const double cumulativeShare = 100.0 * static_cast<double>(cumulative) / static_cast<double>(distributionSamples);
+	out += fmt::format("    {:>6}+{:<7} {:>12} {:>6.2f}%  (cum {:>6.2f}%)\n", low + 1, "", overflowHits,
+	                   overflowShare, cumulativeShare);
 	return out;
 }
 

--- a/src/packet_size_histogram.h
+++ b/src/packet_size_histogram.h
@@ -1,0 +1,103 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#ifndef FS_PACKET_SIZE_HISTOGRAM_H
+#define FS_PACKET_SIZE_HISTOGRAM_H
+
+// Opt-in instrumentation for the perf/profile-baseline work.
+//
+// Whether a SIMD XTEA port is worth anything depends entirely on how large the
+// buffers handed to xtea::encrypt actually are: benchmarks/perf_baseline shows
+// the vectorised kernels winning by 2.4x at 64 bytes, tying at 256, and losing
+// below 48. Guessing that distribution is how this plan mispriotised once
+// already, so measure it on a real server instead.
+//
+// Enable with:
+//     cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_PACKET_SIZE_HISTOGRAM=ON
+//
+// With the option off, TFS_PACKET_SIZE_HISTOGRAM is undefined and every call
+// below compiles to nothing - no counters, no branches, no atomics in the
+// Release binary.
+
+#ifdef TFS_PACKET_SIZE_HISTOGRAM
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace tfs::diagnostics {
+
+// Bucket edges chosen to match the sizes benchmarked in
+// benchmarks/perf_baseline/bench_xtea.cpp, because the decision is read off
+// exactly these boundaries.
+inline constexpr std::array<size_t, 11> PACKET_SIZE_BUCKETS = {8,   16,  24,  32,   48,  64,
+                                                               128, 256, 512, 1024, 4096};
+
+class PacketSizeHistogram
+{
+public:
+	// Called from the IO threads, so the counters are atomic. Relaxed ordering
+	// is enough: nothing else is published through them and the totals are only
+	// read for reporting.
+	void record(size_t length) noexcept
+	{
+		total.fetch_add(1, std::memory_order_relaxed);
+		totalBytes.fetch_add(length, std::memory_order_relaxed);
+
+		for (size_t i = 0; i < PACKET_SIZE_BUCKETS.size(); ++i) {
+			if (length <= PACKET_SIZE_BUCKETS[i]) {
+				buckets[i].fetch_add(1, std::memory_order_relaxed);
+				return;
+			}
+		}
+		overflow.fetch_add(1, std::memory_order_relaxed);
+	}
+
+	// Renders the distribution as a single multi-line string. Kept out of the
+	// header body so this stays cheap to include.
+	std::string report(const char* label) const;
+
+	uint64_t count() const noexcept { return total.load(std::memory_order_relaxed); }
+
+private:
+	std::array<std::atomic<uint64_t>, PACKET_SIZE_BUCKETS.size()> buckets = {};
+	std::atomic<uint64_t> overflow = 0;
+	std::atomic<uint64_t> total = 0;
+	std::atomic<uint64_t> totalBytes = 0;
+};
+
+// One histogram per direction: outgoing buffers are padded to a multiple of 8
+// before encryption, incoming ones arrive already aligned, and the two
+// distributions are not the same shape.
+PacketSizeHistogram& outgoingPacketSizes();
+PacketSizeHistogram& incomingPacketSizes();
+
+// Logs both distributions. Call it from wherever a report is convenient; the
+// XTEA call sites also auto-report every REPORT_INTERVAL packets so a plain
+// `./tfs` run under load produces data without any further wiring.
+void reportPacketSizes();
+
+inline constexpr uint64_t REPORT_INTERVAL = 100000;
+
+} // namespace tfs::diagnostics
+
+#define TFS_RECORD_OUTGOING_PACKET_SIZE(length)                                        \
+	do {                                                                               \
+		auto& histogram = ::tfs::diagnostics::outgoingPacketSizes();                   \
+		histogram.record(length);                                                      \
+		if (histogram.count() % ::tfs::diagnostics::REPORT_INTERVAL == 0) {             \
+			::tfs::diagnostics::reportPacketSizes();                                   \
+		}                                                                              \
+	} while (false)
+
+#define TFS_RECORD_INCOMING_PACKET_SIZE(length) ::tfs::diagnostics::incomingPacketSizes().record(length)
+
+#else
+
+#define TFS_RECORD_OUTGOING_PACKET_SIZE(length) ((void)0)
+#define TFS_RECORD_INCOMING_PACKET_SIZE(length) ((void)0)
+
+#endif // TFS_PACKET_SIZE_HISTOGRAM
+
+#endif // FS_PACKET_SIZE_HISTOGRAM_H

--- a/src/packet_size_histogram.h
+++ b/src/packet_size_histogram.h
@@ -40,18 +40,19 @@ public:
 	// Called from the IO threads, so the counters are atomic. Relaxed ordering
 	// is enough: nothing else is published through them and the totals are only
 	// read for reporting.
-	void record(size_t length) noexcept
+	uint64_t record(size_t length) noexcept
 	{
-		total.fetch_add(1, std::memory_order_relaxed);
+		const uint64_t count = total.fetch_add(1, std::memory_order_relaxed) + 1;
 		totalBytes.fetch_add(length, std::memory_order_relaxed);
 
 		for (size_t i = 0; i < PACKET_SIZE_BUCKETS.size(); ++i) {
 			if (length <= PACKET_SIZE_BUCKETS[i]) {
 				buckets[i].fetch_add(1, std::memory_order_relaxed);
-				return;
+				return count;
 			}
 		}
 		overflow.fetch_add(1, std::memory_order_relaxed);
+		return count;
 	}
 
 	// Renders the distribution as a single multi-line string. Kept out of the
@@ -85,8 +86,8 @@ inline constexpr uint64_t REPORT_INTERVAL = 100000;
 #define TFS_RECORD_OUTGOING_PACKET_SIZE(length)                                        \
 	do {                                                                               \
 		auto& histogram = ::tfs::diagnostics::outgoingPacketSizes();                   \
-		histogram.record(length);                                                      \
-		if (histogram.count() % ::tfs::diagnostics::REPORT_INTERVAL == 0) {             \
+		const uint64_t count = histogram.record(length);                               \
+		if (count % ::tfs::diagnostics::REPORT_INTERVAL == 0) {                        \
 			::tfs::diagnostics::reportPacketSizes();                                   \
 		}                                                                              \
 	} while (false)

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -6,6 +6,7 @@
 #include "protocol.h"
 
 #include "outputmessage.h"
+#include "packet_size_histogram.h"
 #include "rsa.h"
 #include "tasks.h"
 #include "xtea.h"
@@ -21,6 +22,8 @@ void XTEA_encrypt(OutputMessage& msg, const xtea::round_keys& key)
 	}
 
 	uint8_t* buffer = msg.getOutputBuffer();
+	// Compiles to nothing unless -DENABLE_PACKET_SIZE_HISTOGRAM=ON.
+	TFS_RECORD_OUTGOING_PACKET_SIZE(msg.getLength());
 	xtea::encrypt(buffer, msg.getLength(), key);
 }
 
@@ -31,6 +34,7 @@ bool XTEA_decrypt(NetworkMessage& msg, const xtea::round_keys& key)
 	}
 
 	uint8_t* buffer = msg.getBuffer() + msg.getBufferPosition();
+	TFS_RECORD_INCOMING_PACKET_SIZE(msg.getLength() - 6);
 	xtea::decrypt(buffer, msg.getLength() - 6, key);
 
 	uint16_t innerLength = msg.get<uint16_t>();


### PR DESCRIPTION
Branch 0 of the performance plan. No behaviour change: the only edit to a hot path is two macros that expand to nothing unless a new CMake option is on.

benchmarks/perf_baseline compiles src/xtea.cpp itself rather than a copy, so it cannot drift from the shipped implementation, and refuses to report timings unless all four implementations produce identical ciphertext and decrypt round-trips. Measured on an i5-10300H (AVX2, no AVX512) with GCC 13.3 at the real Release flags, the winner turns out to depend on packet size: BlackTek's AVX2 kernel wins 1.79x at 32 bytes, 2.42x at 64 and 1.69x at 128, then ties or loses from 256 upwards, where the current loop wins at 256 and 1024. The 20% gate is therefore met only between 32 and 128 bytes, and the SIMD XTEA branch stays undecided until the real packet size distribution is known.

Two things the plan got wrong, both found by measuring:

The vectorisation check it prescribes reports nothing here, and that is a false negative. The project builds with -flto=auto -fno-fat-lto-objects, so the object file holds GIMPLE bytecode and zero instructions - codegen happens at link time, and -fvisibility=hidden plus LTO inlining means xtea::encrypt is not even a symbol in the final binary. Compiling the same loop in an isolated TU does report "loop vectorized using 32 byte vectors", so the conclusion stands but the method does not.

BlackTek's scalar path is worse than the plan's 1.75x estimate: 2.9x slower at 64 bytes and 7.2x at 16KB. Since its detect() falls through to Level::Scalar on GCC and Clang, that is the column a straight port would ship on Linux.

Adler32 reproduces: zlib is 1.36-1.43x faster above 64 bytes, slower below 32, and byte-identical everywhere including the > MAXSIZE guard. It is already a required dependency, so a port adds no packaging cost - but protocolgame.cpp :1317 checksums a fixed 8 bytes, exactly where zlib loses, so branch 1 cannot swap it blindly.

src/packet_size_histogram.{h,cpp} measures the distribution that decides all of this. Verified both ways: with ENABLE_PACKET_SIZE_HISTOGRAM=ON the strings are in the binary, with it off they are not, and both configurations build clean.

perf record under real load is not in here. It needs a server with MySQL and players, which this machine does not have, so the plan's central question - whether XTEA and Adler32 together are under 3% of CPU - is still open. The instrumentation is what answers it.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional packet-size histogram diagnostics for incoming and outgoing traffic, including size distributions, averages, totals, and periodic reports.
  * Added performance benchmarks for XTEA encryption and Adler-32 checksums, with validation and comparative timing results.

* **Documentation**
  * Added setup, execution, configuration, and interpretation guidance for performance baselines.
  * Added a performance report covering benchmark results, hardware considerations, and measurement limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->