### PR TITLE
fix(protocol): send Astra regeneration time

### DIFF
--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -109,6 +109,7 @@ function Player.feed(self, food)
 
 		self:addCondition(foodCondition)
 	end
+	self:sendStats()
 	return true
 end
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -5323,6 +5323,9 @@ void Player::onEndCondition(ConditionType_t type)
 	}
 
 	sendIcons();
+	if (type == CONDITION_REGENERATION) {
+		sendStats();
+	}
 }
 
 void Player::onCombatRemoveCondition(Condition* condition)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4964,6 +4964,16 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bo
 	msg.addByte(player->canWalkthroughEx(creature) ? 0x00 : 0x01);
 }
 
+uint16_t ProtocolGame::getRegenerationTimeSeconds(int32_t ticks)
+{
+	if (ticks < 0) {
+		return (std::numeric_limits<uint16_t>::max)();
+	}
+
+	return static_cast<uint16_t>(std::min<uint32_t>(static_cast<uint32_t>(ticks) / 1000,
+	                                                (std::numeric_limits<uint16_t>::max)()));
+}
+
 void ProtocolGame::AddPlayerStats(NetworkMessage& msg)
 {
 	msg.addByte(0xA0);
@@ -5014,6 +5024,10 @@ void ProtocolGame::AddPlayerStats(NetworkMessage& msg)
 
 	if (isOTC) {
 		msg.add<uint16_t>(player->getBaseSpeed() / 2);
+		if (isAstraClient) {
+			const Condition* condition = player->getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT);
+			msg.add<uint16_t>(getRegenerationTimeSeconds(condition ? condition->getTicks() : 0));
+		}
 		msg.add<uint16_t>(player->getOfflineTrainingTime() / 60 / 1000);
 		if (isAstraClient) {
 			msg.add<uint16_t>(player->getXpBoostTime());
@@ -5352,6 +5366,7 @@ void ProtocolGame::sendFeatures(bool advertiseAstraItemState)
 	features[GameFeature::ContainerPagination] = true;
 	features[GameFeature::BrowseField] = true;
 	if (isAstraClient) {
+		features[GameFeature::PlayerRegenerationTime] = true;
 		features[GameFeature::ExperienceBonus] = true;
 		features[GameFeature::PlayerFamiliars] = true;
 		features[GameFeature::AstraCreatureIcons] = true;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -26,6 +26,7 @@ class Tile;
 class Connection;
 class ProtocolGame;
 struct ProtocolGameCustomPingTestAccess;
+struct ProtocolGameAstraRegenerationTestAccess;
 using ProtocolGame_ptr = std::shared_ptr<ProtocolGame>;
 class ProtocolSpectator;
 
@@ -299,6 +300,7 @@ private:
 
 	void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove);
 	void AddPlayerStats(NetworkMessage& msg);
+	static uint16_t getRegenerationTimeSeconds(int32_t ticks);
 	void AddOutfit(NetworkMessage& msg, const Outfit_t& outfit);
 	void AddPlayerSkills(NetworkMessage& msg);
 	void AddWorldLight(NetworkMessage& msg, LightInfo lightInfo);
@@ -354,6 +356,7 @@ private:
 	friend class ProtocolSpectator;
 	friend class SpySystem;
 	friend struct ProtocolGameCustomPingTestAccess;
+	friend struct ProtocolGameAstraRegenerationTestAccess;
 
 	//cast
 	void spectatorTurn(uint8_t direction);

--- a/src/tests/test_astra_regeneration_time.cpp
+++ b/src/tests/test_astra_regeneration_time.cpp
@@ -1,0 +1,29 @@
+// Copyright 2023 The Forgotten Server Authors. All rights reserved.
+// Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
+
+#include "../otpch.h"
+
+#include "../protocolgame.h"
+
+#include "test_support.h"
+
+struct ProtocolGameAstraRegenerationTestAccess
+{
+	static uint16_t seconds(int32_t ticks) { return ProtocolGame::getRegenerationTimeSeconds(ticks); }
+};
+
+TEST_CASE(astra_regeneration_time_converts_food_ticks_to_seconds)
+{
+	CHECK(ProtocolGameAstraRegenerationTestAccess::seconds(0) == 0);
+	CHECK(ProtocolGameAstraRegenerationTestAccess::seconds(999) == 0);
+	CHECK(ProtocolGameAstraRegenerationTestAccess::seconds(123'000) == 123);
+}
+
+TEST_CASE(astra_regeneration_time_handles_infinite_and_wire_limit)
+{
+	CHECK(ProtocolGameAstraRegenerationTestAccess::seconds(-1) == (std::numeric_limits<uint16_t>::max)());
+	CHECK(ProtocolGameAstraRegenerationTestAccess::seconds(70'000'000) ==
+	      (std::numeric_limits<uint16_t>::max)());
+}
+
+TFS_TEST_MAIN()

--- a/tools/check-protocolgame-handshake.cmake
+++ b/tools/check-protocolgame-handshake.cmake
@@ -27,6 +27,8 @@ extract_block("void ProtocolGame::login" "void ProtocolGame::finishLogin" login_
 extract_block("void ProtocolGame::finishLogin" "void ProtocolGame::spectate" finish_login_block)
 extract_block("void ProtocolGame::connect" "void ProtocolGame::logout" connect_block)
 extract_block("void ProtocolGame::onRecvFirstMessage" "void ProtocolGame::onConnect" first_message_block)
+extract_block("void ProtocolGame::AddPlayerStats" "void ProtocolGame::AddPlayerSkills" stats_block)
+extract_block("void ProtocolGame::sendFeatures" "void ProtocolGame::spectatorTurn" features_block)
 
 require_occurrences("${login_block}" "sendFeatures\\(isAstraClient\\)" 1 "login feature negotiation")
 require_occurrences("${login_block}" "opcodeMessage\\.addByte\\(0x32\\)" 1 "login extended-opcode negotiation")
@@ -36,6 +38,8 @@ require_occurrences("${finish_login_block}" "sendFeatures\\(" 0 "finishLogin dup
 require_occurrences("${finish_login_block}" "opcodeMessage\\.addByte\\(0x32\\)" 0 "finishLogin duplicate extended-opcode negotiation")
 require_occurrences("${first_message_block}" "sendFeatures\\(" 0 "first-message duplicate feature negotiation")
 require_occurrences("${first_message_block}" "opcodeMessage\\.addByte\\(0x32\\)" 0 "first-message duplicate extended-opcode negotiation")
+require_occurrences("${features_block}" "GameFeature::PlayerRegenerationTime" 1 "Astra regeneration feature negotiation")
+require_occurrences("${stats_block}" "getRegenerationTimeSeconds\\(condition \\? condition->getTicks\\(\\) : 0\\)" 1 "Astra regeneration stats field")
 
 string(FIND "${login_block}" "sendFeatures(isAstraClient);" features_position)
 string(FIND "${login_block}" "connect(foundPlayer->getID(), operatingSystem);" reconnect_position)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player statistics now include the remaining regeneration duration.
  * Regeneration timing is reported in seconds, including support for indefinite regeneration.
  * The regeneration-time capability is now advertised to compatible clients.

* **Bug Fixes**
  * Player statistics now refresh correctly when regeneration starts or ends.

* **Tests**
  * Added coverage for regeneration timing conversion, limits, and special cases.
  * Enhanced protocol handshake validation for regeneration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->