### PR TITLE
refactor: migrate item and house lifetime APIs to smart pointers

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -424,7 +424,8 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, const 
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto tile = item->getTile()) {
 			if (const auto houseTile = tile->getHouseTile()) {
-				if (!item->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
+				auto house = houseTile->getHouse();
+				if (!item->getTopParent()->getCreature() && (!house || !house->isInvited(player))) {
 					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 					return false;
 				}

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -243,7 +243,7 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 		}
 	}
 
-	if (BedItem* bed = item->getBed()) {
+	if (auto bed = item->getBed()) {
 		if (!bed->canUse(player)) {
 			if (!bed->getHouse()) {
 				return RETURNVALUE_YOUCANNOTUSETHISBED;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -203,7 +203,7 @@ Action* Actions::getAction(const Position& pos)
 ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_t index,
                                      const std::shared_ptr<Item>& item, bool isHotkey)
 {
-	if (Door* door = item->getDoor()) {
+	if (auto door = item->getDoor()) {
 		if (!door->canUse(player)) {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -10,6 +10,7 @@
 #include "iologindata.h"
 #include "save_manager.h"
 #include "scheduler.h"
+#include "tasks.h"
 
 using namespace std::chrono;
 
@@ -34,10 +35,6 @@ void BedItem::setHouse(const std::shared_ptr<House>& h) noexcept
 void BedItem::onRemoved()
 {
 	Item::onRemoved();
-
-	if (auto h = getHouse()) {
-		h->removeBed(this);
-	}
 	setHouse(nullptr);
 }
 
@@ -189,14 +186,17 @@ bool BedItem::sleep(Player* player)
 	return true;
 }
 
-void BedItem::wakeUp(Player* player)
+bool BedItem::wakeUp(Player* player)
 {
 	if (sleeperGUID != 0) {
 		if (!player) {
 			Player regenPlayer(nullptr);
-			if (loadOfflineSleeper(&regenPlayer, sleeperGUID)) {
-				regeneratePlayer(&regenPlayer);
-				saveOfflineSleeper(&regenPlayer);
+			if (!loadOfflineSleeper(&regenPlayer, sleeperGUID)) {
+				return false;
+			}
+			regeneratePlayer(&regenPlayer);
+			if (!saveOfflineSleeper(&regenPlayer)) {
+				return false;
 			}
 		} else {
 			regeneratePlayer(player);
@@ -222,10 +222,18 @@ void BedItem::wakeUp(Player* player)
 	if (nextBedItem) {
 		nextBedItem->updateAppearance(nullptr);
 	}
+	return true;
 }
 
 bool BedItem::loadOfflineSleeper(Player* player, uint32_t guid) const
 {
+	// On the dispatcher, the pending-flush state cannot change between this
+	// check and saveOfflineSleeper(). Otherwise savePlayerSync can enqueue a
+	// save yet return false, making a retry apply the same regeneration twice.
+	if (!g_dispatcher.isDispatcherThread() || g_saveManager.hasPendingPlayerSave(guid) ||
+	    g_saveManager.hasFailedRecovery(guid)) {
+		return false;
+	}
 	return IOLoginData::loadPlayerById(player, guid);
 }
 

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -191,10 +191,6 @@ bool BedItem::sleep(Player* player)
 
 void BedItem::wakeUp(Player* player)
 {
-	if (house.expired()) {
-		return;
-	}
-
 	if (sleeperGUID != 0) {
 		if (!player) {
 			Player regenPlayer(nullptr);

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -23,6 +23,11 @@ BedItem::BedItem(uint16_t id) : Item(id) { internalRemoveSleeper(); }
 
 void BedItem::setHouse(const std::shared_ptr<House>& h) noexcept
 {
+	if (auto current = house.lock()) {
+		if (current != h) {
+			current->removeBed(this);
+		}
+	}
 	house = h;
 }
 

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -88,17 +88,7 @@ std::shared_ptr<BedItem> BedItem::getNextBedItem() const
 	if (!tile) {
 		return nullptr;
 	}
-
-	BedItem* nextBed = tile->getBedItem();
-	if (!nextBed) {
-		return nullptr;
-	}
-
-	auto itemRef = nextBed->weak_from_this().lock();
-	if (!itemRef) {
-		return nullptr;
-	}
-	return std::static_pointer_cast<BedItem>(itemRef);
+	return tile->getBedItem();
 }
 
 bool BedItem::canUse(Player* player)

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -21,13 +21,9 @@ static constexpr uint32_t SOUL_REGEN_INTERVAL_SECONDS = 60 * 15;
 
 BedItem::BedItem(uint16_t id) : Item(id) { internalRemoveSleeper(); }
 
-void BedItem::setHouse(House* h) noexcept
+void BedItem::setHouse(const std::shared_ptr<House>& h) noexcept
 {
-	if (h) {
-		house = h->weak_from_this().lock();
-	} else {
-		house.reset();
-	}
+	house = h;
 }
 
 Attr_ReadValue BedItem::readAttr(AttrTypes_t attr, PropStream& propStream)

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -93,7 +93,12 @@ BedItem* BedItem::getNextBedItem() const
 
 bool BedItem::canUse(Player* player)
 {
-	if (!player || house.expired() || !player->isPremium() || player->getZone() != ZONE_PROTECTION) {
+	if (!player || !player->isPremium() || player->getZone() != ZONE_PROTECTION) {
+		return false;
+	}
+
+	auto h = getHouse();
+	if (!h) {
 		return false;
 	}
 
@@ -101,7 +106,7 @@ bool BedItem::canUse(Player* player)
 		return true;
 	}
 
-	if (getHouse()->getHouseAccessLevel(player) == HOUSE_OWNER) {
+	if (h->getHouseAccessLevel(player) == HOUSE_OWNER) {
 		return true;
 	}
 
@@ -110,18 +115,23 @@ bool BedItem::canUse(Player* player)
 		return false;
 	}
 
-	return getHouse()->getHouseAccessLevel(&sleeper) <= getHouse()->getHouseAccessLevel(player);
+	return h->getHouseAccessLevel(&sleeper) <= h->getHouseAccessLevel(player);
 }
 
 bool BedItem::trySleep(Player* player)
 {
-	if (house.expired() || player->isRemoved()) {
+	if (player->isRemoved()) {
+		return false;
+	}
+
+	auto h = getHouse();
+	if (!h) {
 		return false;
 	}
 
 	if (sleeperGUID != 0) {
 		const auto& itemType = Item::items[id];
-		if (itemType.transformToFree != 0 && getHouse()->getOwner() == player->getGUID()) {
+		if (itemType.transformToFree != 0 && h->getOwner() == player->getGUID()) {
 			wakeUp(nullptr);
 		}
 

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -26,6 +26,16 @@ void BedItem::setHouse(const std::shared_ptr<House>& h) noexcept
 	house = h;
 }
 
+void BedItem::onRemoved()
+{
+	Item::onRemoved();
+
+	if (auto h = getHouse()) {
+		h->removeBed(this);
+	}
+	setHouse(nullptr);
+}
+
 Attr_ReadValue BedItem::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	switch (attr) {

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -79,7 +79,7 @@ void BedItem::serializeAttr(PropWriteStream& propWriteStream) const
 	}
 }
 
-BedItem* BedItem::getNextBedItem() const
+std::shared_ptr<BedItem> BedItem::getNextBedItem() const
 {
 	const auto dir = Item::items[id].bedPartnerDir;
 	const auto targetPos = getNextPosition(dir, getPosition());
@@ -88,7 +88,17 @@ BedItem* BedItem::getNextBedItem() const
 	if (!tile) {
 		return nullptr;
 	}
-	return tile->getBedItem();
+
+	BedItem* nextBed = tile->getBedItem();
+	if (!nextBed) {
+		return nullptr;
+	}
+
+	auto itemRef = nextBed->weak_from_this().lock();
+	if (!itemRef) {
+		return nullptr;
+	}
+	return std::static_pointer_cast<BedItem>(itemRef);
 }
 
 bool BedItem::canUse(Player* player)
@@ -147,7 +157,7 @@ bool BedItem::sleep(Player* player)
 		return false;
 	}
 
-	auto* nextBedItem = getNextBedItem();
+	auto nextBedItem = getNextBedItem();
 
 	internalSetSleeper(player);
 
@@ -200,7 +210,7 @@ void BedItem::wakeUp(Player* player)
 	// update the bedSleepersMap
 	g_game.removeBedSleeper(sleeperGUID);
 
-	auto* nextBedItem = getNextBedItem();
+	auto nextBedItem = getNextBedItem();
 
 	// unset sleep info
 	internalRemoveSleeper();

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -194,9 +194,9 @@ void BedItem::wakeUp(Player* player)
 	if (sleeperGUID != 0) {
 		if (!player) {
 			Player regenPlayer(nullptr);
-			if (IOLoginData::loadPlayerById(&regenPlayer, sleeperGUID)) {
+			if (loadOfflineSleeper(&regenPlayer, sleeperGUID)) {
 				regeneratePlayer(&regenPlayer);
-				g_saveManager.savePlayerSync(&regenPlayer);
+				saveOfflineSleeper(&regenPlayer);
 			}
 		} else {
 			regeneratePlayer(player);
@@ -222,6 +222,16 @@ void BedItem::wakeUp(Player* player)
 	if (nextBedItem) {
 		nextBedItem->updateAppearance(nullptr);
 	}
+}
+
+bool BedItem::loadOfflineSleeper(Player* player, uint32_t guid) const
+{
+	return IOLoginData::loadPlayerById(player, guid);
+}
+
+bool BedItem::saveOfflineSleeper(Player* player) const
+{
+	return g_saveManager.savePlayerSync(player);
 }
 
 void BedItem::regeneratePlayer(Player* player) const

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -12,6 +12,8 @@
 #include "scheduler.h"
 #include "tasks.h"
 
+#include <unordered_set>
+
 using namespace std::chrono;
 
 extern Game g_game;
@@ -194,12 +196,12 @@ bool BedItem::wakeUp(Player* player)
 			if (!loadOfflineSleeper(&regenPlayer, sleeperGUID)) {
 				return false;
 			}
-			regeneratePlayer(&regenPlayer);
-			if (!saveOfflineSleeper(&regenPlayer)) {
+			regeneratePlayer(&regenPlayer, sleepStart);
+			if (!saveOfflineSleepers({&regenPlayer})) {
 				return false;
 			}
 		} else {
-			regeneratePlayer(player);
+			regeneratePlayer(player, sleepStart);
 			g_game.addCreatureHealth(player);
 		}
 	}
@@ -225,11 +227,87 @@ bool BedItem::wakeUp(Player* player)
 	return true;
 }
 
+bool BedItem::wakeUpAll(const std::vector<std::shared_ptr<BedItem>>& beds)
+{
+	struct WakeSession {
+		std::shared_ptr<Player> player;
+		uint32_t guid;
+		uint64_t sleepStart;
+		bool offline;
+	};
+	std::vector<WakeSession> sessions;
+	std::vector<std::pair<std::shared_ptr<BedItem>, uint32_t>> bedsToClear;
+	std::unordered_set<uint32_t> sleeperGuids;
+	std::unordered_set<BedItem*> seenBeds;
+	std::vector<Player*> offlinePlayers;
+	std::shared_ptr<BedItem> offlineWriter;
+	auto collectBed = [&](const std::shared_ptr<BedItem>& bed, uint32_t guid) {
+		if (bed && bed->getSleeper() == guid && seenBeds.insert(bed.get()).second) {
+			bedsToClear.emplace_back(bed, guid);
+		}
+	};
+
+	// Preparing temporary offline players must not change a live player, bed,
+	// registry entry or appearance. Either all loads succeed, or nothing wakes.
+	for (const auto& bed : beds) {
+		if (!bed || bed->isRemoved() || bed->getSleeper() == 0) {
+			continue;
+		}
+		const uint32_t guid = bed->getSleeper();
+		collectBed(bed, guid);
+		collectBed(bed->getNextBedItem(), guid);
+		if (!sleeperGuids.insert(guid).second) {
+			continue;
+		}
+		auto player = g_game.getPlayerByGUID(guid);
+		const bool offline = !player;
+		if (offline) {
+			player = std::make_shared<Player>(nullptr);
+			if (!bed->loadOfflineSleeper(player.get(), guid)) {
+				return false;
+			}
+			regeneratePlayer(player.get(), bed->sleepStart);
+			offlinePlayers.push_back(player.get());
+			if (!offlineWriter) {
+				offlineWriter = bed;
+			}
+		}
+		sessions.push_back({std::move(player), guid, bed->sleepStart, offline});
+	}
+	if (offlineWriter && !offlineWriter->saveOfflineSleepers(offlinePlayers)) {
+		return false;
+	}
+
+	// The batch is committed. Clear every session before any live-player or
+	// appearance notification can reenter map removal or wake another bed.
+	for (const auto& session : sessions) {
+		g_game.removeBedSleeper(session.guid);
+	}
+	for (const auto& [bed, guid] : bedsToClear) {
+		if (bed->getSleeper() == guid) {
+			bed->internalRemoveSleeper();
+		}
+	}
+	for (const auto& session : sessions) {
+		if (!session.offline) {
+			regeneratePlayer(session.player.get(), session.sleepStart);
+			g_game.addCreatureHealth(session.player.get());
+		}
+	}
+	for (const auto& entry : bedsToClear) {
+		const auto& bed = entry.first;
+		if (!bed->isRemoved() && bed->getSleeper() == 0) {
+			bed->updateAppearance(nullptr);
+		}
+	}
+	return true;
+}
+
 bool BedItem::loadOfflineSleeper(Player* player, uint32_t guid) const
 {
 	// On the dispatcher, the pending-flush state cannot change between this
-	// check and saveOfflineSleeper(). Otherwise savePlayerSync can enqueue a
-	// save yet return false, making a retry apply the same regeneration twice.
+	// check and saveOfflineSleepers(). Do not load stale state while an older
+	// save is still in flight; the batch save also rejects pending flushes.
 	if (!g_dispatcher.isDispatcherThread() || g_saveManager.hasPendingPlayerSave(guid) ||
 	    g_saveManager.hasFailedRecovery(guid)) {
 		return false;
@@ -237,12 +315,12 @@ bool BedItem::loadOfflineSleeper(Player* player, uint32_t guid) const
 	return IOLoginData::loadPlayerById(player, guid);
 }
 
-bool BedItem::saveOfflineSleeper(Player* player) const
+bool BedItem::saveOfflineSleepers(const std::vector<Player*>& players) const
 {
-	return g_saveManager.savePlayerSync(player);
+	return g_saveManager.savePlayersSync(players);
 }
 
-void BedItem::regeneratePlayer(Player* player) const
+void BedItem::regeneratePlayer(Player* player, uint64_t sleepStart)
 {
 	const auto now = system_clock::now();
 	const auto currentTime = static_cast<uint64_t>(

--- a/src/bed.h
+++ b/src/bed.h
@@ -27,7 +27,7 @@ public:
 	[[nodiscard]] uint32_t getSleeper() const noexcept { return sleeperGUID; }
 
 	[[nodiscard]] std::shared_ptr<House> getHouse() const noexcept { return house.lock(); }
-	void setHouse(House* h) noexcept;
+	void setHouse(const std::shared_ptr<House>& h) noexcept;
 
 	[[nodiscard]] bool canUse(Player* player);
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -16,8 +16,14 @@ class BedItem final : public Item
 public:
 	explicit BedItem(uint16_t id);
 
-	[[nodiscard]] BedItem* getBed() override { return this; }
-	[[nodiscard]] const BedItem* getBed() const override { return this; }
+	[[nodiscard]] std::shared_ptr<BedItem> getBed() override
+	{
+		return std::static_pointer_cast<BedItem>(weak_from_this().lock());
+	}
+	[[nodiscard]] std::shared_ptr<const BedItem> getBed() const override
+	{
+		return std::static_pointer_cast<const BedItem>(weak_from_this().lock());
+	}
 
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 	void serializeAttr(PropWriteStream& propWriteStream) const override;

--- a/src/bed.h
+++ b/src/bed.h
@@ -11,7 +11,7 @@
 class House;
 class Player;
 
-class BedItem final : public Item
+class BedItem : public Item
 {
 public:
 	explicit BedItem(uint16_t id);
@@ -43,6 +43,10 @@ public:
 	void wakeUp(Player* player);
 
 	[[nodiscard]] std::shared_ptr<BedItem> getNextBedItem() const;
+
+protected:
+	virtual bool loadOfflineSleeper(Player* player, uint32_t guid) const;
+	virtual bool saveOfflineSleeper(Player* player) const;
 
 private:
 	void updateAppearance(const Player* player);

--- a/src/bed.h
+++ b/src/bed.h
@@ -35,7 +35,7 @@ public:
 	bool sleep(Player* player);
 	void wakeUp(Player* player);
 
-	[[nodiscard]] BedItem* getNextBedItem() const;
+	[[nodiscard]] std::shared_ptr<BedItem> getNextBedItem() const;
 
 private:
 	void updateAppearance(const Player* player);

--- a/src/bed.h
+++ b/src/bed.h
@@ -40,7 +40,8 @@ public:
 
 	bool trySleep(Player* player);
 	bool sleep(Player* player);
-	void wakeUp(Player* player);
+	// A failed offline load/save leaves the sleep session intact for retry.
+	bool wakeUp(Player* player);
 
 	[[nodiscard]] std::shared_ptr<BedItem> getNextBedItem() const;
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -29,6 +29,7 @@ public:
 	void serializeAttr(PropWriteStream& propWriteStream) const override;
 
 	[[nodiscard]] bool canRemove() const override { return house.expired(); }
+	void onRemoved() override;
 
 	[[nodiscard]] uint32_t getSleeper() const noexcept { return sleeperGUID; }
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -26,7 +26,7 @@ public:
 
 	[[nodiscard]] uint32_t getSleeper() const noexcept { return sleeperGUID; }
 
-	[[nodiscard]] House* getHouse() const noexcept { return house.lock().get(); }
+	[[nodiscard]] std::shared_ptr<House> getHouse() const noexcept { return house.lock(); }
 	void setHouse(House* h) noexcept;
 
 	[[nodiscard]] bool canUse(Player* player);

--- a/src/bed.h
+++ b/src/bed.h
@@ -7,6 +7,7 @@
 #include "item.h"
 
 #include <memory>
+#include <vector>
 
 class House;
 class Player;
@@ -42,16 +43,19 @@ public:
 	bool sleep(Player* player);
 	// A failed offline load/save leaves the sleep session intact for retry.
 	bool wakeUp(Player* player);
+	// Persist every offline sleeper before clearing any of the sleep sessions.
+	static bool wakeUpAll(const std::vector<std::shared_ptr<BedItem>>& beds);
 
 	[[nodiscard]] std::shared_ptr<BedItem> getNextBedItem() const;
 
 protected:
 	virtual bool loadOfflineSleeper(Player* player, uint32_t guid) const;
-	virtual bool saveOfflineSleeper(Player* player) const;
+	// Must persist the whole batch atomically, with no deferred writes on failure.
+	virtual bool saveOfflineSleepers(const std::vector<Player*>& players) const;
 
 private:
 	void updateAppearance(const Player* player);
-	void regeneratePlayer(Player* player) const;
+	static void regeneratePlayer(Player* player, uint64_t sleepStart);
 	void internalSetSleeper(const Player* player);
 	void internalRemoveSleeper() noexcept;
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -494,12 +494,14 @@ ReturnValue Container::queryAdd(int32_t index, const Thing& thing, uint32_t coun
 	if (const auto tile = topParent->getTile()) {
 		if (const auto houseTile = tile->getHouseTile()) {
 			const auto house = houseTile->getHouse();
-			if (house && house->getProtected() && actor && !topParent->getCreature() && !house->canModifyItems(actor->getPlayer())) {
-				return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
-		}
-		if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-			if (!topParent->getCreature() && !house->isInvited(actor->getPlayer())) {
-				return RETURNVALUE_PLAYERISNOTINVITED;
+			if (house) {
+				if (house->getProtected() && actor && !topParent->getCreature() && !house->canModifyItems(actor->getPlayer())) {
+					return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
+				}
+				if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+					if (!topParent->getCreature() && !house->isInvited(actor->getPlayer())) {
+						return RETURNVALUE_PLAYERISNOTINVITED;
+					}
 				}
 			}
 		}
@@ -590,12 +592,14 @@ ReturnValue Container::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 	if (const auto tile = topParent->getTile()) {
 		if (const auto houseTile = tile->getHouseTile()) {
 			const auto house = houseTile->getHouse();
-			if (house && house->getProtected() && actor && !topParent->getCreature() && !house->canModifyItems(actor->getPlayer())) {
-				return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
-		}
-		if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-			if (!topParent->getCreature() && !house->isInvited(actor->getPlayer())) {
-				return RETURNVALUE_PLAYERISNOTINVITED;
+			if (house) {
+				if (house->getProtected() && actor && !topParent->getCreature() && !house->canModifyItems(actor->getPlayer())) {
+					return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
+				}
+				if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+					if (!topParent->getCreature() && !house->isInvited(actor->getPlayer())) {
+						return RETURNVALUE_PLAYERISNOTINVITED;
+					}
 				}
 			}
 		}

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -271,7 +271,7 @@ bool Container::canMergeIntoExistingStack(const Item* item, int32_t index) const
 		return false;
 	}
 
-	return canStackWith(getItemByIndex(index));
+	return canStackWith(getItemByIndex(index).get());
 }
 
 bool Container::hasRoomForItem(const Item* item, int32_t index, uint32_t count) const
@@ -305,12 +305,7 @@ uint64_t Container::getWeightReductionContentWeight() const
 	return weight;
 }
 
-Item* Container::getItemByIndex(size_t index) const
-{
-	return getItemByIndexRef(index).get();
-}
-
-std::shared_ptr<Item> Container::getItemByIndexRef(size_t index) const
+std::shared_ptr<Item> Container::getItemByIndex(size_t index) const
 {
 	if (index >= size()) {
 		return nullptr;
@@ -330,7 +325,7 @@ uint32_t Container::getItemHoldingCount() const
 bool Container::isHoldingItem(const Item* item) const
 {
 	for (ContainerIterator it = iterator(); it.hasNext(); it.advance()) {
-		if (*it == item) {
+		if ((*it).get() == item) {
 			return true;
 		}
 	}
@@ -548,7 +543,7 @@ ReturnValue Container::queryMaxCount(int32_t index, const Thing& thing, uint32_t
 				++slotIndex;
 			}
 		} else {
-			const auto destItemRef = getItemByIndexRef(index);
+			const auto destItemRef = getItemByIndex(index);
 			const Item* destItem = destItemRef.get();
 			if (item->equals(destItem) && destItem->getItemCount() < destItem->getStackSize()) {
 				if (queryAdd(index, *item, count, flags) == RETURNVALUE_NOERROR) {
@@ -644,7 +639,7 @@ Cylinder* Container::queryDestination(int32_t& index, const Thing& thing, Item**
 	}
 
 	if (index != INDEX_WHEREEVER) {
-		auto itemFromIndexRef = getItemByIndexRef(index);
+		auto itemFromIndexRef = getItemByIndex(index);
 		Item* itemFromIndex = itemFromIndexRef.get();
 		if (itemFromIndex) {
 			*destItem = itemFromIndex;
@@ -781,7 +776,7 @@ void Container::replaceThing(uint32_t index, Thing* thing)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	auto replacedItemRef = getItemByIndexRef(index);
+	auto replacedItemRef = getItemByIndex(index);
 	Item* replacedItem = replacedItemRef.get();
 	if (!replacedItem) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
@@ -897,7 +892,7 @@ ItemVector Container::getItems(bool recursive /*= false*/) const
 	return {itemlist.begin(), itemlist.end()};
 }
 
-Thing* Container::getThing(size_t index) const { return getItemByIndex(index); }
+Thing* Container::getThing(size_t index) const { return getItemByIndex(index).get(); }
 
 void Container::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
 {
@@ -1033,12 +1028,12 @@ bool Container::isRewardCorpse() const
 	return false;
 }
 
-Item* ContainerIterator::operator*() const
+std::shared_ptr<Item> ContainerIterator::operator*() const
 {
 	if (!hasNext()) {
 		return nullptr;
 	}
-	return items[index].get();
+	return items[index];
 }
 
 void ContainerIterator::advance()

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -494,6 +494,9 @@ ReturnValue Container::queryAdd(int32_t index, const Thing& thing, uint32_t coun
 	if (const auto tile = topParent->getTile()) {
 		if (const auto houseTile = tile->getHouseTile()) {
 			const auto house = houseTile->getHouse();
+			if (!house && actor && !topParent->getCreature()) {
+				return RETURNVALUE_NOTPOSSIBLE;
+			}
 			if (house) {
 				if (house->getProtected() && actor && !topParent->getCreature() && !house->canModifyItems(actor->getPlayer())) {
 					return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
@@ -592,6 +595,9 @@ ReturnValue Container::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 	if (const auto tile = topParent->getTile()) {
 		if (const auto houseTile = tile->getHouseTile()) {
 			const auto house = houseTile->getHouse();
+			if (!house && actor && !topParent->getCreature()) {
+				return RETURNVALUE_NOTPOSSIBLE;
+			}
 			if (house) {
 				if (house->getProtected() && actor && !topParent->getCreature() && !house->canModifyItems(actor->getPlayer())) {
 					return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;

--- a/src/container.h
+++ b/src/container.h
@@ -26,7 +26,7 @@ public:
 	bool hasNext() const { return index < items.size(); }
 
 	void advance();
-	Item* operator*() const;
+	std::shared_ptr<Item> operator*() const;
 
 private:
 	ItemVector items;
@@ -91,8 +91,7 @@ public:
 
 	bool addItem(const std::shared_ptr<Item>& item);
 	bool addItem(Item* item);
-	Item* getItemByIndex(size_t index) const;
-	std::shared_ptr<Item> getItemByIndexRef(size_t index) const;
+	std::shared_ptr<Item> getItemByIndex(size_t index) const;
 	bool isHoldingItem(const Item* item) const;
 	bool isRewardCorpse() const;
 

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -22,6 +22,7 @@ enum cylinderflags_t
 	FLAG_IGNOREFIELDDAMAGE = 1 << 5,   // Bypass field damage checks
 	FLAG_IGNORENOTMOVEABLE = 1 << 6,   // Bypass check for mobility
 	FLAG_IGNOREAUTOSTACK = 1 << 7,     // queryDestination will not try to stack items together
+	FLAG_IGNORECANREMOVE = 1 << 8,     // Internal cleanup only: bypass Item::canRemove()
 };
 
 enum cylinderlink_t

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2512,7 +2512,7 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 		return ret;
 	}
 
-	if (!item->canRemove()) {
+	if (!hasBitSet(FLAG_NOLIMIT, flags) && !item->canRemove()) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -408,7 +408,7 @@ ReturnValue moveQuickLootItem(Game& game, Player* player, const std::shared_ptr<
 		}
 
 		for (ContainerIterator it = current->iterator(); it.hasNext(); it.advance()) {
-			Item* child = *it;
+			auto child = *it;
 			if (Container* childContainer = child ? child->getContainer() : nullptr) {
 				if (ContainerPtr childRef = game.getContainerSharedRef(childContainer)) {
 					destinations.push_back(childRef);
@@ -457,15 +457,13 @@ QuickLootResult collectQuickLootContainer(Game& game, Player* player, const Cont
 
 	std::vector<std::shared_ptr<Item>> lootItems;
 	for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-		Item* item = *it;
-		if (!item || item->isRemoved() || !shouldQuickLootItem(player, item)) {
+		auto item = *it;
+		if (!item || item->isRemoved() || !shouldQuickLootItem(player, item.get())) {
 			continue;
 		}
 
-		if (std::shared_ptr<Item> itemRef = game.getItemSharedRef(item)) {
-			result.hadLoot = true;
-			lootItems.push_back(itemRef);
-		}
+		result.hadLoot = true;
+		lootItems.push_back(std::move(item));
 	}
 
 	for (const std::shared_ptr<Item>& itemRef : lootItems) {
@@ -871,7 +869,7 @@ Thing* Game::internalGetThing(Player* player, const Position& pos, int32_t index
 		}
 
 		uint8_t slot = pos.z;
-		return parentContainer->getItemByIndex(player->getContainerIndex(fromCid) + slot);
+		return parentContainer->getItemByIndex(player->getContainerIndex(fromCid) + slot).get();
 	} else if (pos.y == 0 && pos.z == 0) {
 		const ItemType& it = Item::items[static_cast<uint16_t>(spriteId)];
 		if (it.id == 0) {
@@ -2973,8 +2971,9 @@ Item* searchForItem(Container* container, uint16_t itemId, bool hasTier = false,
 	}
 
 	for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-		if ((*it)->getID() == itemId && (!hasTier || (*it)->getTier() == tier)) {
-			return *it;
+		auto item = *it;
+		if (item->getID() == itemId && (!hasTier || item->getTier() == tier)) {
+			return item.get();
 		}
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8598,7 +8598,7 @@ void Game::internalRemoveItems(std::vector<std::shared_ptr<Item>> itemList, uint
 	}
 }
 
-BedItem* Game::getBedBySleeper(uint32_t guid)
+std::shared_ptr<BedItem> Game::getBedBySleeper(uint32_t guid)
 {
 	auto it = bedSleepersMap.find(guid);
 	if (it == bedSleepersMap.end()) {
@@ -8610,7 +8610,7 @@ BedItem* Game::getBedBySleeper(uint32_t guid)
 		bedSleepersMap.erase(it);
 		return nullptr;
 	}
-	return bed.get();
+	return bed;
 }
 
 void Game::setBedSleeper(BedItem* bed, uint32_t guid)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8573,21 +8573,27 @@ void Game::addGuild(Guild_ptr guild)
 
 void Game::removeGuild(uint32_t guildId) { guilds.erase(guildId); }
 
-void Game::internalRemoveItems(std::vector<ObserverPtr<Item>> itemList, uint32_t amount, bool stackable)
+void Game::internalRemoveItems(std::vector<std::shared_ptr<Item>> itemList, uint32_t amount, bool stackable)
 {
 	if (stackable) {
-		for (Item* item : itemList) {
+		for (const auto& item : itemList) {
+			if (!item || item->isRemoved()) {
+				continue;
+			}
 			if (item->getItemCount() > amount) {
-				internalRemoveItem(item, amount);
+				internalRemoveItem(item.get(), amount);
 				break;
 			} else {
 				amount -= item->getItemCount();
-				internalRemoveItem(item);
+				internalRemoveItem(item.get());
 			}
 		}
 	} else {
-		for (Item* item : itemList) {
-			internalRemoveItem(item);
+		for (const auto& item : itemList) {
+			if (!item || item->isRemoved()) {
+				continue;
+			}
+			internalRemoveItem(item.get());
 		}
 	}
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2497,9 +2497,12 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	std::shared_ptr<Tile> browseFieldTile = getBrowseFieldTile(cylinder);
-	if (browseFieldTile) {
-		cylinder = browseFieldTile.get();
+	std::shared_ptr<Tile> cylinderTile = getBrowseFieldTile(cylinder);
+	if (cylinderTile) {
+		cylinder = cylinderTile.get();
+	} else if (auto* tile = dynamic_cast<Tile*>(cylinder)) {
+		// Bed transforms and removal notifications can remove the source tile.
+		cylinderTile = tile->weak_from_this().lock();
 	}
 
 	if (count == -1) {
@@ -2529,7 +2532,17 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 		// clear the partner bed and registry exactly once before destruction.
 		if (auto bed = item->getBed(); bed && bed->getSleeper() != 0) {
 			auto sleeper = getPlayerByGUID(bed->getSleeper());
-			bed->wakeUp(sleeper.get());
+			if (!bed->wakeUp(sleeper.get())) {
+				return RETURNVALUE_NOTPOSSIBLE;
+			}
+			if (item->isRemoved()) {
+				return RETURNVALUE_NOERROR;
+			}
+			// Appearance callbacks may move/remove the bed or reorder tile items.
+			index = cylinder->getThingIndex(item);
+			if (index == -1) {
+				return RETURNVALUE_NOTPOSSIBLE;
+			}
 		}
 
 		// remove the item

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2083,7 +2083,7 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		if (!actorPlayer->hasFlag(PlayerFlag_CanEditHouses)) {
 			if (Tile* fromTile = fromCylinder->getTile()) {
 				if (HouseTile* fromHouseTile = dynamic_cast<HouseTile*>(fromTile)) {
-					House* fromHouse = fromHouseTile->getHouse();
+					auto fromHouse = fromHouseTile->getHouse();
 					if (fromHouse && !fromHouse->canModifyItems(actorPlayer)) {
 						return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
 					}
@@ -2101,7 +2101,7 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 
 			if (Tile* toTile = toCylinder->getTile()) {
 				if (HouseTile* toHouseTile = dynamic_cast<HouseTile*>(toTile)) {
-					House* toHouse = toHouseTile->getHouse();
+					auto toHouse = toHouseTile->getHouse();
 					if (toHouse && !toHouse->canModifyItems(actorPlayer)) {
 						return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
 					}
@@ -4509,7 +4509,7 @@ void Game::playerWrapableItem(uint32_t playerId, const Position& pos, uint8_t st
 
 	Tile* tile = item->getTile();
 	HouseTile* houseTile = tile ? tile->getHouseTile() : nullptr;
-	House* house = houseTile ? houseTile->getHouse() : nullptr;
+	auto house = houseTile ? houseTile->getHouse() : nullptr;
 	if (!house) {
 		player->sendCancelMessage("You may construct this only inside a house.");
 		return;
@@ -4713,9 +4713,10 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto tile = tradeItem->getTile()) {
 			if (const auto houseTile = tile->getHouseTile()) {
-			if (!tradeItem->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
-				player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
-				return;
+				auto house = houseTile->getHouse();
+				if (!tradeItem->getTopParent()->getCreature() && (!house || !house->isInvited(player))) {
+					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
+					return;
 				}
 			}
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2524,6 +2524,14 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
+		// End an occupied bed session while the BedItem is still attached to its
+		// tile and House. This preserves sleeper regeneration and lets wakeUp()
+		// clear the partner bed and registry exactly once before destruction.
+		if (auto bed = item->getBed(); bed && bed->getSleeper() != 0) {
+			auto sleeper = getPlayerByGUID(bed->getSleeper());
+			bed->wakeUp(sleeper.get());
+		}
+
 		// remove the item
 		cylinder->removeThing(item, count);
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -468,7 +468,16 @@ QuickLootResult collectQuickLootContainer(Game& game, Player* player, const Cont
 
 	for (const std::shared_ptr<Item>& itemRef : lootItems) {
 		Item* item = itemRef.get();
-		if (!item || item->isRemoved()) {
+		if (!item || item->isRemoved() || container->isRemoved() || player->isRemoved()) {
+			continue;
+		}
+		const Cylinder* parent = item->getParent();
+		// A selected bag can be moved before its contents are routed to their
+		// own categories. Continue only inside the corpse or this player.
+		while (parent && parent != container && parent != player) {
+			parent = parent->getParent();
+		}
+		if (!parent) {
 			continue;
 		}
 
@@ -507,7 +516,7 @@ QuickLootResult collectQuickLootContainer(Game& game, Player* player, const Cont
 uint32_t collectQuickLootTile(Game& game, Player* player, const Position& pos, uint32_t maxCorpses,
                               bool& foundCorpse, ReturnValue& firstFailure)
 {
-	Tile* tile = game.map.getTile(pos);
+	const auto tile = game.getTileSharedRef(game.map.getTile(pos));
 	if (!tile) {
 		firstFailure = RETURNVALUE_NOTPOSSIBLE;
 		return 0;
@@ -519,9 +528,16 @@ uint32_t collectQuickLootTile(Game& game, Player* player, const Position& pos, u
 	}
 
 	uint32_t lootedCorpses = 0;
-	for (const auto& itemRef : *itemList) {
+	const std::vector<std::shared_ptr<Item>> snapshot(itemList->begin(), itemList->end());
+	for (const auto& itemRef : snapshot) {
 		if (lootedCorpses >= maxCorpses) {
 			break;
+		}
+		if (game.map.getTile(pos) != tile.get()) {
+			break;
+		}
+		if (!itemRef || itemRef->isRemoved() || tile->getThingIndex(itemRef.get()) == -1) {
+			continue;
 		}
 
 		Container* container = itemRef ? itemRef->getContainer() : nullptr;
@@ -2055,6 +2071,30 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
                                    Creature* actor /* = nullptr*/, Item* tradeItem /* = nullptr*/,
                                    const Position* fromPos /*= nullptr*/, const Position* toPos /*= nullptr*/)
 {
+	if (!fromCylinder || !toCylinder || !item) {
+		return RETURNVALUE_NOTPOSSIBLE;
+	}
+	const auto itemRef = getItemSharedRef(item);
+	if (!itemRef) {
+		return RETURNVALUE_NOTPOSSIBLE;
+	}
+	// Removal/equip callbacks may release either cylinder while the rest of
+	// this move still needs it. Stack-owned internal cylinders have no anchor.
+	auto retainCylinder = [](Cylinder* cylinder) -> std::shared_ptr<Thing> {
+		if (Item* owner = cylinder->getItem()) {
+			return owner->weak_from_this().lock();
+		}
+		if (Creature* owner = cylinder->getCreature()) {
+			return owner->weak_from_this().lock();
+		}
+		if (auto tile = dynamic_cast<Tile*>(cylinder)) {
+			return tile->weak_from_this().lock();
+		}
+		return nullptr;
+	};
+	const auto sourceRef = retainCylinder(fromCylinder);
+	const auto originalDestinationRef = retainCylinder(toCylinder);
+	const auto actorRef = actor ? actor->weak_from_this().lock() : nullptr;
 	std::shared_ptr<Tile> browseFieldTile = getBrowseFieldTile(fromCylinder);
 	if (browseFieldTile) {
 		fromCylinder = browseFieldTile.get();
@@ -2078,6 +2118,9 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		                                                        *fromPos, *toPos, fromCylinder, toCylinder);
 		if (ret != RETURNVALUE_NOERROR) {
 			return ret;
+		}
+		if (item->isRemoved() || fromCylinder->getThingIndex(item) == -1 || toCylinder->isRemoved()) {
+			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
 		if (!actorPlayer->hasFlag(PlayerFlag_CanEditHouses)) {
@@ -2128,6 +2171,8 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 			break;
 		}
 	}
+	const auto destinationRef = retainCylinder(toCylinder);
+	const auto destinationItemRef = getItemSharedRef(toItem);
 
 	if (actorPlayer) {
 		const ReturnValue storeInboxLockRet = getStoreInboxLockedItemMoveReturn(item);
@@ -2296,10 +2341,6 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 	int32_t itemIndex = fromCylinder->getThingIndex(item);
 	Item* updateItem = nullptr;
 	std::shared_ptr<Item> clonedMoveItem;
-	auto itemRef = getItemSharedRef(item);
-	if (!itemRef) {
-		return RETURNVALUE_NOTPOSSIBLE;
-	}
 	fromCylinder->removeThing(item, m);
 
 	// update item(s)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2512,7 +2512,7 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 		return ret;
 	}
 
-	if (!hasBitSet(FLAG_NOLIMIT, flags) && !item->canRemove()) {
+	if (!hasBitSet(FLAG_IGNORECANREMOVE, flags) && !item->canRemove()) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 

--- a/src/game.h
+++ b/src/game.h
@@ -593,7 +593,7 @@ public:
 
 	void internalRemoveItems(std::vector<std::shared_ptr<Item>> itemList, uint32_t amount, bool stackable);
 
-	[[nodiscard]] BedItem* getBedBySleeper(uint32_t guid);
+	[[nodiscard]] std::shared_ptr<BedItem> getBedBySleeper(uint32_t guid);
 	void setBedSleeper(BedItem* bed, uint32_t guid);
 	void removeBedSleeper(uint32_t guid);
 

--- a/src/game.h
+++ b/src/game.h
@@ -591,7 +591,7 @@ public:
 	void addGuild(Guild_ptr guild);
 	void removeGuild(uint32_t guildId);
 
-	void internalRemoveItems(std::vector<ObserverPtr<Item>> itemList, uint32_t amount, bool stackable);
+	void internalRemoveItems(std::vector<std::shared_ptr<Item>> itemList, uint32_t amount, bool stackable);
 
 	[[nodiscard]] BedItem* getBedBySleeper(uint32_t guid);
 	void setBedSleeper(BedItem* bed, uint32_t guid);

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -117,25 +117,57 @@ std::tuple<uint32_t, uint32_t, std::string, uint32_t, std::string> House::initia
 	throw std::runtime_error("Error in House::setOwner - Failed to find guild ID");
 }
 
-void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Player* previousPlayer /* = nullptr*/)
+bool House::updateOwnerInDatabase(uint32_t guid_guild, bool resetProtection)
 {
-	if (updateDatabase && owner != guid_guild) {
-		Database& db = Database::getInstance();
-	bool resetProtection = (guid_guild == 0 || owner == 0);
+	Database& db = Database::getInstance();
 	if (resetProtection) {
-            db.executeQuery(fmt::format(
-                "UPDATE `houses` SET `owner` = {:d}, `bid` = 0, `bid_end` = 0, `last_bid` = 0, `highest_bidder` = 0, `is_protected` = 0 WHERE `id` = {:d}",
-                guid_guild, id));
-        setProtected(false);
-	} else {
-			db.executeQuery(fmt::format(
-			    "UPDATE `houses` SET `owner` = {:d}, `bid` = 0, `bid_end` = 0, `last_bid` = 0, `highest_bidder` = 0 WHERE `id` = {:d}",
-			    guid_guild, id));
+		return db.executeQuery(fmt::format(
+		    "UPDATE `houses` SET `owner` = {:d}, `bid` = 0, `bid_end` = 0, `last_bid` = 0, `highest_bidder` = 0, `is_protected` = 0 WHERE `id` = {:d}",
+		    guid_guild, id));
+	}
+	return db.executeQuery(fmt::format(
+	    "UPDATE `houses` SET `owner` = {:d}, `bid` = 0, `bid_end` = 0, `last_bid` = 0, `highest_bidder` = 0 WHERE `id` = {:d}",
+	    guid_guild, id));
+}
+
+bool House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Player* previousPlayer /* = nullptr*/)
+{
+	if (ownerTransitionInProgress) {
+		return false;
+	}
+	if (isLoaded && owner == guid_guild) {
+		return true;
+	}
+	const auto houseRef = weak_from_this().lock();
+	ownerTransitionInProgress = true;
+	struct TransitionGuard {
+		bool& inProgress;
+		~TransitionGuard() { inProgress = false; }
+	} transitionGuard{ownerTransitionInProgress};
+
+	OwnerData newOwnerData;
+	if (guid_guild != 0) {
+		try {
+			newOwnerData = initializeOwnerDataFromDatabase(guid_guild, type);
+		} catch (const std::runtime_error& err) {
+			LOG_ERROR("{}", err.what());
+			return false;
 		}
 	}
 
-	if (isLoaded && owner == guid_guild) {
-		return;
+	// Do this before owner SQL, depot moves, kicks or access-list changes.
+	// A failed offline load/save must preserve every occupied sleep session.
+	if (owner != 0 && updateDatabase && !BedItem::wakeUpAll(getBeds())) {
+		return false;
+	}
+	if (updateDatabase && owner != guid_guild) {
+		const bool resetProtection = (guid_guild == 0 || owner == 0);
+		if (!updateOwnerInDatabase(guid_guild, resetProtection)) {
+			return false;
+		}
+		if (resetProtection) {
+			setProtected(false);
+		}
 	}
 
 	isLoaded = true;
@@ -158,16 +190,6 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 					if (creature && !creature->isRemoved() && creature->getTile() == tile.get()) {
 						kickPlayer(nullptr, creature->getPlayer());
 					}
-				}
-			}
-		}
-
-		// Remove players from beds
-		{
-			auto bedsSnapshot = getBeds();
-			for (const auto& bed : bedsSnapshot) {
-				if (bed && bed->getSleeper() != 0) {
-					bed->wakeUp(nullptr);
 				}
 			}
 		}
@@ -212,14 +234,7 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 	rentWarnings = 0;
 
 	if (guid_guild != 0) {
-		uint32_t sqlAccountId = 0, sqlPlayerGuid = 0, sqlGuildId = 0;
-		std::string sqlPlayerName, sqlGuildName;
-		try {
-			std::tie(sqlPlayerGuid, sqlAccountId, sqlPlayerName, sqlGuildId, sqlGuildName) = initializeOwnerDataFromDatabase(guid_guild, type);
-		} catch (const std::runtime_error& err) {
-			LOG_ERROR(fmt::format("{}", err.what()));
-			return;
-		}
+		const auto& [sqlPlayerGuid, sqlAccountId, sqlPlayerName, sqlGuildId, sqlGuildName] = newOwnerData;
 
 		owner = guid_guild;
 		ownerAccountId = sqlAccountId;
@@ -232,8 +247,12 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 		}
 		updateDoorDescription();
 	} else {
+		owner = 0;
+		ownerAccountId = 0;
+		ownerName.clear();
 		updateDoorDescription();
 	}
+	return true;
 }
 
 AccessHouseLevel_t House::getHouseAccessLevel(const Player* player) const
@@ -427,52 +446,73 @@ bool House::transferToDepot(Player* player) const
 		}
 
 		for (const auto& item : toProcess) {
+			if (!item || item->isRemoved() || tile->getThingIndex(item.get()) == -1) {
+				continue;
+			}
 			if (Container* container = item->getContainer()) {
-				std::vector<Container*> subContainers = {container};
+				std::vector<std::shared_ptr<Container>> subContainers = {g_game.getContainerSharedRef(container)};
 				size_t idx = 0;
 				while (idx < subContainers.size()) {
-					Container* current = subContainers[idx++];
+					const auto current = subContainers[idx++];
+					if (!current || current->isRemoved() || current->getTile() != tile.get()) {
+						continue;
+					}
 					std::vector<std::shared_ptr<Item>> children;
 					for (const auto& child : current->getItemList()) {
 						children.push_back(child);
 					}
 
 					for (const auto& child : children) {
+						if (!child || child->isRemoved() || child->getParent() != current.get()) {
+							continue;
+						}
+						auto processedChild = child;
 						if (child->hasAttribute(ITEM_ATTRIBUTE_WRAPID)) {
 							uint16_t wrapId = static_cast<uint16_t>(child->getIntAttr(ITEM_ATTRIBUTE_WRAPID));
 							if (wrapId != 0) {
-								g_game.transformItem(child.get(), wrapId);
+								processedChild = g_game.getItemSharedRef(g_game.transformItem(child.get(), wrapId));
 							}
 						}
 
-						if (Container* sub = child->getContainer()) {
-							subContainers.push_back(sub);
-						} else if (child->isPickupable()) {
-							g_game.internalMoveItem(child->getParent(), targetInbox, INDEX_WHEREEVER, child.get(), child->getItemCount(), nullptr, FLAG_NOLIMIT);
+						if (!processedChild || processedChild->isRemoved()) {
+							continue;
+						}
+						if (Container* sub = processedChild->getContainer()) {
+							subContainers.push_back(g_game.getContainerSharedRef(sub));
+						} else if (processedChild->isPickupable()) {
+							g_game.internalMoveItem(processedChild->getParent(), targetInbox, INDEX_WHEREEVER, processedChild.get(), processedChild->getItemCount(), nullptr, FLAG_NOLIMIT);
 						}
 					}
 				}
 			}
 
-			Item* processedItem = item.get();
+			auto processedItem = item;
+			if (processedItem->isRemoved() || tile->getThingIndex(processedItem.get()) == -1) {
+				continue;
+			}
 			if (processedItem->hasAttribute(ITEM_ATTRIBUTE_WRAPID)) {
 				uint16_t wrapId = static_cast<uint16_t>(processedItem->getIntAttr(ITEM_ATTRIBUTE_WRAPID));
 				if (wrapId != 0) {
-					if (Item* newItem = g_game.transformItem(processedItem, wrapId)) {
-						processedItem = newItem;
+					if (Item* newItem = g_game.transformItem(processedItem.get(), wrapId)) {
+						processedItem = g_game.getItemSharedRef(newItem);
 					}
 				}
 			}
 
+			if (!processedItem || processedItem->isRemoved()) {
+				continue;
+			}
 			if (processedItem->isPickupable()) {
-				g_game.internalMoveItem(processedItem->getParent(), targetInbox, INDEX_WHEREEVER, processedItem, processedItem->getItemCount(), nullptr, FLAG_NOLIMIT);
+				g_game.internalMoveItem(processedItem->getParent(), targetInbox, INDEX_WHEREEVER, processedItem.get(), processedItem->getItemCount(), nullptr, FLAG_NOLIMIT);
 			} else if (Container* container = processedItem->getContainer()) {
 				std::vector<std::shared_ptr<Item>> contents;
 				for (const auto& content : container->getItemList()) {
 					contents.push_back(content);
 				}
 				for (const auto& content : contents) {
-					g_game.internalMoveItem(content->getParent(), targetInbox, INDEX_WHEREEVER, content.get(), content->getItemCount(), nullptr, FLAG_NOLIMIT);
+					if (content && !content->isRemoved() && content->getParent() == container) {
+						g_game.internalMoveItem(content->getParent(), targetInbox, INDEX_WHEREEVER, content.get(), content->getItemCount(), nullptr, FLAG_NOLIMIT);
+					}
 				}
 			}
 		}
@@ -742,7 +782,16 @@ void HouseTransferItem::onTradeEvent(TradeEvents_t event, Player* owner)
 {
 	if (event == ON_TRADE_TRANSFER) {
 		if (auto h = house.lock()) {
-			h->executeTransfer(this, owner);
+			if (!h->executeTransfer(this, owner)) {
+				// The trade engine has already moved this virtual document. Do not
+				// leave a removed/stale document cached as the house transfer item.
+				h->resetTransferItem();
+				if (owner) {
+					owner->sendTextMessage(MESSAGE_EVENT_ADVANCE,
+					                       "The house transfer could not be completed. No ownership was changed.");
+				}
+				return;
+			}
 		}
 
 		g_game.internalRemoveItem(this, 1);
@@ -755,17 +804,22 @@ void HouseTransferItem::onTradeEvent(TradeEvents_t event, Player* owner)
 
 bool House::executeTransfer(HouseTransferItem* item, Player* newOwner)
 {
+	if (!newOwner) {
+		return false;
+	}
 	auto currentItem = transferItem.lock();
 	if (!currentItem || currentItem.get() != item) {
 		return false;
 	}
 
 	if (type == HOUSE_TYPE_NORMAL) {
-		setOwner(newOwner->getGUID());
+		if (!setOwner(newOwner->getGUID())) {
+			return false;
+		}
 	} else {
 		const auto& newOwnerGuild = newOwner->getGuild();
-		if (newOwnerGuild) {
-			setOwner(newOwnerGuild->getId());
+		if (!newOwnerGuild || !setOwner(newOwnerGuild->getId())) {
+			return false;
 		}
 	}
 	transferItem.reset();

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -233,7 +233,7 @@ bool House::kickPlayer(Player* player, Player* target) const
 	}
 
 	const auto houseTile = tile->getHouseTile();
-	if (!houseTile || houseTile->getHouse() != this) {
+	if (!houseTile || houseTile->getHouse().get() != this) {
 		return false;
 	}
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -31,9 +31,14 @@ void House::addTile(HouseTile* tile)
 	tile->setFlag(TILESTATE_PROTECTIONZONE);
 	if (auto tileRef = tile->weak_from_this().lock()) {
 		auto houseTileRef = std::static_pointer_cast<HouseTile>(tileRef);
-		for (const auto& weakTile : houseTiles) {
-			if (weakTile.lock() == houseTileRef) {
+		for (auto it = houseTiles.begin(); it != houseTiles.end();) {
+			auto locked = it->lock();
+			if (!locked) {
+				it = houseTiles.erase(it);
+			} else if (locked == houseTileRef) {
 				return;
+			} else {
+				++it;
 			}
 		}
 		houseTiles.push_back(houseTileRef);
@@ -47,9 +52,14 @@ void House::addTile(const std::shared_ptr<HouseTile>& tile)
 	}
 
 	tile->setFlag(TILESTATE_PROTECTIONZONE);
-	for (const auto& weakTile : houseTiles) {
-		if (weakTile.lock() == tile) {
+	for (auto it = houseTiles.begin(); it != houseTiles.end();) {
+		auto locked = it->lock();
+		if (!locked) {
+			it = houseTiles.erase(it);
+		} else if (locked == tile) {
 			return;
+		} else {
+			++it;
 		}
 	}
 	houseTiles.push_back(tile);
@@ -502,12 +512,16 @@ void House::addDoor(Door* door)
 	}
 	auto doorShared = std::static_pointer_cast<Door>(doorRef);
 
-	// Check for duplicates
-	for (const auto& weakDoor : doorList) {
-		if (weakDoor.lock() == doorShared) {
-			// Already registered, just ensure house backlink
+	// Check for duplicates and prune expired entries
+	for (auto it = doorList.begin(); it != doorList.end();) {
+		auto locked = it->lock();
+		if (!locked) {
+			it = doorList.erase(it);
+		} else if (locked == doorShared) {
 			door->setHouse(this);
 			return;
+		} else {
+			++it;
 		}
 	}
 
@@ -521,16 +535,16 @@ void House::removeDoor(Door* door)
 		return;
 	}
 
-	for (auto it = doorList.begin(); it != doorList.end(); ++it) {
+	for (auto it = doorList.begin(); it != doorList.end();) {
 		auto locked = it->lock();
 		if (!locked || locked.get() == door) {
+			const bool found = (locked && locked.get() == door);
 			it = doorList.erase(it);
-			if (locked) {
+			if (found) {
 				return;
 			}
-			// Continue pruning expired entries, but we haven't found our door yet
-			--it; // adjust for outer loop increment
-			continue;
+		} else {
+			++it;
 		}
 	}
 }
@@ -547,12 +561,16 @@ void House::addBed(BedItem* bed)
 	}
 	auto bedShared = std::static_pointer_cast<BedItem>(bedRef);
 
-	// Check for duplicates
-	for (const auto& weakBed : bedsList) {
-		if (weakBed.lock() == bedShared) {
-			// Already registered, just ensure house backlink
+	// Check for duplicates and prune expired entries
+	for (auto it = bedsList.begin(); it != bedsList.end();) {
+		auto locked = it->lock();
+		if (!locked) {
+			it = bedsList.erase(it);
+		} else if (locked == bedShared) {
 			bed->setHouse(weak_from_this().lock());
 			return;
+		} else {
+			++it;
 		}
 	}
 
@@ -566,15 +584,16 @@ void House::removeBed(BedItem* bed)
 		return;
 	}
 
-	for (auto it = bedsList.begin(); it != bedsList.end(); ++it) {
+	for (auto it = bedsList.begin(); it != bedsList.end();) {
 		auto locked = it->lock();
 		if (!locked || locked.get() == bed) {
+			const bool found = (locked && locked.get() == bed);
 			it = bedsList.erase(it);
-			if (locked) {
+			if (found) {
 				return;
 			}
-			--it;
-			continue;
+		} else {
+			++it;
 		}
 	}
 }

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -151,9 +151,12 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 		}
 
 		// Remove players from beds
-		for (BedItem* bed : bedsList) {
-			if (bed && bed->getSleeper() != 0) {
-				bed->wakeUp(nullptr);
+		{
+			auto bedsSnapshot = getBeds();
+			for (const auto& bed : bedsSnapshot) {
+				if (bed && bed->getSleeper() != 0) {
+					bed->wakeUp(nullptr);
+				}
 			}
 		}
 
@@ -167,8 +170,11 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 		setAccessList(SUBOWNER_LIST, "");
 		setAccessList(GUEST_LIST, "");
 
-		for (Door* door : doorSet) {
-			door->setAccessList("");
+		{
+			auto doorsSnapshot = getDoors();
+			for (const auto& door : doorsSnapshot) {
+				door->setAccessList("");
+			}
 		}
 	} else {
 		auto strRentPeriod =
@@ -486,15 +492,46 @@ bool House::isInvited(const Player* player) const { return getHouseAccessLevel(p
 
 void House::addDoor(Door* door)
 {
-	doorSet.insert(door);
+	if (!door) {
+		return;
+	}
+
+	auto doorRef = door->weak_from_this().lock();
+	if (!doorRef) {
+		return;
+	}
+	auto doorShared = std::static_pointer_cast<Door>(doorRef);
+
+	// Check for duplicates
+	for (const auto& weakDoor : doorList) {
+		if (weakDoor.lock() == doorShared) {
+			// Already registered, just ensure house backlink
+			door->setHouse(this);
+			return;
+		}
+	}
+
 	door->setHouse(this);
+	doorList.emplace_back(doorShared);
 }
 
 void House::removeDoor(Door* door)
 {
-	auto it = doorSet.find(door);
-	if (it != doorSet.end()) {
-		doorSet.erase(it);
+	if (!door) {
+		return;
+	}
+
+	for (auto it = doorList.begin(); it != doorList.end(); ++it) {
+		auto locked = it->lock();
+		if (!locked || locked.get() == door) {
+			it = doorList.erase(it);
+			if (locked) {
+				return;
+			}
+			// Continue pruning expired entries, but we haven't found our door yet
+			--it; // adjust for outer loop increment
+			continue;
+		}
 	}
 }
 
@@ -504,14 +541,23 @@ void House::addBed(BedItem* bed)
 		return;
 	}
 
-	for (BedItem* existing : bedsList) {
-		if (existing == bed) {
+	auto bedRef = bed->weak_from_this().lock();
+	if (!bedRef) {
+		return;
+	}
+	auto bedShared = std::static_pointer_cast<BedItem>(bedRef);
+
+	// Check for duplicates
+	for (const auto& weakBed : bedsList) {
+		if (weakBed.lock() == bedShared) {
+			// Already registered, just ensure house backlink
+			bed->setHouse(weak_from_this().lock());
 			return;
 		}
 	}
 
-	bedsList.push_back(bed);
 	bed->setHouse(weak_from_this().lock());
+	bedsList.emplace_back(bedShared);
 }
 
 void House::removeBed(BedItem* bed)
@@ -520,16 +566,25 @@ void House::removeBed(BedItem* bed)
 		return;
 	}
 
-	bedsList.remove(bed);
+	for (auto it = bedsList.begin(); it != bedsList.end(); ++it) {
+		auto locked = it->lock();
+		if (!locked || locked.get() == bed) {
+			it = bedsList.erase(it);
+			if (locked) {
+				return;
+			}
+			--it;
+			continue;
+		}
+	}
 }
 
 std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const
 {
-	for (Door* door : doorSet) {
+	for (const auto& weakDoor : doorList) {
+		auto door = weakDoor.lock();
 		if (door && door->getDoorId() == doorId) {
-			if (auto itemRef = door->weak_from_this().lock()) {
-				return std::static_pointer_cast<Door>(itemRef);
-			}
+			return std::static_pointer_cast<Door>(door);
 		}
 	}
 	return nullptr;
@@ -537,14 +592,78 @@ std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const
 
 std::shared_ptr<Door> House::getDoorByPosition(const Position& pos) const
 {
-	for (Door* door : doorSet) {
+	for (const auto& weakDoor : doorList) {
+		auto door = weakDoor.lock();
 		if (door && door->getPosition() == pos) {
-			if (auto itemRef = door->weak_from_this().lock()) {
-				return std::static_pointer_cast<Door>(itemRef);
-			}
+			return std::static_pointer_cast<Door>(door);
 		}
 	}
 	return nullptr;
+}
+
+std::vector<std::shared_ptr<Door>> House::getDoors() const
+{
+	std::vector<std::shared_ptr<Door>> result;
+	result.reserve(doorList.size());
+	for (const auto& weakDoor : doorList) {
+		if (auto door = weakDoor.lock()) {
+			result.push_back(std::static_pointer_cast<Door>(door));
+		}
+	}
+	return result;
+}
+
+size_t House::getDoorCount() const
+{
+	size_t count = 0;
+	for (const auto& weakDoor : doorList) {
+		if (!weakDoor.expired()) {
+			++count;
+		}
+	}
+	return count;
+}
+
+std::vector<std::shared_ptr<BedItem>> House::getBeds() const
+{
+	std::vector<std::shared_ptr<BedItem>> result;
+	result.reserve(bedsList.size());
+	for (const auto& weakBed : bedsList) {
+		if (auto bed = weakBed.lock()) {
+			result.push_back(std::static_pointer_cast<BedItem>(bed));
+		}
+	}
+	return result;
+}
+
+uint32_t House::getBedCount() const
+{
+	size_t liveCount = 0;
+	for (const auto& weakBed : bedsList) {
+		if (!weakBed.expired()) {
+			++liveCount;
+		}
+	}
+	return static_cast<uint32_t>(
+	    std::ceil(liveCount / 2.)); // each bed takes 2 sqms of space, ceil is just for bad maps
+}
+
+void House::removeTile(const HouseTile* tile)
+{
+	if (!tile) {
+		return;
+	}
+	for (auto it = houseTiles.begin(); it != houseTiles.end();) {
+		auto locked = it->lock();
+		if (!locked || locked.get() == tile) {
+			it = houseTiles.erase(it);
+			if (locked) {
+				return;
+			}
+		} else {
+			++it;
+		}
+	}
 }
 
 bool House::canEditAccessList(uint32_t listId, const Player* player) const
@@ -761,18 +880,16 @@ Attr_ReadValue Door::readAttr(AttrTypes_t attr, PropStream& propStream)
 
 void Door::setHouse(House* house)
 {
-	if (!this->house.expired()) {
-		return;
-	}
-
 	auto houseRef = house ? house->weak_from_this().lock() : nullptr;
-	if (!houseRef) {
-		return;
+	if (auto currentHouse = this->house.lock()) {
+		if (currentHouse != houseRef) {
+			currentHouse->removeDoor(this);
+		}
 	}
 
-	this->house = std::move(houseRef);
+	this->house = houseRef;
 
-	if (!accessList) {
+	if (houseRef && !accessList) {
 		accessList = std::make_unique<AccessList>();
 	}
 }
@@ -822,6 +939,7 @@ void Door::onRemoved()
 	if (auto h = house.lock()) {
 		h->removeDoor(this);
 	}
+	house.reset();
 }
 
 void House::updateDoorDescription() const
@@ -849,8 +967,11 @@ void House::updateDoorDescription() const
 		description << " It requires " << requiredReset << " resets.";
 	}
 
-	for (Door* door : doorSet) {
-		door->setSpecialDescription(description.str());
+	{
+		auto doorsSnapshot = getDoors();
+		for (const auto& door : doorsSnapshot) {
+			door->setSpecialDescription(description.str());
+		}
 	}
 }
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -778,11 +778,11 @@ void House::updateDoorDescription() const
 	}
 }
 
-House* Houses::getHouseByPlayerId(uint32_t playerId)
+std::shared_ptr<House> Houses::getHouseByPlayerId(uint32_t playerId) const
 {
 	for (const auto& it : houseMap) {
-		if (it.second->getOwner() == playerId) {
-			return it.second.get();
+		if (it.second && it.second->getOwner() == playerId) {
+			return it.second;
 		}
 	}
 	return nullptr;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -24,8 +24,46 @@ House::~House()
 
 void House::addTile(HouseTile* tile)
 {
+	if (!tile) {
+		return;
+	}
+
 	tile->setFlag(TILESTATE_PROTECTIONZONE);
+	if (auto tileRef = tile->weak_from_this().lock()) {
+		auto houseTileRef = std::static_pointer_cast<HouseTile>(tileRef);
+		for (const auto& weakTile : houseTiles) {
+			if (weakTile.lock() == houseTileRef) {
+				return;
+			}
+		}
+		houseTiles.push_back(houseTileRef);
+	}
+}
+
+void House::addTile(const std::shared_ptr<HouseTile>& tile)
+{
+	if (!tile) {
+		return;
+	}
+
+	tile->setFlag(TILESTATE_PROTECTIONZONE);
+	for (const auto& weakTile : houseTiles) {
+		if (weakTile.lock() == tile) {
+			return;
+		}
+	}
 	houseTiles.push_back(tile);
+}
+
+size_t House::getTileCount() const
+{
+	size_t count = 0;
+	for (const auto& weakTile : houseTiles) {
+		if (!weakTile.expired()) {
+			++count;
+		}
+	}
+	return count;
 }
 
 std::tuple<uint32_t, uint32_t, std::string, uint32_t, std::string> House::initializeOwnerDataFromDatabase(uint32_t guid_guild, HouseType_t type)
@@ -99,17 +137,22 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 			transferToDepot();
 		}
 
-		for (HouseTile* tile : houseTiles) {
-			if (const CreatureVector* creatures = tile->getCreatures()) {
-				for (int32_t i = creatures->size(); --i >= 0;) {
-					kickPlayer(nullptr, (*creatures)[i]->getPlayer());
+		for (auto it = houseTiles.begin(); it != houseTiles.end();) {
+			if (auto tile = it->lock()) {
+				if (const CreatureVector* creatures = tile->getCreatures()) {
+					for (int32_t i = creatures->size(); --i >= 0;) {
+						kickPlayer(nullptr, (*creatures)[i]->getPlayer());
+					}
 				}
+				++it;
+			} else {
+				it = houseTiles.erase(it);
 			}
 		}
 
 		// Remove players from beds
 		for (BedItem* bed : bedsList) {
-			if (bed->getSleeper() != 0) {
+			if (bed && bed->getSleeper() != 0) {
 				bed->wakeUp(nullptr);
 			}
 		}
@@ -266,14 +309,19 @@ void House::setAccessList(uint32_t listId, std::string_view textlist)
 	}
 
 	// kick uninvited players
-	for (HouseTile* tile : houseTiles) {
-		if (CreatureVector* creatures = tile->getCreatures()) {
-			for (int32_t i = creatures->size(); --i >= 0;) {
-				Player* player = (*creatures)[i]->getPlayer();
-				if (player && !isInvited(player)) {
-					kickPlayer(nullptr, player);
+	for (auto it = houseTiles.begin(); it != houseTiles.end();) {
+		if (auto tile = it->lock()) {
+			if (CreatureVector* creatures = tile->getCreatures()) {
+				for (int32_t i = creatures->size(); --i >= 0;) {
+					Player* player = (*creatures)[i]->getPlayer();
+					if (player && !isInvited(player)) {
+						kickPlayer(nullptr, player);
+					}
 				}
 			}
+			++it;
+		} else {
+			it = houseTiles.erase(it);
 		}
 	}
 }
@@ -348,7 +396,12 @@ bool House::transferToDepot(Player* player) const
 		}
 	}
 
-	for (HouseTile* tile : houseTiles) {
+	for (const auto& weakTile : houseTiles) {
+		auto tile = weakTile.lock();
+		if (!tile) {
+			continue;
+		}
+
 		const TileItemVector* items = tile->getItemList();
 		if (!items) {
 			continue;
@@ -451,8 +504,23 @@ void House::addBed(BedItem* bed)
 		return;
 	}
 
+	for (BedItem* existing : bedsList) {
+		if (existing == bed) {
+			return;
+		}
+	}
+
 	bedsList.push_back(bed);
 	bed->setHouse(weak_from_this().lock());
+}
+
+void House::removeBed(BedItem* bed)
+{
+	if (!bed) {
+		return;
+	}
+
+	bedsList.remove(bed);
 }
 
 std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const
@@ -772,7 +840,7 @@ void House::updateDoorDescription() const
 
 		const int32_t housePrice = getInteger(ConfigManager::HOUSE_PRICE);
 		if (housePrice != -1 && getBoolean(ConfigManager::HOUSE_DOOR_SHOW_PRICE)) {
-			description << " It costs " << (houseTiles.size() * housePrice) << " gold coins.";
+			description << " It costs " << (getTileCount() * housePrice) << " gold coins.";
 		}
 	}
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -485,10 +485,10 @@ bool House::canEditAccessList(uint32_t listId, const Player* player) const
 	}
 }
 
-HouseTransferItem* House::getTransferItem()
+std::shared_ptr<HouseTransferItem> House::getTransferItem()
 {
 	if (auto item = transferItem.lock()) {
-		return item.get();
+		return item;
 	}
 
 	auto newTransferItem = HouseTransferItem::createHouseTransferItem(this);
@@ -498,7 +498,7 @@ HouseTransferItem* House::getTransferItem()
 
 	transferItem = newTransferItem;
 	transfer_container.addThing(newTransferItem.get());
-	return newTransferItem.get();
+	return newTransferItem;
 }
 
 void House::resetTransferItem()

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -30,18 +30,7 @@ void House::addTile(HouseTile* tile)
 
 	tile->setFlag(TILESTATE_PROTECTIONZONE);
 	if (auto tileRef = tile->weak_from_this().lock()) {
-		auto houseTileRef = std::static_pointer_cast<HouseTile>(tileRef);
-		for (auto it = houseTiles.begin(); it != houseTiles.end();) {
-			auto locked = it->lock();
-			if (!locked) {
-				it = houseTiles.erase(it);
-			} else if (locked == houseTileRef) {
-				return;
-			} else {
-				++it;
-			}
-		}
-		houseTiles.push_back(houseTileRef);
+		addTile(std::static_pointer_cast<HouseTile>(tileRef));
 	}
 }
 
@@ -74,6 +63,18 @@ size_t House::getTileCount() const
 		}
 	}
 	return count;
+}
+
+std::vector<std::shared_ptr<HouseTile>> House::getTilesSnapshot() const
+{
+	std::vector<std::shared_ptr<HouseTile>> tiles;
+	tiles.reserve(houseTiles.size());
+	for (const auto& weakTile : houseTiles) {
+		if (auto tile = weakTile.lock()) {
+			tiles.push_back(std::move(tile));
+		}
+	}
+	return tiles;
 }
 
 std::tuple<uint32_t, uint32_t, std::string, uint32_t, std::string> House::initializeOwnerDataFromDatabase(uint32_t guid_guild, HouseType_t type)
@@ -147,16 +148,17 @@ void House::setOwner(uint32_t guid_guild, bool updateDatabase /* = true*/, Playe
 			transferToDepot();
 		}
 
-		for (auto it = houseTiles.begin(); it != houseTiles.end();) {
-			if (auto tile = it->lock()) {
-				if (const CreatureVector* creatures = tile->getCreatures()) {
-					for (int32_t i = creatures->size(); --i >= 0;) {
-						kickPlayer(nullptr, (*creatures)[i]->getPlayer());
+		// Kicking a player runs movement callbacks, which may remove other
+		// creatures or unregister this tile from the house.
+		for (const auto& tile : getTilesSnapshot()) {
+			if (const CreatureVector* creatures = tile->getCreatures()) {
+				const auto snapshot = *creatures;
+				for (auto it = snapshot.rbegin(); it != snapshot.rend(); ++it) {
+					const auto& creature = *it;
+					if (creature && !creature->isRemoved() && creature->getTile() == tile.get()) {
+						kickPlayer(nullptr, creature->getPlayer());
 					}
 				}
-				++it;
-			} else {
-				it = houseTiles.erase(it);
 			}
 		}
 
@@ -325,19 +327,19 @@ void House::setAccessList(uint32_t listId, std::string_view textlist)
 	}
 
 	// kick uninvited players
-	for (auto it = houseTiles.begin(); it != houseTiles.end();) {
-		if (auto tile = it->lock()) {
-			if (CreatureVector* creatures = tile->getCreatures()) {
-				for (int32_t i = creatures->size(); --i >= 0;) {
-					Player* player = (*creatures)[i]->getPlayer();
-					if (player && !isInvited(player)) {
-						kickPlayer(nullptr, player);
-					}
+	for (const auto& tile : getTilesSnapshot()) {
+		if (const CreatureVector* creatures = tile->getCreatures()) {
+			const auto snapshot = *creatures;
+			for (auto it = snapshot.rbegin(); it != snapshot.rend(); ++it) {
+				const auto& creature = *it;
+				if (!creature || creature->isRemoved() || creature->getTile() != tile.get()) {
+					continue;
+				}
+				Player* player = creature->getPlayer();
+				if (player && !isInvited(player)) {
+					kickPlayer(nullptr, player);
 				}
 			}
-			++it;
-		} else {
-			it = houseTiles.erase(it);
 		}
 	}
 }
@@ -412,12 +414,8 @@ bool House::transferToDepot(Player* player) const
 		}
 	}
 
-	for (const auto& weakTile : houseTiles) {
-		auto tile = weakTile.lock();
-		if (!tile) {
-			continue;
-		}
-
+	// Moving items also runs callbacks that can mutate the house tile registry.
+	for (const auto& tile : getTilesSnapshot()) {
 		const TileItemVector* items = tile->getItemList();
 		if (!items) {
 			continue;
@@ -603,7 +601,7 @@ std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const
 	for (const auto& weakDoor : doorList) {
 		auto door = weakDoor.lock();
 		if (door && door->getDoorId() == doorId) {
-			return std::static_pointer_cast<Door>(door);
+			return door;
 		}
 	}
 	return nullptr;
@@ -614,7 +612,7 @@ std::shared_ptr<Door> House::getDoorByPosition(const Position& pos) const
 	for (const auto& weakDoor : doorList) {
 		auto door = weakDoor.lock();
 		if (door && door->getPosition() == pos) {
-			return std::static_pointer_cast<Door>(door);
+			return door;
 		}
 	}
 	return nullptr;
@@ -626,7 +624,7 @@ std::vector<std::shared_ptr<Door>> House::getDoors() const
 	result.reserve(doorList.size());
 	for (const auto& weakDoor : doorList) {
 		if (auto door = weakDoor.lock()) {
-			result.push_back(std::static_pointer_cast<Door>(door));
+			result.push_back(std::move(door));
 		}
 	}
 	return result;
@@ -649,7 +647,7 @@ std::vector<std::shared_ptr<BedItem>> House::getBeds() const
 	result.reserve(bedsList.size());
 	for (const auto& weakBed : bedsList) {
 		if (auto bed = weakBed.lock()) {
-			result.push_back(std::static_pointer_cast<BedItem>(bed));
+			result.push_back(std::move(bed));
 		}
 	}
 	return result;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -463,11 +463,13 @@ std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const
 	return nullptr;
 }
 
-Door* House::getDoorByPosition(const Position& pos) const
+std::shared_ptr<Door> House::getDoorByPosition(const Position& pos) const
 {
 	for (Door* door : doorSet) {
-		if (door->getPosition() == pos) {
-			return door;
+		if (door && door->getPosition() == pos) {
+			if (auto itemRef = door->weak_from_this().lock()) {
+				return std::static_pointer_cast<Door>(itemRef);
+			}
 		}
 	}
 	return nullptr;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -448,7 +448,9 @@ void House::removeDoor(Door* door)
 void House::addBed(BedItem* bed)
 {
 	bedsList.push_back(bed);
-	bed->setHouse(this);
+	if (bed) {
+		bed->setHouse(weak_from_this().lock());
+	}
 }
 
 std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -447,10 +447,12 @@ void House::removeDoor(Door* door)
 
 void House::addBed(BedItem* bed)
 {
-	bedsList.push_back(bed);
-	if (bed) {
-		bed->setHouse(weak_from_this().lock());
+	if (!bed) {
+		return;
 	}
+
+	bedsList.push_back(bed);
+	bed->setHouse(weak_from_this().lock());
 }
 
 std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -805,7 +805,7 @@ bool Houses::loadHousesXML(const std::string& filename)
 
 		int32_t houseId = pugi::cast<int32_t>(houseIdAttribute.value());
 
-		House* house = getHouse(houseId);
+		auto house = getHouse(houseId);
 		if (!house) {
 			LOG_ERROR(fmt::format("Error: [Houses::loadHousesXML] Unknown house, id = {}", houseId));
 			return false;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -256,7 +256,7 @@ void House::setAccessList(uint32_t listId, std::string_view textlist)
 	} else if (listId == SUBOWNER_LIST) {
 		subOwnerList.parseList(textlist);
 	} else {
-		Door* door = getDoorByNumber(listId);
+		auto door = getDoorByNumber(listId);
 		if (door) {
 			door->setAccessList(textlist);
 		}
@@ -421,7 +421,7 @@ std::optional<std::string_view> House::getAccessList(uint32_t listId) const
 		return std::make_optional(subOwnerList.getList());
 	}
 
-	Door* door = getDoorByNumber(listId);
+	auto door = getDoorByNumber(listId);
 	if (!door) {
 		return std::nullopt;
 	}
@@ -451,11 +451,13 @@ void House::addBed(BedItem* bed)
 	bed->setHouse(this);
 }
 
-Door* House::getDoorByNumber(uint32_t doorId) const
+std::shared_ptr<Door> House::getDoorByNumber(uint32_t doorId) const
 {
 	for (Door* door : doorSet) {
-		if (door->getDoorId() == doorId) {
-			return door;
+		if (door && door->getDoorId() == doorId) {
+			if (auto itemRef = door->weak_from_this().lock()) {
+				return std::static_pointer_cast<Door>(itemRef);
+			}
 		}
 	}
 	return nullptr;

--- a/src/house.h
+++ b/src/house.h
@@ -166,7 +166,7 @@ public:
 
 	void addDoor(Door* door);
 	void removeDoor(Door* door);
-	Door* getDoorByNumber(uint32_t doorId) const;
+	[[nodiscard]] std::shared_ptr<Door> getDoorByNumber(uint32_t doorId) const;
 	Door* getDoorByPosition(const Position& pos) const;
 
 	std::shared_ptr<HouseTransferItem> getTransferItem();

--- a/src/house.h
+++ b/src/house.h
@@ -46,7 +46,7 @@ public:
 	Door* getDoor() override { return this; }
 	const Door* getDoor() const override { return this; }
 
-	House* getHouse() { return house.lock().get(); }
+	std::shared_ptr<House> getHouse() const { return house.lock(); }
 
 	// serialization
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;

--- a/src/house.h
+++ b/src/house.h
@@ -43,8 +43,14 @@ public:
 	Door(const Door&) = delete;
 	Door& operator=(const Door&) = delete;
 
-	Door* getDoor() override { return this; }
-	const Door* getDoor() const override { return this; }
+	[[nodiscard]] std::shared_ptr<Door> getDoor() override
+	{
+		return std::static_pointer_cast<Door>(weak_from_this().lock());
+	}
+	[[nodiscard]] std::shared_ptr<const Door> getDoor() const override
+	{
+		return std::static_pointer_cast<const Door>(weak_from_this().lock());
+	}
 
 	std::shared_ptr<House> getHouse() const { return house.lock(); }
 

--- a/src/house.h
+++ b/src/house.h
@@ -206,6 +206,7 @@ private:
 	bool transferToDepot() const;
 	bool transferToDepot(Player* player) const;
 	void updateDoorDescription() const;
+	std::vector<std::shared_ptr<HouseTile>> getTilesSnapshot() const;
 
 	AccessList guestList;
 	AccessList subOwnerList;

--- a/src/house.h
+++ b/src/house.h
@@ -97,7 +97,6 @@ enum HouseType_t
 };
 
 using HouseTileList = std::list<std::weak_ptr<HouseTile>>;
-using HouseBedItemList = std::list<ObserverPtr<BedItem>>;
 
 class HouseTransferItem final : public Item
 {
@@ -182,17 +181,15 @@ public:
 
 	const HouseTileList& getTiles() const { return houseTiles; }
 	size_t getTileCount() const;
+	void removeTile(const HouseTile* tile);
 
-	const std::set<ObserverPtr<Door>>& getDoors() const { return doorSet; }
+	[[nodiscard]] std::vector<std::shared_ptr<Door>> getDoors() const;
+	[[nodiscard]] size_t getDoorCount() const;
 
 	void addBed(BedItem* bed);
 	void removeBed(BedItem* bed);
-	const HouseBedItemList& getBeds() const { return bedsList; }
-	uint32_t getBedCount() const
-	{
-		return static_cast<uint32_t>(
-		    std::ceil(bedsList.size() / 2.)); // each bed takes 2 sqms of space, ceil is just for bad maps
-	}
+	[[nodiscard]] std::vector<std::shared_ptr<BedItem>> getBeds() const;
+	uint32_t getBedCount() const;
 
 	// Protection guest management and permission checks
 	bool addProtectionGuest(uint32_t playerId);
@@ -216,8 +213,8 @@ private:
 	Container transfer_container{ITEM_LOCKER};
 
 	HouseTileList houseTiles;
-	std::set<ObserverPtr<Door>> doorSet;
-	HouseBedItemList bedsList;
+	std::vector<std::weak_ptr<Door>> doorList;
+	std::vector<std::weak_ptr<BedItem>> bedsList;
 
 	std::string houseName;
 	std::string ownerName;

--- a/src/house.h
+++ b/src/house.h
@@ -96,7 +96,7 @@ enum HouseType_t
 	HOUSE_TYPE_GUILDHALL = 2,
 };
 
-using HouseTileList = std::list<ObserverPtr<HouseTile>>;
+using HouseTileList = std::list<std::weak_ptr<HouseTile>>;
 using HouseBedItemList = std::list<ObserverPtr<BedItem>>;
 
 class HouseTransferItem final : public Item
@@ -120,6 +120,7 @@ public:
 	~House();
 
 	void addTile(HouseTile* tile);
+	void addTile(const std::shared_ptr<HouseTile>& tile);
 
 	bool canEditAccessList(uint32_t listId, const Player* player) const;
 	// listId special values:
@@ -180,10 +181,12 @@ public:
 	bool executeTransfer(HouseTransferItem* item, Player* newOwner);
 
 	const HouseTileList& getTiles() const { return houseTiles; }
+	size_t getTileCount() const;
 
 	const std::set<ObserverPtr<Door>>& getDoors() const { return doorSet; }
 
 	void addBed(BedItem* bed);
+	void removeBed(BedItem* bed);
 	const HouseBedItemList& getBeds() const { return bedsList; }
 	uint32_t getBedCount() const
 	{

--- a/src/house.h
+++ b/src/house.h
@@ -258,15 +258,15 @@ public:
 	Houses(const Houses&) = delete;
 	Houses& operator=(const Houses&) = delete;
 
-	House* addHouse(uint32_t id)
+	std::shared_ptr<House> addHouse(uint32_t id)
 	{
 		auto it = houseMap.find(id);
 		if (it != houseMap.end()) {
-			return it->second.get();
+			return it->second;
 		}
 
 		auto [ins, ok] = houseMap.emplace(id, std::make_shared<House>(id));
-		return ins->second.get();
+		return ins->second;
 	}
 
 	[[nodiscard]] std::shared_ptr<House> getHouse(uint32_t houseId)

--- a/src/house.h
+++ b/src/house.h
@@ -169,7 +169,7 @@ public:
 	Door* getDoorByNumber(uint32_t doorId) const;
 	Door* getDoorByPosition(const Position& pos) const;
 
-	HouseTransferItem* getTransferItem();
+	std::shared_ptr<HouseTransferItem> getTransferItem();
 	void resetTransferItem();
 	bool executeTransfer(HouseTransferItem* item, Player* newOwner);
 

--- a/src/house.h
+++ b/src/house.h
@@ -269,13 +269,13 @@ public:
 		return ins->second.get();
 	}
 
-	[[nodiscard]] House* getHouse(uint32_t houseId)
+	[[nodiscard]] std::shared_ptr<House> getHouse(uint32_t houseId)
 	{
 		auto it = houseMap.find(houseId);
 		if (it == houseMap.end()) {
 			return nullptr;
 		}
-		return it->second.get();
+		return it->second;
 	}
 
 	[[nodiscard]] House* getHouseByPlayerId(uint32_t playerId);

--- a/src/house.h
+++ b/src/house.h
@@ -167,7 +167,7 @@ public:
 	void addDoor(Door* door);
 	void removeDoor(Door* door);
 	[[nodiscard]] std::shared_ptr<Door> getDoorByNumber(uint32_t doorId) const;
-	Door* getDoorByPosition(const Position& pos) const;
+	[[nodiscard]] std::shared_ptr<Door> getDoorByPosition(const Position& pos) const;
 
 	std::shared_ptr<HouseTransferItem> getTransferItem();
 	void resetTransferItem();

--- a/src/house.h
+++ b/src/house.h
@@ -116,7 +116,7 @@ class House : public std::enable_shared_from_this<House>
 {
 public:
 	explicit House(uint32_t houseId);
-	~House();
+	virtual ~House();
 
 	void addTile(HouseTile* tile);
 	void addTile(const std::shared_ptr<HouseTile>& tile);
@@ -140,7 +140,7 @@ public:
 	std::string_view getName() const { return houseName; }
 
 	std::string_view getOwnerName() const { return ownerName; }
-	void setOwner(uint32_t guid_guild, bool updateDatabase = true, Player* previousPlayer = nullptr);
+	bool setOwner(uint32_t guid_guild, bool updateDatabase = true, Player* previousPlayer = nullptr);
 	uint32_t getOwner() const { return owner; }
 	uint32_t getOwnerAccountId() const { return ownerAccountId; }
 
@@ -201,8 +201,12 @@ public:
 	bool getProtected() const { return isProtected; }
 	void setProtected(bool protect) { isProtected = protect; }
 
+protected:
+	using OwnerData = std::tuple<uint32_t, uint32_t, std::string, uint32_t, std::string>;
+	virtual OwnerData initializeOwnerDataFromDatabase(uint32_t guid_guild, HouseType_t type);
+	virtual bool updateOwnerInDatabase(uint32_t guid_guild, bool resetProtection);
+
 private:
-	std::tuple<uint32_t, uint32_t, std::string, uint32_t, std::string> initializeOwnerDataFromDatabase(uint32_t guid_guild, HouseType_t type);
 	bool transferToDepot() const;
 	bool transferToDepot(Player* player) const;
 	void updateDoorDescription() const;
@@ -235,6 +239,7 @@ private:
 	Position posEntry = {};
 
 	bool isLoaded = false;
+	bool ownerTransitionInProgress = false;
 
 	// Protection state and guest list
 	bool isProtected = false;

--- a/src/house.h
+++ b/src/house.h
@@ -278,7 +278,7 @@ public:
 		return it->second;
 	}
 
-	[[nodiscard]] House* getHouseByPlayerId(uint32_t playerId);
+	[[nodiscard]] std::shared_ptr<House> getHouseByPlayerId(uint32_t playerId) const;
 
 	bool loadHousesXML(const std::string& filename);
 

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -68,13 +68,19 @@ void HouseTile::updateHouse(Item* item)
 ReturnValue HouseTile::queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
                                 Creature* actor /* = nullptr*/) const
 {
-	if (hasBitSet(FLAG_NOLIMIT, flags)) {
-		return RETURNVALUE_NOERROR;
-	}
-
 	auto house = getHouse();
 	if (!house) {
+		// A HouseTile whose House has expired must not silently become a normal,
+		// unrestricted tile. Actor-less item operations are kept available for
+		// internal maintenance; creature and actor-driven operations fail closed.
+		if (thing.getCreature() || actor) {
+			return RETURNVALUE_NOTPOSSIBLE;
+		}
 		return Tile::queryAdd(index, thing, count, flags, actor);
+	}
+
+	if (hasBitSet(FLAG_NOLIMIT, flags)) {
+		return RETURNVALUE_NOERROR;
 	}
 
 	if (const Creature* creature = thing.getCreature()) {
@@ -111,23 +117,28 @@ Tile* HouseTile::queryDestination(int32_t& index, const Thing& thing, Item** des
 {
 	if (const Creature* creature = thing.getCreature()) {
 		if (const Player* player = creature->getPlayer()) {
-			if (auto house = getHouse()) {
-				if (!house->isInvited(player)) {
-					const Position& entryPos = house->getEntryPosition();
-					Tile* destTile = g_game.map.getTile(entryPos);
+			auto house = getHouse();
+			if (!house) {
+				index = -1;
+				*destItem = nullptr;
+				return &Tile::nullptr_tile;
+			}
+
+			if (!house->isInvited(player)) {
+				const Position& entryPos = house->getEntryPosition();
+				Tile* destTile = g_game.map.getTile(entryPos);
+				if (!destTile) {
+					LOG_ERROR(fmt::format("[HouseTile::queryDestination] House entry not correct - Name: {} - House id: {} - Tile not found: {}", house->getName(), house->getId(), entryPos));
+
+					destTile = g_game.map.getTile(player->getTemplePosition());
 					if (!destTile) {
-						LOG_ERROR(fmt::format("[HouseTile::queryDestination] House entry not correct - Name: {} - House id: {} - Tile not found: {}", house->getName(), house->getId(), entryPos));
-
-						destTile = g_game.map.getTile(player->getTemplePosition());
-						if (!destTile) {
-							destTile = &(Tile::nullptr_tile);
-						}
+						destTile = &(Tile::nullptr_tile);
 					}
-
-					index = -1;
-					*destItem = nullptr;
-					return destTile;
 				}
+
+				index = -1;
+				*destItem = nullptr;
+				return destTile;
 			}
 		}
 	}
@@ -144,15 +155,18 @@ ReturnValue HouseTile::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 	}
 
 	if (actor) {
-		if (auto house = getHouse()) {
-			if (house->getProtected() && !house->canModifyItems(actor->getPlayer())) {
-				return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
-			}
+		auto house = getHouse();
+		if (!house) {
+			return RETURNVALUE_NOTPOSSIBLE;
+		}
 
-			if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-				if (!house->isInvited(actor->getPlayer())) {
-					return RETURNVALUE_PLAYERISNOTINVITED;
-				}
+		if (house->getProtected() && !house->canModifyItems(actor->getPlayer())) {
+			return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
+		}
+
+		if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+			if (!house->isInvited(actor->getPlayer())) {
+				return RETURNVALUE_PLAYERISNOTINVITED;
 			}
 		}
 	}

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -58,9 +58,9 @@ void HouseTile::updateHouse(Item* item)
 			house->addDoor(door);
 		}
 	} else {
-		BedItem* bed = item->getBed();
+		auto bed = item->getBed();
 		if (bed) {
-			house->addBed(bed);
+			house->addBed(bed.get());
 		}
 	}
 }

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -52,10 +52,10 @@ void HouseTile::updateHouse(Item* item)
 		return;
 	}
 
-	Door* door = item->getDoor();
+	auto door = item->getDoor();
 	if (door) {
 		if (door->getDoorId() != 0) {
-			house->addDoor(door);
+			house->addDoor(door.get());
 		}
 	} else {
 		auto bed = item->getBed();

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -56,15 +56,20 @@ void HouseTile::updateHouse(Item* item)
 		return;
 	}
 
+	auto house = getHouse();
+	if (!house) {
+		return;
+	}
+
 	Door* door = item->getDoor();
 	if (door) {
 		if (door->getDoorId() != 0) {
-			getHouse()->addDoor(door);
+			house->addDoor(door);
 		}
 	} else {
 		BedItem* bed = item->getBed();
 		if (bed) {
-			getHouse()->addBed(bed);
+			house->addBed(bed);
 		}
 	}
 }
@@ -76,10 +81,15 @@ ReturnValue HouseTile::queryAdd(int32_t index, const Thing& thing, uint32_t coun
 		return RETURNVALUE_NOERROR;
 	}
 
+	auto house = getHouse();
+	if (!house) {
+		return Tile::queryAdd(index, thing, count, flags, actor);
+	}
+
 	if (const Creature* creature = thing.getCreature()) {
 		if (const Player* player = creature->getPlayer()) {
-			if (!getHouse()->isInvited(player)) {
-				if (getHouse()->getType() == HOUSE_TYPE_GUILDHALL) {
+			if (!house->isInvited(player)) {
+				if (house->getType() == HOUSE_TYPE_GUILDHALL) {
 					return RETURNVALUE_ONLYGUILDMEMBERSMAYENTER;
 				}
 				return RETURNVALUE_PLAYERISNOTINVITED;
@@ -93,11 +103,11 @@ ReturnValue HouseTile::queryAdd(int32_t index, const Thing& thing, uint32_t coun
 		}
 
 		if (actor) {
-			if (getHouse()->getProtected() && !getHouse()->canModifyItems(actor->getPlayer())) {
+			if (house->getProtected() && !house->canModifyItems(actor->getPlayer())) {
 				return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
 			}
 			Player* actorPlayer = actor->getPlayer();
-			if (!getHouse()->isInvited(actorPlayer)) {
+			if (!house->isInvited(actorPlayer)) {
 				return RETURNVALUE_CANNOTTHROW;
 			}
 		}
@@ -110,21 +120,23 @@ Tile* HouseTile::queryDestination(int32_t& index, const Thing& thing, Item** des
 {
 	if (const Creature* creature = thing.getCreature()) {
 		if (const Player* player = creature->getPlayer()) {
-			if (!getHouse()->isInvited(player)) {
-				const Position& entryPos = getHouse()->getEntryPosition();
-				Tile* destTile = g_game.map.getTile(entryPos);
-				if (!destTile) {
-					LOG_ERROR(fmt::format("[HouseTile::queryDestination] House entry not correct - Name: {} - House id: {} - Tile not found: {}", getHouse()->getName(), getHouse()->getId(), entryPos));
-
-					destTile = g_game.map.getTile(player->getTemplePosition());
+			if (auto house = getHouse()) {
+				if (!house->isInvited(player)) {
+					const Position& entryPos = house->getEntryPosition();
+					Tile* destTile = g_game.map.getTile(entryPos);
 					if (!destTile) {
-						destTile = &(Tile::nullptr_tile);
-					}
-				}
+						LOG_ERROR(fmt::format("[HouseTile::queryDestination] House entry not correct - Name: {} - House id: {} - Tile not found: {}", house->getName(), house->getId(), entryPos));
 
-				index = -1;
-				*destItem = nullptr;
-				return destTile;
+						destTile = g_game.map.getTile(player->getTemplePosition());
+						if (!destTile) {
+							destTile = &(Tile::nullptr_tile);
+						}
+					}
+
+					index = -1;
+					*destItem = nullptr;
+					return destTile;
+				}
 			}
 		}
 	}
@@ -140,13 +152,17 @@ ReturnValue HouseTile::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	if (actor && getHouse()->getProtected() && !getHouse()->canModifyItems(actor->getPlayer())) {
-		return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
-	}
+	if (actor) {
+		if (auto house = getHouse()) {
+			if (house->getProtected() && !house->canModifyItems(actor->getPlayer())) {
+				return RETURNVALUE_CANNOTMOVEITEMISPROTECTED;
+			}
 
-	if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		if (!getHouse()->isInvited(actor->getPlayer())) {
-			return RETURNVALUE_PLAYERISNOTINVITED;
+			if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+				if (!house->isInvited(actor->getPlayer())) {
+					return RETURNVALUE_PLAYERISNOTINVITED;
+				}
+			}
 		}
 	}
 

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -13,16 +13,7 @@
 
 extern Game g_game;
 
-namespace {
-
-std::shared_ptr<House> getSharedHouse(House* house)
-{
-	return house ? house->weak_from_this().lock() : nullptr;
-}
-
-} // namespace
-
-HouseTile::HouseTile(uint16_t x, uint16_t y, uint8_t z, House* house) : DynamicTile(x, y, z), house(getSharedHouse(house)) {}
+HouseTile::HouseTile(uint16_t x, uint16_t y, uint8_t z, const std::shared_ptr<House>& house) : DynamicTile(x, y, z), house(house) {}
 
 void HouseTile::addThing(int32_t index, Thing* thing)
 {

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -33,7 +33,7 @@ public:
 	void addThing(int32_t index, Thing* thing) override;
 	void internalAddThing(uint32_t index, Thing* thing) override;
 
-	House* getHouse() const { return house.lock().get(); }
+	std::shared_ptr<House> getHouse() const { return house.lock(); }
 
 private:
 	void updateHouse(Item* item);

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -13,7 +13,7 @@ class House;
 class HouseTile final : public DynamicTile
 {
 public:
-	HouseTile(uint16_t x, uint16_t y, uint8_t z, House* house);
+	HouseTile(uint16_t x, uint16_t y, uint8_t z, const std::shared_ptr<House>& house);
 
 	using Tile::internalAddThing;
 

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -457,7 +457,7 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
             uint16_t x = base_x + tile_coord.x;
             uint16_t y = base_y + tile_coord.y;
 
-            House* house = nullptr;
+            std::shared_ptr<House> house = nullptr;
             std::unique_ptr<Tile> tilePtr;
             Tile* tile = nullptr;
             std::shared_ptr<Item> ground_item;
@@ -476,7 +476,7 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
                 return false;
             }
 
-            tilePtr = std::make_unique<HouseTile>(x, y, z, house);
+            tilePtr = std::make_unique<HouseTile>(x, y, z, house.get());
             tile = tilePtr.get();
             house->addTile(static_cast<HouseTile*>(tile));
 

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -476,7 +476,7 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
                 return false;
             }
 
-            tilePtr = std::make_unique<HouseTile>(x, y, z, house.get());
+            tilePtr = std::make_unique<HouseTile>(x, y, z, house);
             tile = tilePtr.get();
             house->addTile(static_cast<HouseTile*>(tile));
 

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -478,7 +478,6 @@ bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Ma
 
             tilePtr = std::make_unique<HouseTile>(x, y, z, house);
             tile = tilePtr.get();
-            house->addTile(static_cast<HouseTile*>(tile));
 
             uint8_t attribute;
             while (tilePropStream.read(attribute)) {

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -321,7 +321,7 @@ bool IOMapSerialize::loadHouseInfo()
 	}
 
 	do {
-			House* house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("id"));
+			auto house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("id"));
 			if (house) {
 				std::string_view typeStr = result->getString("type");
 				uint32_t typeVal = house->getType();
@@ -348,7 +348,7 @@ bool IOMapSerialize::loadHouseInfo()
 	result = db.storeQuery("SELECT `house_id`, `listid`, `list` FROM `house_lists`");
 	if (result) {
 		do {
-			House* house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("house_id"));
+			auto house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("house_id"));
 			if (house) {
 				house->setAccessList(result->getNumber<uint32_t>("listid"), result->getString("list"));
 			}
@@ -359,7 +359,7 @@ bool IOMapSerialize::loadHouseInfo()
 	result = db.storeQuery("SELECT `house_id`, `player_id` FROM `house_guests`");
 	if (result) {
 		do {
-			House* house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("house_id"));
+			auto house = g_game.map.houses.getHouse(result->getNumber<uint32_t>("house_id"));
 			if (house) {
 				house->getProtectionGuests().insert(result->getNumber<uint32_t>("player_id"));
 			}

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -101,16 +101,18 @@ bool IOMapSerialize::saveHouseItems()
 		for (const auto& it : g_game.map.houses.getHouses()) {
 			// save house items
 			House* house = it.second.get();
-			for (HouseTile* tile : house->getTiles()) {
-				saveTile(stream, tile);
+			for (const auto& weakTile : house->getTiles()) {
+				if (auto tile = weakTile.lock()) {
+					saveTile(stream, tile.get());
 
-				if (auto attributes = stream.getStream(); !attributes.empty()) {
-					if (notEmpty) {
-						query << ",";
+					if (auto attributes = stream.getStream(); !attributes.empty()) {
+						if (notEmpty) {
+							query << ",";
+						}
+						query << "(" << house->getId() << "," << db.escapeString(attributes) << ")";
+						notEmpty = true;
+						stream.clear();
 					}
-					query << "(" << house->getId() << "," << db.escapeString(attributes) << ")";
-					notEmpty = true;
-					stream.clear();
 				}
 			}
 		}
@@ -392,7 +394,7 @@ bool IOMapSerialize::saveHouseInfo()
 		}
 		query << fmt::format("({:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:s}, {:d}, {:d}, {:d}, {:d})",
 		                     house->getId(), static_cast<uint32_t>(house->getType()), house->getOwner(), house->getPaidUntil(), house->getPayRentWarnings(),
-		                     (house->getProtected() ? 1 : 0), db.escapeString(house->getName()), house->getTownId(), house->getRent(), house->getTiles().size(),
+		                     (house->getProtected() ? 1 : 0), db.escapeString(house->getName()), house->getTownId(), house->getRent(), house->getTileCount(),
 		                     house->getBedCount());
 		notEmpty = true;
 	}
@@ -475,14 +477,16 @@ bool IOMapSerialize::saveHouse(const House* house)
 	DBInsert stmt("INSERT INTO `tile_store` (`house_id`, `data`) VALUES ");
 
 	PropWriteStream stream;
-	for (HouseTile* tile : house->getTiles()) {
-		saveTile(stream, tile);
+	for (const auto& weakTile : house->getTiles()) {
+		if (auto tile = weakTile.lock()) {
+			saveTile(stream, tile.get());
 
-		if (auto attributes = stream.getStream(); attributes.size() > 0) {
-			if (!stmt.addRow(fmt::format("{:d}, {:s}", houseId, db.escapeString(attributes)))) {
-				return false;
+			if (auto attributes = stream.getStream(); attributes.size() > 0) {
+				if (!stmt.addRow(fmt::format("{:d}, {:s}", houseId, db.escapeString(attributes)))) {
+					return false;
+				}
+				stream.clear();
 			}
-			stream.clear();
 		}
 	}
 

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -439,7 +439,7 @@ bool IOMapSerialize::saveHouseInfo()
 			}
 		}
 
-		for (Door* door : house->getDoors()) {
+		for (const auto& door : house->getDoors()) {
 			listText = door->getAccessList().value_or("");
 			if (!listText.empty()) {
 				if (!stmt.addRow(fmt::format("{:d}, {:d}, {:s}", house->getId(), door->getDoorId(),

--- a/src/item.h
+++ b/src/item.h
@@ -499,8 +499,8 @@ public:
 	virtual const TrashHolder* getTrashHolder() const { return nullptr; }
 	virtual Mailbox* getMailbox() { return nullptr; }
 	virtual const Mailbox* getMailbox() const { return nullptr; }
-	virtual Door* getDoor() { return nullptr; }
-	virtual const Door* getDoor() const { return nullptr; }
+	virtual std::shared_ptr<Door> getDoor() { return nullptr; }
+	virtual std::shared_ptr<const Door> getDoor() const { return nullptr; }
 	virtual MagicField* getMagicField() { return nullptr; }
 	virtual const MagicField* getMagicField() const { return nullptr; }
 	virtual std::shared_ptr<BedItem> getBed() { return nullptr; }

--- a/src/item.h
+++ b/src/item.h
@@ -503,8 +503,8 @@ public:
 	virtual const Door* getDoor() const { return nullptr; }
 	virtual MagicField* getMagicField() { return nullptr; }
 	virtual const MagicField* getMagicField() const { return nullptr; }
-	virtual BedItem* getBed() { return nullptr; }
-	virtual const BedItem* getBed() const { return nullptr; }
+	virtual std::shared_ptr<BedItem> getBed() { return nullptr; }
+	virtual std::shared_ptr<const BedItem> getBed() const { return nullptr; }
 
 	std::string_view getStrAttr(itemAttrTypes type) const
 	{

--- a/src/luacontainer.cpp
+++ b/src/luacontainer.cpp
@@ -82,7 +82,8 @@ int luaContainerGetEmptySlots(lua_State* L)
 	uint32_t slots = container->capacity() - container->size();
 	if (getBoolean(L, 2, false)) {
 		for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-			if (Container* tmpContainer = (*it)->getContainer()) {
+			auto item = *it;
+			if (Container* tmpContainer = item->getContainer()) {
 				slots += tmpContainer->capacity() - tmpContainer->size();
 			}
 		}
@@ -114,9 +115,10 @@ int luaContainerGetItem(lua_State* L)
 	}
 
 	uint32_t index = getInteger<uint32_t>(L, 2);
-	Item* item = container->getItemByIndex(index);
+	auto item = container->getItemByIndex(index);
 	if (item) {
-		pushItem(L, item);
+		pushSharedPtr(L, item);
+		setItemMetatable(L, -1, item.get());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luagame.cpp
+++ b/src/luagame.cpp
@@ -452,7 +452,7 @@ int luaGameGetHouses(lua_State* L)
 
 	int index = 0;
 	for (auto& houseEntry : houses) {
-		pushUserdata<House>(L, houseEntry.second.get());
+		pushSharedPtr(L, houseEntry.second);
 		setMetatable(L, -1, "House");
 		lua_rawseti(L, -2, ++index);
 	}

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -298,14 +298,14 @@ int luaHouseStartTrade(lua_State* L)
 			return 1;
 		}
 
-		Item* transferItem = house->getTransferItem();
+		auto transferItem = house->getTransferItem();
 		if (!transferItem) {
 			lua_pushinteger(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
 			return 1;
 		}
 
 		transferItem->getParent()->setParent(player);
-		if (!g_game.internalStartTrade(player, tradePartner, transferItem)) {
+		if (!g_game.internalStartTrade(player, tradePartner, transferItem.get())) {
 			house->resetTransferItem();
 		}
 
@@ -342,14 +342,14 @@ int luaHouseStartTrade(lua_State* L)
 		return 1;
 	}
 
-	Item* transferItem = house->getTransferItem();
+	auto transferItem = house->getTransferItem();
 	if (!transferItem) {
 		lua_pushinteger(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
 		return 1;
 	}
 
 	transferItem->getParent()->setParent(player);
-	if (!g_game.internalStartTrade(player, tradePartner, transferItem)) {
+	if (!g_game.internalStartTrade(player, tradePartner, transferItem.get())) {
 		house->resetTransferItem();
 	}
 

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -304,7 +304,13 @@ int luaHouseStartTrade(lua_State* L)
 			return 1;
 		}
 
-		transferItem->getParent()->setParent(player);
+		Cylinder* parent = transferItem->getParent();
+		if (!parent) {
+			lua_pushinteger(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
+			return 1;
+		}
+
+		parent->setParent(player);
 		if (!g_game.internalStartTrade(player, tradePartner, transferItem.get())) {
 			house->resetTransferItem();
 		}
@@ -348,7 +354,13 @@ int luaHouseStartTrade(lua_State* L)
 		return 1;
 	}
 
-	transferItem->getParent()->setParent(player);
+	Cylinder* parent = transferItem->getParent();
+	if (!parent) {
+		lua_pushinteger(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
+		return 1;
+	}
+
+	parent->setParent(player);
 	if (!g_game.internalStartTrade(player, tradePartner, transferItem.get())) {
 		house->resetTransferItem();
 	}
@@ -449,13 +461,15 @@ int luaHouseGetTiles(lua_State* L)
 	}
 
 	const auto& tiles = house->getTiles();
-	lua_createtable(L, tiles.size(), 0);
+	lua_newtable(L);
 
 	int index = 0;
-	for (Tile* tile : tiles) {
-		pushUserdata<Tile>(L, tile);
-		setMetatable(L, -1, "Tile");
-		lua_rawseti(L, -2, ++index);
+	for (const auto& weakTile : tiles) {
+		if (auto tile = weakTile.lock()) {
+			pushUserdata<Tile>(L, tile.get());
+			setMetatable(L, -1, "Tile");
+			lua_rawseti(L, -2, ++index);
+		}
 	}
 	return 1;
 }
@@ -473,13 +487,15 @@ int luaHouseGetItems(lua_State* L)
 	lua_newtable(L);
 
 	int index = 0;
-	for (Tile* tile : tiles) {
-		TileItemVector* itemVector = tile->getItemList();
-		if (itemVector) {
-			for (const auto& item : *itemVector) {
-				pushSharedPtr(L, item);
-				setItemMetatable(L, -1, item.get());
-				lua_rawseti(L, -2, ++index);
+	for (const auto& weakTile : tiles) {
+		if (auto tile = weakTile.lock()) {
+			TileItemVector* itemVector = tile->getItemList();
+			if (itemVector) {
+				for (const auto& item : *itemVector) {
+					pushSharedPtr(L, item);
+					setItemMetatable(L, -1, item.get());
+					lua_rawseti(L, -2, ++index);
+				}
 			}
 		}
 	}
@@ -491,7 +507,7 @@ int luaHouseGetTileCount(lua_State* L)
 	// house:getTileCount()
 	const House* house = getUserdata<const House>(L, 1);
 	if (house) {
-		lua_pushinteger(L, house->getTiles().size());
+		lua_pushinteger(L, house->getTileCount());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -241,8 +241,7 @@ int luaHouseSetOwnerGuid(lua_State* L)
 		Player* previousPlayer = lua_gettop(L) >= 4 ? getUserdata<Player>(L, 4) : nullptr;
 
 		if (house->getType() == HOUSE_TYPE_GUILDHALL && guid_guild == 0) {
-			house->setOwner(0, updateDatabase, previousPlayer);
-			pushBoolean(L, true);
+			pushBoolean(L, house->setOwner(0, updateDatabase, previousPlayer));
 			return 1;
 		}
 
@@ -257,8 +256,7 @@ int luaHouseSetOwnerGuid(lua_State* L)
 				return 1;
 			}
 		}
-		house->setOwner(guid_guild, updateDatabase);
-		pushBoolean(L, true);
+		pushBoolean(L, house->setOwner(guid_guild, updateDatabase, previousPlayer));
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -22,7 +22,7 @@ int luaHouseCreate(lua_State* L)
 	// House(id)
 	auto house = g_game.map.houses.getHouse(getInteger<uint32_t>(L, 2));
 	if (house) {
-		pushUserdata<House>(L, house.get());
+		pushSharedPtr(L, house);
 		setMetatable(L, -1, "House");
 	} else {
 		lua_pushnil(L);
@@ -33,7 +33,7 @@ int luaHouseCreate(lua_State* L)
 int luaHouseGetId(lua_State* L)
 {
 	// house:getId()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getId());
 	} else {
@@ -45,7 +45,7 @@ int luaHouseGetId(lua_State* L)
 int luaHouseGetName(lua_State* L)
 {
 	// house:getName()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		pushString(L, house->getName());
 	} else {
@@ -57,7 +57,7 @@ int luaHouseGetName(lua_State* L)
 int luaHouseGetTown(lua_State* L)
 {
 	// house:getTown()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -76,7 +76,7 @@ int luaHouseGetTown(lua_State* L)
 int luaHouseGetExitPosition(lua_State* L)
 {
 	// house:getExitPosition()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		pushPosition(L, house->getEntryPosition());
 	} else {
@@ -88,7 +88,7 @@ int luaHouseGetExitPosition(lua_State* L)
 int luaHouseGetRent(lua_State* L)
 {
 	// house:getRent()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getRent());
 	} else {
@@ -100,7 +100,7 @@ int luaHouseGetRent(lua_State* L)
 int luaHouseSetRent(lua_State* L)
 {
 	// house:setRent(rent)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		uint32_t rent = getInteger<uint32_t>(L, 2);
 		house->setRent(rent);
@@ -114,7 +114,7 @@ int luaHouseSetRent(lua_State* L)
 int luaHouseGetPaidUntil(lua_State* L)
 {
 	// house:getPaidUntil()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getPaidUntil());
 	} else {
@@ -126,7 +126,7 @@ int luaHouseGetPaidUntil(lua_State* L)
 int luaHouseSetPaidUntil(lua_State* L)
 {
 	// house:setPaidUntil(timestamp)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		time_t timestamp = getInteger<time_t>(L, 2);
 		house->setPaidUntil(timestamp);
@@ -140,7 +140,7 @@ int luaHouseSetPaidUntil(lua_State* L)
 int luaHouseGetPayRentWarnings(lua_State* L)
 {
 	// house:getPayRentWarnings()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getPayRentWarnings());
 	} else {
@@ -152,7 +152,7 @@ int luaHouseGetPayRentWarnings(lua_State* L)
 int luaHouseSetPayRentWarnings(lua_State* L)
 {
 	// house:setPayRentWarnings(warnings)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		uint32_t warnings = getInteger<uint32_t>(L, 2);
 		house->setPayRentWarnings(warnings);
@@ -166,7 +166,7 @@ int luaHouseSetPayRentWarnings(lua_State* L)
 int luaHouseGetOwnerName(lua_State* L)
 {
 	// house:getOwnerName()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		pushString(L, house->getOwnerName());
 	} else {
@@ -178,7 +178,7 @@ int luaHouseGetOwnerName(lua_State* L)
 int luaHouseGetOwnerGuid(lua_State* L)
 {
 	// house:getOwnerGuid()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		if (house->getType() == HOUSE_TYPE_NORMAL) {
 			lua_pushinteger(L, house->getOwner());
@@ -194,7 +194,7 @@ int luaHouseGetOwnerGuid(lua_State* L)
 int luaHouseGetOwnerAccountId(lua_State* L)
 {
 	// house:getOwnerAccountId()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getOwnerAccountId());
 	} else {
@@ -206,7 +206,7 @@ int luaHouseGetOwnerAccountId(lua_State* L)
 int luaHouseGetType(lua_State* L)
 {
 	// house:getType()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getType());
 	} else {
@@ -218,7 +218,7 @@ int luaHouseGetType(lua_State* L)
 int luaHouseGetOwnerGuild(lua_State* L)
 {
 	// house:getOwnerGuild()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		if (house->getType() == HOUSE_TYPE_GUILDHALL) {
 			lua_pushinteger(L, house->getOwner());
@@ -234,7 +234,7 @@ int luaHouseGetOwnerGuild(lua_State* L)
 int luaHouseSetOwnerGuid(lua_State* L)
 {
 	// house:setOwnerGuid(guid[, updateDatabase = true[, player]])
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		uint32_t guid_guild = getInteger<uint32_t>(L, 2);
 		bool updateDatabase = getBoolean(L, 3, true);
@@ -268,7 +268,7 @@ int luaHouseSetOwnerGuid(lua_State* L)
 int luaHouseStartTrade(lua_State* L)
 {
 	// house:startTrade(player, tradePartner)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	Player* player = getUserdata<Player>(L, 2);
 	Player* tradePartner = getUserdata<Player>(L, 3);
 
@@ -372,7 +372,7 @@ int luaHouseStartTrade(lua_State* L)
 int luaHouseGetBeds(lua_State* L)
 {
 	// house:getBeds()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -392,7 +392,7 @@ int luaHouseGetBeds(lua_State* L)
 int luaHouseGetBedCount(lua_State* L)
 {
 	// house:getBedCount()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getBedCount());
 	} else {
@@ -404,7 +404,7 @@ int luaHouseGetBedCount(lua_State* L)
 int luaHouseGetDoors(lua_State* L)
 {
 	// house:getDoors()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -424,7 +424,7 @@ int luaHouseGetDoors(lua_State* L)
 int luaHouseGetDoorCount(lua_State* L)
 {
 	// house:getDoorCount()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getDoorCount());
 	} else {
@@ -436,7 +436,7 @@ int luaHouseGetDoorCount(lua_State* L)
 int luaHouseGetDoorIdByPosition(lua_State* L)
 {
 	// house:getDoorIdByPosition(position)
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -454,7 +454,7 @@ int luaHouseGetDoorIdByPosition(lua_State* L)
 int luaHouseGetTiles(lua_State* L)
 {
 	// house:getTiles()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -477,7 +477,7 @@ int luaHouseGetTiles(lua_State* L)
 int luaHouseGetItems(lua_State* L)
 {
 	// house:getItems()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -505,7 +505,7 @@ int luaHouseGetItems(lua_State* L)
 int luaHouseGetTileCount(lua_State* L)
 {
 	// house:getTileCount()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getTileCount());
 	} else {
@@ -517,7 +517,7 @@ int luaHouseGetTileCount(lua_State* L)
 int luaHouseCanEditAccessList(lua_State* L)
 {
 	// house:canEditAccessList(listId, player)
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -533,7 +533,7 @@ int luaHouseCanEditAccessList(lua_State* L)
 int luaHouseIsInvited(lua_State* L)
 {
 	// house:isInvited(player)
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -547,7 +547,7 @@ int luaHouseIsInvited(lua_State* L)
 int luaHouseCanModifyItems(lua_State* L)
 {
 	// house:canModifyItems(player)
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -561,7 +561,7 @@ int luaHouseCanModifyItems(lua_State* L)
 int luaHouseGetAccessList(lua_State* L)
 {
 	// house:getAccessList(listId)
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -579,7 +579,7 @@ int luaHouseGetAccessList(lua_State* L)
 int luaHouseSetAccessList(lua_State* L)
 {
 	// house:setAccessList(listId, list)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -595,7 +595,7 @@ int luaHouseSetAccessList(lua_State* L)
 int luaHouseKickPlayer(lua_State* L)
 {
 	// house:kickPlayer(player, targetPlayer)
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -608,7 +608,7 @@ int luaHouseKickPlayer(lua_State* L)
 int luaHouseSave(lua_State* L)
 {
 	// house:save()
-	const House* house = getUserdata<const House>(L, 1);
+	const House* house = getSharedUserdata<const House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -622,7 +622,7 @@ int luaHouseSave(lua_State* L)
 int luaHouseGetProtected(lua_State* L)
 {
 	// house:getProtected()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -634,7 +634,7 @@ int luaHouseGetProtected(lua_State* L)
 int luaHouseSetProtected(lua_State* L)
 {
 	// house:setProtected(protected)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -649,7 +649,7 @@ int luaHouseSetProtected(lua_State* L)
 int luaHouseAddProtectionGuest(lua_State* L)
 {
 	// house:addProtectionGuest(playerId)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -663,7 +663,7 @@ int luaHouseAddProtectionGuest(lua_State* L)
 int luaHouseRemoveProtectionGuest(lua_State* L)
 {
 	// house:removeProtectionGuest(playerId)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -677,7 +677,7 @@ int luaHouseRemoveProtectionGuest(lua_State* L)
 int luaHouseIsProtectionGuest(lua_State* L)
 {
 	// house:isProtectionGuest(playerId)
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -691,7 +691,7 @@ int luaHouseIsProtectionGuest(lua_State* L)
 int luaHouseGetProtectionGuests(lua_State* L)
 {
 	// house:getProtectionGuests()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -711,7 +711,7 @@ int luaHouseGetProtectionGuests(lua_State* L)
 int luaHouseGetRequiredReset(lua_State* L)
 {
 	// house:getRequiredReset()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (house) {
 		lua_pushinteger(L, house->getRequiredReset());
 	} else {
@@ -723,7 +723,7 @@ int luaHouseGetRequiredReset(lua_State* L)
 int luaHouseClearProtectionGuests(lua_State* L)
 {
 	// house:clearProtectionGuests()
-	House* house = getUserdata<House>(L, 1);
+	House* house = getSharedUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -741,6 +741,7 @@ void LuaScriptInterface::registerHouse()
 	// House
 	registerClass("House", "", luaHouseCreate);
 	registerMetaMethod("House", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("House", "__gc", LuaScriptInterface::luaSharedPtrGC<House>);
 
 	registerMethod("House", "getId", luaHouseGetId);
 	registerMethod("House", "getName", luaHouseGetName);

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -20,9 +20,9 @@ using namespace Lua;
 int luaHouseCreate(lua_State* L)
 {
 	// House(id)
-	House* house = g_game.map.houses.getHouse(getInteger<uint32_t>(L, 2));
+	auto house = g_game.map.houses.getHouse(getInteger<uint32_t>(L, 2));
 	if (house) {
-		pushUserdata<House>(L, house);
+		pushUserdata<House>(L, house.get());
 		setMetatable(L, -1, "House");
 	} else {
 		lua_pushnil(L);

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -430,7 +430,7 @@ int luaHouseGetDoorIdByPosition(lua_State* L)
 		return 1;
 	}
 
-	const Door* door = house->getDoorByPosition(getPosition(L, 2));
+	const auto door = house->getDoorByPosition(getPosition(L, 2));
 	if (door) {
 		lua_pushinteger(L, door->getDoorId());
 	} else {

--- a/src/luahouse.cpp
+++ b/src/luahouse.cpp
@@ -378,12 +378,12 @@ int luaHouseGetBeds(lua_State* L)
 		return 1;
 	}
 
-	const auto& beds = house->getBeds();
+	const auto beds = house->getBeds();
 	lua_createtable(L, beds.size(), 0);
 
 	int index = 0;
-	for (BedItem* bedItem : beds) {
-		pushItem(L, bedItem);
+	for (const auto& bedItem : beds) {
+		pushItem(L, bedItem.get());
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -410,12 +410,12 @@ int luaHouseGetDoors(lua_State* L)
 		return 1;
 	}
 
-	const auto& doors = house->getDoors();
+	const auto doors = house->getDoors();
 	lua_createtable(L, doors.size(), 0);
 
 	int index = 0;
-	for (Door* door : doors) {
-		pushItem(L, door);
+	for (const auto& door : doors) {
+		pushItem(L, door.get());
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -426,7 +426,7 @@ int luaHouseGetDoorCount(lua_State* L)
 	// house:getDoorCount()
 	const House* house = getUserdata<const House>(L, 1);
 	if (house) {
-		lua_pushinteger(L, house->getDoors().size());
+		lua_pushinteger(L, house->getDoorCount());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -3690,10 +3690,7 @@ int luaPlayerStartOfflineTraining(lua_State* L)
 		}
 		
 		Tile* tile = g_game.map.getTile(lookPosition);
-		BedItem* bed = nullptr;
-		if (tile) {
-			bed = tile->getBedItem();
-		}
+		std::shared_ptr<BedItem> bed = tile ? tile->getBedItem() : nullptr;
 		
 		if (bed) {
 			if (!player->isPremium()) {

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -2907,7 +2907,7 @@ int luaPlayerGetHouse(lua_State* L)
 
 	auto house = g_game.map.houses.getHouseByPlayerId(player->getGUID());
 	if (house) {
-		pushUserdata<House>(L, house.get());
+		pushSharedPtr(L, house);
 		setMetatable(L, -1, "House");
 	} else {
 		lua_pushnil(L);
@@ -2924,7 +2924,7 @@ int luaPlayerSendHouseWindow(lua_State* L)
 		return 1;
 	}
 
-	House* house = getUserdata<House>(L, 2);
+	House* house = getSharedUserdata<House>(L, 2);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -2945,7 +2945,7 @@ int luaPlayerSetEditHouse(lua_State* L)
 		return 1;
 	}
 
-	House* house = getUserdata<House>(L, 2);
+	House* house = getSharedUserdata<House>(L, 2);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -2905,9 +2905,9 @@ int luaPlayerGetHouse(lua_State* L)
 		return 1;
 	}
 
-	House* house = g_game.map.houses.getHouseByPlayerId(player->getGUID());
+	auto house = g_game.map.houses.getHouseByPlayerId(player->getGUID());
 	if (house) {
-		pushUserdata<House>(L, house);
+		pushUserdata<House>(L, house.get());
 		setMetatable(L, -1, "House");
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1113,6 +1113,20 @@ void Lua::setMetatable(lua_State* L, int32_t index, std::string_view name)
 {
 	luaL_getmetatable(L, name.data());
 	lua_setmetatable(L, index - 1);
+	if (name == "Tile") {
+		if (Tile** userdata = static_cast<Tile**>(lua_touserdata(L, index))) {
+			if (*userdata) {
+				std::weak_ptr<Tile> weakTile;
+				try {
+					weakTile = (*userdata)->weak_from_this();
+				} catch (const std::bad_weak_ptr&) {
+				}
+				new (lua_newuserdatauv(L, sizeof(std::weak_ptr<Tile>), 0))
+				    std::weak_ptr<Tile>(std::move(weakTile));
+				lua_setiuservalue(L, index - 1, 1);
+			}
+		}
+	}
 }
 
 void Lua::setWeakMetatable(lua_State* L, int32_t index, std::string_view name)
@@ -1211,6 +1225,32 @@ Creature* Lua::getValidatedCreatureUserdata(lua_State* L, int32_t arg)
 		return nullptr;
 	}
 	return rawCreature;
+}
+
+Tile* Lua::getValidatedTileUserdata(lua_State* L, int32_t arg)
+{
+	Tile* rawTile = nullptr;
+	if (Tile** userdata = static_cast<Tile**>(lua_touserdata(L, arg))) {
+		rawTile = *userdata;
+	}
+
+	const int userValueType = lua_getiuservalue(L, arg, 1);
+	if (userValueType == LUA_TUSERDATA) {
+		auto* weakPtr = static_cast<std::weak_ptr<Tile>*>(lua_touserdata(L, -1));
+		auto tileRef = weakPtr ? weakPtr->lock() : std::shared_ptr<Tile>{};
+		lua_pop(L, 1);
+
+		if (tileRef) {
+			return tileRef.get();
+		}
+
+		return nullptr;
+	}
+	if (userValueType != LUA_TNONE) {
+		lua_pop(L, 1);
+	}
+
+	return rawTile;
 }
 
 // Is

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4509,6 +4509,13 @@ int LuaScriptInterface::luaUserdataCompare(lua_State* L)
 		return 1;
 	}
 
+	if (typeA == LuaData_House || typeB == LuaData_House) {
+		Lua::pushBoolean(L,
+		                 typeA == typeB &&
+		                     Lua::getSharedUserdata<House>(L, 1) == Lua::getSharedUserdata<House>(L, 2));
+		return 1;
+	}
+
 	Lua::pushBoolean(L, Lua::getUserdata<void>(L, 1, false) == Lua::getUserdata<void>(L, 2, false));
 	return 1;
 }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1116,13 +1116,8 @@ void Lua::setMetatable(lua_State* L, int32_t index, std::string_view name)
 	if (name == "Tile") {
 		if (Tile** userdata = static_cast<Tile**>(lua_touserdata(L, index))) {
 			if (*userdata) {
-				std::weak_ptr<Tile> weakTile;
-				try {
-					weakTile = (*userdata)->weak_from_this();
-				} catch (const std::bad_weak_ptr&) {
-				}
 				new (lua_newuserdatauv(L, sizeof(std::weak_ptr<Tile>), 0))
-				    std::weak_ptr<Tile>(std::move(weakTile));
+				    std::weak_ptr<Tile>((*userdata)->weak_from_this());
 				lua_setiuservalue(L, index - 1, 1);
 			}
 		}
@@ -1229,11 +1224,6 @@ Creature* Lua::getValidatedCreatureUserdata(lua_State* L, int32_t arg)
 
 Tile* Lua::getValidatedTileUserdata(lua_State* L, int32_t arg)
 {
-	Tile* rawTile = nullptr;
-	if (Tile** userdata = static_cast<Tile**>(lua_touserdata(L, arg))) {
-		rawTile = *userdata;
-	}
-
 	const int userValueType = lua_getiuservalue(L, arg, 1);
 	if (userValueType == LUA_TUSERDATA) {
 		auto* weakPtr = static_cast<std::weak_ptr<Tile>*>(lua_touserdata(L, -1));
@@ -1246,11 +1236,9 @@ Tile* Lua::getValidatedTileUserdata(lua_State* L, int32_t arg)
 
 		return nullptr;
 	}
-	if (userValueType != LUA_TNONE) {
-		lua_pop(L, 1);
-	}
-
-	return rawTile;
+	lua_pop(L, 1);
+	// A Tile must have its ownership token; never revive an unvalidated raw address.
+	return nullptr;
 }
 
 // Is
@@ -4513,6 +4501,12 @@ int LuaScriptInterface::luaUserdataCompare(lua_State* L)
 		Lua::pushBoolean(L,
 		                 typeA == typeB &&
 		                     Lua::getSharedUserdata<House>(L, 1) == Lua::getSharedUserdata<House>(L, 2));
+		return 1;
+	}
+
+	if (typeA == LuaData_Tile || typeB == LuaData_Tile) {
+		const Tile* tile = Lua::getUserdata<Tile>(L, 1);
+		Lua::pushBoolean(L, typeA == typeB && tile && tile == Lua::getUserdata<Tile>(L, 2));
 		return 1;
 	}
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -574,6 +574,7 @@ private:
 
 	static int luaUserdataCompare(lua_State* L);
 	static int luaCreatureGC(lua_State* L);
+	static int luaTileGC(lua_State* L);
 	static int luaItemGC(lua_State* L);
 
 	static int luaIsType(lua_State* L);
@@ -910,6 +911,7 @@ inline std::unique_ptr<T> releaseOwnedUserdataPtr(lua_State* L, int32_t arg)
 }
 
 Creature* getValidatedCreatureUserdata(lua_State* L, int32_t arg);
+Tile* getValidatedTileUserdata(lua_State* L, int32_t arg);
 
 template <class T>
 inline T* getUserdata(lua_State* L, int32_t arg, const bool checkType = true)
@@ -922,6 +924,13 @@ inline T* getUserdata(lua_State* L, int32_t arg, const bool checkType = true)
 
 		Creature* creature = getValidatedCreatureUserdata(L, arg);
 		return creature ? dynamic_cast<T*>(creature) : nullptr;
+	} else if constexpr (std::is_base_of_v<Tile, RawT>) {
+		if (checkType && !isType<T>(L, arg)) {
+			return nullptr;
+		}
+
+		Tile* tile = getValidatedTileUserdata(L, arg);
+		return tile ? dynamic_cast<T*>(tile) : nullptr;
 	}
 
 	T** userdata = getRawUserdata<T>(L, arg, checkType);
@@ -1107,7 +1116,7 @@ inline void pushUserdata(lua_State* L, T* value, int nuvalue = 1)
 {
 	using RawT = std::remove_const_t<T>;
 	int uservalueCount = nuvalue;
-	if constexpr (std::is_base_of_v<Creature, RawT>) {
+	if constexpr (std::is_base_of_v<Creature, RawT> || std::is_base_of_v<Tile, RawT>) {
 		if (uservalueCount < 2) {
 			uservalueCount = 2;
 		}

--- a/src/luatile.cpp
+++ b/src/luatile.cpp
@@ -731,8 +731,12 @@ int luaTileGetHouse(lua_State* L)
 	}
 
 	if (HouseTile* houseTile = tile->getHouseTile()) {
-		pushUserdata<House>(L, houseTile->getHouse());
-		setMetatable(L, -1, "House");
+		if (auto house = houseTile->getHouse()) {
+			pushUserdata<House>(L, house.get());
+			setMetatable(L, -1, "House");
+		} else {
+			lua_pushnil(L);
+		}
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luatile.cpp
+++ b/src/luatile.cpp
@@ -744,11 +744,32 @@ int luaTileGetHouse(lua_State* L)
 }
 } // namespace
 
+int LuaScriptInterface::luaTileGC(lua_State* L)
+{
+	Tile** tilePtr = getRawUserdata<Tile>(L, 1);
+	if (tilePtr) {
+		*tilePtr = nullptr;
+	}
+
+	if (getAssociatedValue(L, 1, 1)) {
+		auto* weakPtr = static_cast<std::weak_ptr<Tile>*>(lua_touserdata(L, -1));
+		if (weakPtr) {
+			std::destroy_at(weakPtr);
+		}
+		lua_pop(L, 1);
+
+		lua_pushnil(L);
+		lua_setiuservalue(L, 1, 1);
+	}
+	return 0;
+}
+
 void LuaScriptInterface::registerTile()
 {
 	// Tile
 	registerClass("Tile", "", luaTileCreate);
 	registerMetaMethod("Tile", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Tile", "__gc", LuaScriptInterface::luaTileGC);
 
 	registerMethod("Tile", "remove", luaTileRemove);
 

--- a/src/luatile.cpp
+++ b/src/luatile.cpp
@@ -49,8 +49,7 @@ int luaTileRemove(lua_State* L)
 		g_game.removeTileToClean(tile);
 	}
 
-	g_game.map.removeTile(tile->getPosition());
-	pushBoolean(L, true);
+	pushBoolean(L, g_game.map.removeTile(tile->getPosition()));
 	return 1;
 }
 

--- a/src/luatile.cpp
+++ b/src/luatile.cpp
@@ -732,7 +732,7 @@ int luaTileGetHouse(lua_State* L)
 
 	if (HouseTile* houseTile = tile->getHouseTile()) {
 		if (auto house = houseTile->getHouse()) {
-			pushUserdata<House>(L, house.get());
+			pushSharedPtr(L, house);
 			setMetatable(L, -1, "House");
 		} else {
 			lua_pushnil(L);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5,6 +5,7 @@
 
 #include "map.h"
 
+#include "bed.h"
 #include "combat.h"
 #include "creature.h"
 #include "game.h"
@@ -231,6 +232,42 @@ bool Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 	// Keep the original object alive without holding a reference to its map slot.
 	auto tile = tilePair.first;
 	if (tile) {
+		// Finish occupied sleep sessions before removing any tile contents. A
+		// failed offline load/save must not destroy earlier down-items. Do not
+		// remove beds in this pass either: another sleeper may still fail.
+		{
+			std::vector<std::shared_ptr<BedItem>> bedsToWake;
+			if (Item* ground = tile->getGround()) {
+				if (auto bed = ground->getBed(); bed && bed->getSleeper() != 0) {
+					bedsToWake.push_back(std::move(bed));
+				}
+			}
+			if (const TileItemVector* items = tile->getItemList()) {
+				for (const auto& item : *items) {
+					if (!item) {
+						continue;
+					}
+					if (auto bed = item->getBed(); bed && bed->getSleeper() != 0) {
+						bedsToWake.push_back(std::move(bed));
+					}
+				}
+			}
+			for (const auto& bed : bedsToWake) {
+				if (bed->isRemoved() || bed->getSleeper() == 0 || tile->getThingIndex(bed.get()) == -1) {
+					continue;
+				}
+				auto sleeper = g_game.getPlayerByGUID(bed->getSleeper());
+				const bool wokeUp = bed->wakeUp(sleeper.get());
+				// Appearance callbacks may remove/recreate the source tile.
+				if (tilePair.first != tile) {
+					return true;
+				}
+				if (!wokeUp) {
+					return false;
+				}
+			}
+		}
+
 		if (const CreatureVector* creatures = tile->getCreatures()) {
 			const auto snapshot = *creatures;
 			for (auto it = snapshot.rbegin(); it != snapshot.rend(); ++it) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -246,13 +246,13 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 				if (!item || item->isRemoved()) {
 					continue;
 				}
-				g_game.internalRemoveItem(item.get(), -1, false, FLAG_NOLIMIT);
+				g_game.internalRemoveItem(item.get(), -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE);
 			}
 		}
 
 		Item* ground = tile->getGround();
 		if (ground) {
-			g_game.internalRemoveItem(ground, -1, false, FLAG_NOLIMIT);
+			g_game.internalRemoveItem(ground, -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE);
 			tile->setGround(nullptr);
 		}
 		// Unregister HouseTile from its House before releasing

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -252,19 +252,13 @@ bool Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 					}
 				}
 			}
-			for (const auto& bed : bedsToWake) {
-				if (bed->isRemoved() || bed->getSleeper() == 0 || tile->getThingIndex(bed.get()) == -1) {
-					continue;
-				}
-				auto sleeper = g_game.getPlayerByGUID(bed->getSleeper());
-				const bool wokeUp = bed->wakeUp(sleeper.get());
-				// Appearance callbacks may remove/recreate the source tile.
-				if (tilePair.first != tile) {
-					return true;
-				}
-				if (!wokeUp) {
-					return false;
-				}
+			const bool wokeUp = BedItem::wakeUpAll(bedsToWake);
+			// Appearance callbacks may remove/recreate the source tile.
+			if (tilePair.first != tile) {
+				return true;
+			}
+			if (!wokeUp) {
+				return false;
 			}
 		}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -241,14 +241,18 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 		}
 
 		if (TileItemVector* items = tile->getItemList()) {
-			for (auto it = items->begin(), end = items->end(); it != end; ++it) {
-				g_game.internalRemoveItem(it->get());
+			std::vector<std::shared_ptr<Item>> itemsToRemove(items->begin(), items->end());
+			for (const auto& item : itemsToRemove) {
+				if (!item || item->isRemoved()) {
+					continue;
+				}
+				g_game.internalRemoveItem(item.get(), -1, false, FLAG_NOLIMIT);
 			}
 		}
 
 		Item* ground = tile->getGround();
 		if (ground) {
-			g_game.internalRemoveItem(ground);
+			g_game.internalRemoveItem(ground, -1, false, FLAG_NOLIMIT);
 			tile->setGround(nullptr);
 		}
 		

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -209,33 +209,42 @@ void Map::setTile(uint16_t x, uint16_t y, uint8_t z, std::unique_ptr<Tile> newTi
 	}
 }
 
-void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
+bool Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 {
 	if (z >= MAP_MAX_LAYERS) {
-		return;
+		return false;
 	}
 
 	const QTreeLeafNode* leaf = QTreeNode::getLeafStatic<const QTreeLeafNode*, const QTreeNode*>(&root, x, y);
 	if (!leaf) {
-		return;
+		return false;
 	}
 
 	Floor* floor = const_cast<Floor*>(leaf->getFloor(z));
 	if (!floor) {
-		return;
+		return false;
 	}
 
 	auto& tilePair = floor->tiles[x & FLOOR_MASK][y & FLOOR_MASK];
-	Zones::unregisterPosition(Position(x, y, z));
 
-	auto& tile = tilePair.first;
+	// Callbacks can recursively remove this tile and even recreate its position.
+	// Keep the original object alive without holding a reference to its map slot.
+	auto tile = tilePair.first;
 	if (tile) {
 		if (const CreatureVector* creatures = tile->getCreatures()) {
-			for (int32_t i = creatures->size(); --i >= 0;) {
-				if (Player* player = (*creatures)[i]->getPlayer()) {
+			const auto snapshot = *creatures;
+			for (auto it = snapshot.rbegin(); it != snapshot.rend(); ++it) {
+				const auto& creature = *it;
+				if (!creature || creature->isRemoved() || creature->getTile() != tile.get()) {
+					continue;
+				}
+				if (Player* player = creature->getPlayer()) {
 					g_game.internalTeleport(player, player->getTown()->getTemplePosition(), false, FLAG_NOLIMIT);
 				} else {
-					g_game.removeCreature((*creatures)[i].get());
+					g_game.removeCreature(creature.get());
+				}
+				if (tilePair.first != tile) {
+					return true;
 				}
 			}
 		}
@@ -243,16 +252,30 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 		if (TileItemVector* items = tile->getItemList()) {
 			std::vector<std::shared_ptr<Item>> itemsToRemove(items->begin(), items->end());
 			for (const auto& item : itemsToRemove) {
-				if (!item || item->isRemoved()) {
+				if (!item || item->isRemoved() || tile->getThingIndex(item.get()) == -1) {
 					continue;
 				}
-				g_game.internalRemoveItem(item.get(), -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE);
+				const auto ret = g_game.internalRemoveItem(item.get(), -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE);
+				if (tilePair.first != tile) {
+					return true;
+				}
+				if (ret != RETURNVALUE_NOERROR) {
+					// In particular, an offline sleeper's failed save must keep
+					// the occupied bed, its tile and zone registrations alive.
+					return false;
+				}
 			}
 		}
 
 		Item* ground = tile->getGround();
 		if (ground) {
-			g_game.internalRemoveItem(ground, -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE);
+			const auto ret = g_game.internalRemoveItem(ground, -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE);
+			if (tilePair.first != tile) {
+				return true;
+			}
+			if (ret != RETURNVALUE_NOERROR) {
+				return false;
+			}
 			tile->setGround(nullptr);
 		}
 		// Unregister HouseTile from its House before releasing
@@ -263,11 +286,13 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 		}
 
 		// Reset shared_ptr to release the tile
-		tile.reset();
+		tilePair.first.reset();
 	}
-	
+
+	Zones::unregisterPosition(Position(x, y, z));
 	// Also clear cache
 	tilePair.second = 0;
+	return true;
 }
 
 bool Map::placeCreature(const Position& centerPos, Creature* creature, bool extendedPos /* = false*/,
@@ -330,6 +355,9 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 	Item* toItem = nullptr;
 
 	Cylinder* toCylinder = tile->queryDestination(index, *creature, &toItem, flags, creature->getInstanceID());
+	if (!toCylinder || toCylinder == &Tile::nullptr_tile) {
+		return false;
+	}
 	toCylinder->internalAddThing(creature);
 
 	const Position& dest = toCylinder->getPosition();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -200,6 +200,11 @@ void Map::setTile(uint16_t x, uint16_t y, uint8_t z, std::unique_ptr<Tile> newTi
 	}
 
 	if (tile) {
+		if (HouseTile* houseTile = tile->getHouseTile()) {
+			if (auto house = houseTile->getHouse()) {
+				house->addTile(houseTile);
+			}
+		}
 		Zones::registerPositionZones(Position(x, y, z), tile->getZoneIds());
 	}
 }
@@ -1339,6 +1344,14 @@ Tile* Floor::getTile(uint16_t x, uint16_t y, uint8_t z) {
 	
 	tilePair.first = MapCacheUtils::createTileFromBasic(basicTile, x, y, z, g_game.map.houses);
 	tilePair.second = 0; // Clear cache
+
+	if (tilePair.first) {
+		if (HouseTile* houseTile = tilePair.first->getHouseTile()) {
+			if (auto house = houseTile->getHouse()) {
+				house->addTile(houseTile);
+			}
+		}
+	}
 	
 	return tilePair.first.get();
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -255,7 +255,13 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 			g_game.internalRemoveItem(ground, -1, false, FLAG_NOLIMIT);
 			tile->setGround(nullptr);
 		}
-		
+		// Unregister HouseTile from its House before releasing
+		if (HouseTile* houseTile = tile->getHouseTile()) {
+			if (auto house = houseTile->getHouse()) {
+				house->removeTile(houseTile);
+			}
+		}
+
 		// Reset shared_ptr to release the tile
 		tile.reset();
 	}

--- a/src/map.h
+++ b/src/map.h
@@ -234,11 +234,11 @@ public:
 	}
 
 	/**
-	 * Removes a single tile.
+	 * Removes a single tile. Returns false if removal cannot be completed.
 	 */
 
-	void removeTile(uint16_t x, uint16_t y, uint8_t z);
-	void removeTile(const Position& pos) { removeTile(pos.x, pos.y, pos.z); }
+	bool removeTile(uint16_t x, uint16_t y, uint8_t z);
+	bool removeTile(const Position& pos) { return removeTile(pos.x, pos.y, pos.z); }
 
 	/**
 	 * Place a creature on the map

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -1068,7 +1068,7 @@ std::unique_ptr<Tile> createTileFromBasic(const BasicTile* basicTile,
     if (basicTile->isHouse()) {
         auto house = houses.getHouse(basicTile->houseId);
         if (house) {
-            auto houseTile = std::make_unique<HouseTile>(x, y, z, house.get());
+            auto houseTile = std::make_unique<HouseTile>(x, y, z, house);
             house->addTile(houseTile.get());
             tile = std::move(houseTile);
         } else {

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -1019,7 +1019,7 @@ std::shared_ptr<Item> createItemFromBasic(const std::shared_ptr<BasicItem>& basi
     
     // Handle door/depot ID
     if (basicItem->doorOrDepotId != 0) {
-        if (Door* door = item->getDoor()) {
+        if (auto door = item->getDoor()) {
             door->setDoorId(basicItem->doorOrDepotId);
         } else if (Container* container = item->getContainer()) {
             if (DepotLocker* depot = container->getDepotLocker()) {

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -1068,9 +1068,7 @@ std::unique_ptr<Tile> createTileFromBasic(const BasicTile* basicTile,
     if (basicTile->isHouse()) {
         auto house = houses.getHouse(basicTile->houseId);
         if (house) {
-            auto houseTile = std::make_unique<HouseTile>(x, y, z, house);
-            house->addTile(houseTile.get());
-            tile = std::move(houseTile);
+            tile = std::make_unique<HouseTile>(x, y, z, house);
         } else {
             LOG_ERROR(fmt::format("[MapCache] House not found for houseId {}", basicTile->houseId));
             tile = std::make_unique<StaticTile>(x, y, z);

--- a/src/mapcache.cpp
+++ b/src/mapcache.cpp
@@ -1066,9 +1066,9 @@ std::unique_ptr<Tile> createTileFromBasic(const BasicTile* basicTile,
     
     // Create appropriate tile type
     if (basicTile->isHouse()) {
-        House* house = houses.getHouse(basicTile->houseId);
+        auto house = houses.getHouse(basicTile->houseId);
         if (house) {
-            auto houseTile = std::make_unique<HouseTile>(x, y, z, house);
+            auto houseTile = std::make_unique<HouseTile>(x, y, z, house.get());
             house->addTile(houseTile.get());
             tile = std::move(houseTile);
         } else {

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -359,6 +359,21 @@ ReturnValue MoveEvents::onPlayerDeEquip(Player* player, Item* item, slots_t slot
 
 uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 {
+	// Lua callbacks can remove the tile or other items in this event batch.
+	// Keep the original objects alive and do not iterate a mutating tile list.
+	const auto tileRef = tile->weak_from_this().lock();
+	const auto itemRef = item->weak_from_this().lock();
+	const Position pos = tile->getPosition();
+	std::vector<std::shared_ptr<Item>> tileItems;
+	for (size_t i = tile->getFirstIndex(), end = tile->getLastIndex(); i < end; ++i) {
+		Thing* thing = tile->getThing(i);
+		if (Item* tileItem = thing ? thing->getItem() : nullptr; tileItem && tileItem != item) {
+			if (auto ref = tileItem->weak_from_this().lock()) {
+				tileItems.push_back(std::move(ref));
+			}
+		}
+	}
+
 	MoveEvent_t eventType1, eventType2;
 	if (isAdd) {
 		eventType1 = MOVE_EVENT_ADD_ITEM;
@@ -371,28 +386,22 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 	uint32_t ret = 1;
 	MoveEvent* moveEvent = getEvent(tile, eventType1);
 	if (moveEvent) {
-		ret &= moveEvent->fireAddRemItem(item, nullptr, tile->getPosition());
+		ret &= moveEvent->fireAddRemItem(item, nullptr, pos);
 	}
 
 	moveEvent = getEvent(item, eventType1);
 	if (moveEvent) {
-		ret &= moveEvent->fireAddRemItem(item, nullptr, tile->getPosition());
+		ret &= moveEvent->fireAddRemItem(item, nullptr, pos);
 	}
 
-	for (size_t i = tile->getFirstIndex(), j = tile->getLastIndex(); i < j; ++i) {
-		Thing* thing = tile->getThing(i);
-		if (!thing) {
+	for (const auto& tileItem : tileItems) {
+		if (tileItem->isRemoved() || tile->getThingIndex(tileItem.get()) == -1) {
 			continue;
 		}
 
-		Item* tileItem = thing->getItem();
-		if (!tileItem || tileItem == item) {
-			continue;
-		}
-
-		moveEvent = getEvent(tileItem, eventType2);
+		moveEvent = getEvent(tileItem.get(), eventType2);
 		if (moveEvent) {
-			ret &= moveEvent->fireAddRemItem(item, tileItem, tile->getPosition());
+			ret &= moveEvent->fireAddRemItem(item, tileItem.get(), pos);
 		}
 	}
 	return ret;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -744,11 +744,11 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 					Container* quiverContainer = rightItem->getContainer();
 					if (quiverContainer) {
 						for (ContainerIterator cit = quiverContainer->iterator(); cit.hasNext(); cit.advance()) {
-							Item* quiverAmmo = *cit;
+							auto quiverAmmo = *cit;
 							if (quiverAmmo->getAmmoType() == it.ammoType) {
-								const Weapon* quiverAmmoWeapon = g_weapons->getWeapon(quiverAmmo);
+								const Weapon* quiverAmmoWeapon = g_weapons->getWeapon(quiverAmmo.get());
 								if (quiverAmmoWeapon && quiverAmmoWeapon->ammoCheck(this)) {
-									return quiverAmmo;
+									return quiverAmmo.get();
 								}
 							}
 						}
@@ -2136,18 +2136,21 @@ void Player::sendAddContainerItem(const Container* container, const Item* item)
 		}
 
 		uint16_t slot = openContainer.index;
+		std::shared_ptr<Item> itemToSendRef;
 		const Item* itemToSend = item;
 		if (container->getID() == ITEM_BROWSEFIELD && container->size() > 0) {
 			const uint16_t containerSize = static_cast<uint16_t>(container->size() - 1);
 			const uint16_t pageEnd = openContainer.index + static_cast<uint16_t>(container->capacity()) - 1;
 			if (containerSize > pageEnd) {
 				slot = pageEnd;
-				itemToSend = container->getItemByIndex(pageEnd);
+				itemToSendRef = container->getItemByIndex(pageEnd);
+				itemToSend = itemToSendRef.get();
 			} else {
 				slot = containerSize;
 			}
 		} else if (openContainer.index >= container->capacity()) {
-			itemToSend = container->getItemByIndex(openContainer.index);
+			itemToSendRef = container->getItemByIndex(openContainer.index);
+			itemToSend = itemToSendRef.get();
 		}
 
 		if (itemToSend) {
@@ -2218,10 +2221,11 @@ void Player::sendRemoveContainerItem(const Container* container, uint16_t slot)
 		}
 
 		const uint32_t capacity = container->capacity();
-		const Item* lastItem = capacity > 0 ?
-		                           container->getItemByIndex(firstIndex + static_cast<uint16_t>(capacity)) :
-		                           nullptr;
-		client->sendRemoveContainerItem(it->first, std::max<uint16_t>(slot, firstIndex), lastItem);
+		std::shared_ptr<Item> lastItem;
+		if (capacity > 0) {
+			lastItem = container->getItemByIndex(firstIndex + static_cast<uint16_t>(capacity));
+		}
+		client->sendRemoveContainerItem(it->first, std::max<uint16_t>(slot, firstIndex), lastItem.get());
 		++it;
 	}
 }
@@ -4312,7 +4316,8 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 
 					// iterate through all items, including sub-containers (deep search)
 					for (ContainerIterator it = subContainer->iterator(); it.hasNext(); it.advance()) {
-						if (Container* tmpContainer = (*it)->getContainer()) {
+						auto containerItem = *it;
+						if (Container* tmpContainer = containerItem->getContainer()) {
 							queryCount = 0;
 							tmpContainer->queryMaxCount(INDEX_WHEREEVER, *item, item->getItemCount(), queryCount,
 							                            flags);
@@ -4700,8 +4705,9 @@ uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/, boo
 
 		if (Container* container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-				if ((*it)->getID() == itemId) {
-					count += Item::countByType(*it, subType);
+				auto containerItem = *it;
+				if (containerItem->getID() == itemId) {
+					count += Item::countByType(containerItem.get(), subType);
 				}
 			}
 		}
@@ -4739,7 +4745,8 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 			}
 		} else if (Container* container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-				Item* containerItem = *it;
+				auto containerItemRef = *it;
+				Item* containerItem = containerItemRef.get();
 				if (containerItem->getID() == itemId) {
 					uint32_t itemCount = Item::countByType(containerItem, subType);
 					if (itemCount == 0) {
@@ -4772,7 +4779,8 @@ std::unordered_map<uint32_t, uint32_t>& Player::getAllItemTypeCount(std::unorder
 
 		if (Container* container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-				countMap[(*it)->getID()] += Item::countByType(*it, -1);
+				auto containerItem = *it;
+				countMap[containerItem->getID()] += Item::countByType(containerItem.get(), -1);
 			}
 		}
 	}
@@ -6978,7 +6986,7 @@ Container* Player::findGoldPouch() const
 
 			if (const auto container = storeItem->getContainer()) {
 				for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-					Item* item = *it;
+					auto item = *it;
 					if (item && item->getID() == ITEM_GOLD_POUCH) {
 						return item->getContainer();
 					}
@@ -7003,7 +7011,7 @@ Container* Player::findGoldPouch() const
 		}
 
 		for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-			Item* item = *it;
+			auto item = *it;
 			if (item && item->getID() == ITEM_GOLD_POUCH) {
 				return item->getContainer();
 			}
@@ -7043,11 +7051,11 @@ void Player::lootCorpse(Container* container)
 		sendTextMessage(MESSAGE_EVENT_ORANGE, "Your store inbox is unavailable. Items will fall back to backpack.");
 	}
 
-	std::vector<std::pair<Item*, uint16_t>> toMove;
+	std::vector<std::pair<std::shared_ptr<Item>, uint16_t>> toMove;
 
 	AutoLootMap::iterator iter;
 	for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-		Item* item = *it;
+		auto item = *it;
 		if (autolootConfig.lootAnything) {
 			toMove.push_back(std::make_pair(item, 0));
 		} else {
@@ -7058,7 +7066,7 @@ void Player::lootCorpse(Container* container)
 		}
 	}
 
-	std::vector<std::pair<Item*, uint64_t>> moneyItemsToDeposit;
+	std::vector<std::pair<std::shared_ptr<Item>, uint64_t>> moneyItemsToDeposit;
 	std::unordered_set<Item*> queuedMoneyItems;
 	bool missingGoldPouchMessageSent = false;
 	bool skipCoinMessageSent = false;
@@ -7138,7 +7146,8 @@ void Player::lootCorpse(Container* container)
 	};
 
 	for (const auto& pair : toMove) {
-		Item* item = pair.first;
+		const auto& itemRef = pair.first;
+		Item* item = itemRef.get();
 		const uint16_t itemId = item->getID();
 		const int64_t rawWorth = item->getWorth();
 		const uint64_t value = rawWorth > 0 ? static_cast<uint64_t>(rawWorth) : 0;
@@ -7158,7 +7167,7 @@ void Player::lootCorpse(Container* container)
 				}
 			}
 			if (autobankEnabled) {
-				moneyItemsToDeposit.emplace_back(item, value);
+				moneyItemsToDeposit.emplace_back(itemRef, value);
 				continue;
 			}
 		}
@@ -7167,14 +7176,14 @@ void Player::lootCorpse(Container* container)
 	}
 
 	if (autolootConfig.goldEnabled) {
-		std::vector<Item*> moneyItemsToMove;
+		std::vector<std::shared_ptr<Item>> moneyItemsToMove;
 		for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-			Item* goldItem = *it;
+			auto goldItem = *it;
 			const uint16_t itemId = goldItem->getID();
 			const int64_t rawWorth = goldItem->getWorth();
 			const uint64_t worth = rawWorth > 0 ? static_cast<uint64_t>(rawWorth) : 0;
-			if (moneyIds.contains(itemId) && worth > 0 && !queuedMoneyItems.contains(goldItem)) {
-				queuedMoneyItems.insert(goldItem);
+			if (moneyIds.contains(itemId) && worth > 0 && !queuedMoneyItems.contains(goldItem.get())) {
+				queuedMoneyItems.insert(goldItem.get());
 				if (autobankEnabled) {
 					moneyItemsToDeposit.emplace_back(goldItem, worth);
 				} else {
@@ -7183,15 +7192,15 @@ void Player::lootCorpse(Container* container)
 			}
 		}
 
-		for (Item* goldItem : moneyItemsToMove) {
-			moveAutolootItem(goldItem);
+		for (const auto& goldItem : moneyItemsToMove) {
+			moveAutolootItem(goldItem.get());
 		}
 	}
 
 	uint64_t totalDepositValue = 0;
 	if (autobankEnabled) {
 		for (const auto& [item, value] : moneyItemsToDeposit) {
-			if (g_game.internalRemoveItem(item, item->getItemCount()) == RETURNVALUE_NOERROR) {
+			if (g_game.internalRemoveItem(item.get(), item->getItemCount()) == RETURNVALUE_NOERROR) {
 				totalDepositValue += value;
 			}
 		}
@@ -7247,7 +7256,7 @@ Container* findHeldContainerByIdentity(Container* parent, uint16_t itemId, uint6
 	}
 
 	for (ContainerIterator it = parent->iterator(); it.hasNext(); it.advance()) {
-		Item* item = *it;
+		auto item = *it;
 		if (!item) {
 			continue;
 		}
@@ -7543,7 +7552,7 @@ void Player::addPendingLoot(std::string monsterName, Container* corpse)
 	group->killCount++;
 
 	for (ContainerIterator it = corpse->iterator(); it.hasNext(); it.advance()) {
-		Item* item = *it;
+		auto item = *it;
 		if (!item) {
 			continue;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2297,8 +2297,7 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin)
 
 		updateRegeneration();
 
-		BedItem* bed = g_game.getBedBySleeper(guid);
-		if (bed) {
+		if (auto bed = g_game.getBedBySleeper(guid)) {
 			bed->wakeUp(this);
 		}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -7034,7 +7034,9 @@ Container* Player::getOrCreateGoldPouchPage(Container* pouch)
 
 void Player::lootCorpse(Container* container)
 {
-	if (!container) {
+	const auto corpseRef = g_game.getContainerSharedRef(container);
+	const auto playerRef = weak_from_this().lock();
+	if (!corpseRef || container->isRemoved()) {
 		return;
 	}
 
@@ -7052,8 +7054,10 @@ void Player::lootCorpse(Container* container)
 	const bool autobankEnabled = ConfigManager::getBoolean(ConfigManager::AUTOLOOT_AUTO_BANK);
 	const bool autolootGoldPouchEnabled = ConfigManager::getBoolean(ConfigManager::AUTOLOOT_GOLD_POUCH);
 
-	auto goldPouchDestination = autolootGoldPouchEnabled ? findGoldPouch() : nullptr;
-	auto storeInboxDestination = getStoreInbox();
+	const auto goldPouchRef = g_game.getContainerSharedRef(autolootGoldPouchEnabled ? findGoldPouch() : nullptr);
+	const auto storeInboxRef = g_game.getContainerSharedRef(getStoreInbox());
+	auto goldPouchDestination = goldPouchRef.get();
+	auto storeInboxDestination = storeInboxRef.get();
 	if (goldPouchDestination && !storeInboxDestination) {
 		sendTextMessage(MESSAGE_EVENT_ORANGE, "Your store inbox is unavailable. Items will fall back to backpack.");
 	}
@@ -7078,13 +7082,29 @@ void Player::lootCorpse(Container* container)
 	bool missingGoldPouchMessageSent = false;
 	bool skipCoinMessageSent = false;
 
+	auto isPendingLoot = [&](const Item* item) {
+		if (!item || item->isRemoved() || container->isRemoved() || isRemoved()) {
+			return false;
+		}
+		for (const Cylinder* parent = item->getParent(); parent; parent = parent->getParent()) {
+			// Loot-all may already have moved the enclosing bag to the player.
+			if (parent == container || parent == this) {
+				return true;
+			}
+		}
+		return false;
+	};
+
 	auto moveAutolootItem = [&](Item* item, uint16_t backpackId = 0) {
+		if (!isPendingLoot(item)) {
+			return false;
+		}
 		ReturnValue ret;
 		Cylinder* primaryDestination = nullptr;
 		Cylinder* fallbackDestination = nullptr;
 		bool usedGoldPouch = false;
 
-		if (autolootGoldPouchEnabled && goldPouchDestination) {
+		if (autolootGoldPouchEnabled && goldPouchDestination && !goldPouchDestination->isRemoved()) {
 			primaryDestination = goldPouchDestination;
 			fallbackDestination = storeInboxDestination;
 			usedGoldPouch = true;
@@ -7102,7 +7122,7 @@ void Player::lootCorpse(Container* container)
 			fallbackDestination = storeInboxDestination;
 		}
 
-		ret = g_game.internalMoveItem(container, primaryDestination, INDEX_WHEREEVER, item,
+		ret = g_game.internalMoveItem(item->getParent(), primaryDestination, INDEX_WHEREEVER, item,
 		                                          item->getItemCount(), nullptr);
 		if (ret == RETURNVALUE_NOERROR) {
 			return true;
@@ -7112,8 +7132,11 @@ void Player::lootCorpse(Container* container)
 			return false;
 		}
 
-		if (fallbackDestination && fallbackDestination != primaryDestination) {
-			ret = g_game.internalMoveItem(container, fallbackDestination, INDEX_WHEREEVER, item,
+		if (!isPendingLoot(item)) {
+			return false;
+		}
+		if (fallbackDestination && !fallbackDestination->isRemoved() && fallbackDestination != primaryDestination) {
+			ret = g_game.internalMoveItem(item->getParent(), fallbackDestination, INDEX_WHEREEVER, item,
 			                                          item->getItemCount(), nullptr);
 			if (ret == RETURNVALUE_NOERROR) {
 				if (usedGoldPouch) {
@@ -7134,10 +7157,13 @@ void Player::lootCorpse(Container* container)
 			return false;
 		}
 
+		if (!isPendingLoot(item)) {
+			return false;
+		}
 		auto backpackItem = getInventoryItem(CONST_SLOT_BACKPACK);
 		auto backpack = backpackItem ? backpackItem->getContainer() : nullptr;
 		if (backpack) {
-			ret = g_game.internalMoveItem(container, backpack, INDEX_WHEREEVER, item, item->getItemCount(), nullptr);
+			ret = g_game.internalMoveItem(item->getParent(), backpack, INDEX_WHEREEVER, item, item->getItemCount(), nullptr);
 			if (ret == RETURNVALUE_NOERROR) {
 				sendTextMessage(MESSAGE_STATUS_SMALL, "Your store inbox is full. Item sent to backpack.");
 				return true;
@@ -7155,6 +7181,9 @@ void Player::lootCorpse(Container* container)
 	for (const auto& pair : toMove) {
 		const auto& itemRef = pair.first;
 		Item* item = itemRef.get();
+		if (!isPendingLoot(item)) {
+			continue;
+		}
 		const uint16_t itemId = item->getID();
 		const int64_t rawWorth = item->getWorth();
 		const uint64_t value = rawWorth > 0 ? static_cast<uint64_t>(rawWorth) : 0;
@@ -7207,7 +7236,8 @@ void Player::lootCorpse(Container* container)
 	uint64_t totalDepositValue = 0;
 	if (autobankEnabled) {
 		for (const auto& [item, value] : moneyItemsToDeposit) {
-			if (g_game.internalRemoveItem(item.get(), item->getItemCount()) == RETURNVALUE_NOERROR) {
+			if (isPendingLoot(item.get()) &&
+			    g_game.internalRemoveItem(item.get(), item->getItemCount()) == RETURNVALUE_NOERROR) {
 				totalDepositValue += value;
 			}
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4721,7 +4721,7 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 		return true;
 	}
 
-	std::vector<Item*> itemList;
+	std::vector<std::shared_ptr<Item>> itemList;
 
 	uint32_t count = 0;
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
@@ -4736,7 +4736,7 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 				continue;
 			}
 
-			itemList.push_back(item);
+			itemList.push_back(inventory[i]);
 
 			count += itemCount;
 			if (count >= amount) {
@@ -4753,7 +4753,7 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 						continue;
 					}
 
-					itemList.push_back(containerItem);
+					itemList.push_back(containerItemRef);
 
 					count += itemCount;
 					if (count >= amount) {
@@ -4807,14 +4807,18 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 
 	if (link == LINK_OWNER) {
 		// calling movement scripts
-		g_moveEvents->onPlayerEquip(this, thing->getItem(), static_cast<slots_t>(index), false);
+		if (g_moveEvents) {
+			g_moveEvents->onPlayerEquip(this, thing->getItem(), static_cast<slots_t>(index), false);
+		}
 		if (isInventorySlot(static_cast<slots_t>(index))) {
 			Item* item = thing->getItem();
 			if (item && item->hasImbuements()) {
 				addItemImbuements(thing->getItem(), static_cast<slots_t>(index));
 			}
 		}
-		g_events->eventPlayerOnUpdateInventory(this, thing->getItem(), static_cast<slots_t>(index), true);
+		if (g_events) {
+			g_events->eventPlayerOnUpdateInventory(this, thing->getItem(), static_cast<slots_t>(index), true);
+		}
 	}
 
 	bool requireListUpdate = false;
@@ -4872,14 +4876,18 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 {
 	if (link == LINK_OWNER) {
 		// calling movement scripts
-		g_moveEvents->onPlayerDeEquip(this, thing->getItem(), static_cast<slots_t>(index));
+		if (g_moveEvents) {
+			g_moveEvents->onPlayerDeEquip(this, thing->getItem(), static_cast<slots_t>(index));
+		}
 		if (isInventorySlot(static_cast<slots_t>(index))) {
 			Item* item = thing->getItem();
 			if (item && item->hasImbuements()) {
 				removeItemImbuements(thing->getItem(), static_cast<slots_t>(index));
 			}
 		}
-		g_events->eventPlayerOnUpdateInventory(this, thing->getItem(), static_cast<slots_t>(index), false);
+		if (g_events) {
+			g_events->eventPlayerOnUpdateInventory(this, thing->getItem(), static_cast<slots_t>(index), false);
+		}
 	}
 
 	bool requireListUpdate = false;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -8058,8 +8058,7 @@ void Player::handleNamelockManager(const std::string& text, std::ostringstream& 
 			                    Database::getInstance().escapeString(managerData.string1), guid))) {
 				Database::getInstance().executeQuery(
 				    fmt::format("DELETE FROM `player_namelocks` WHERE `player_id` = {:d}", guid));
-
-				if (House* house = g_game.map.houses.getHouseByPlayerId(guid)) {
+				if (auto house = g_game.map.houses.getHouseByPlayerId(guid)) {
 					house->updateOwnerName(managerData.string1);
 				}
 

--- a/src/save_manager.cpp
+++ b/src/save_manager.cpp
@@ -190,6 +190,72 @@ bool SaveManager::savePlayerSync(Player* player)
 	return success;
 }
 
+bool SaveManager::savePlayersSync(const std::vector<Player*>& players)
+{
+	if (!g_dispatcher.isDispatcherThread()) {
+		LOG_ERROR("[SaveManager] savePlayersSync must be called on the dispatcher thread.");
+		return false;
+	}
+	if (players.empty()) {
+		return true;
+	}
+	Database& db = Database::getInstance();
+	if (db.isInTransaction()) {
+		// A nested BEGIN/COMMIT would commit the caller's transaction.
+		return false;
+	}
+
+	std::unordered_set<uint32_t> guids;
+	std::vector<IOLoginData::PlayerSaveSnapshot> saves;
+	saves.reserve(players.size());
+	for (Player* player : players) {
+		if (!player || hasPendingPlayerSave(player->getGUID()) || hasFailedRecovery(player->getGUID()) ||
+		    !guids.insert(player->getGUID()).second) {
+			return false;
+		}
+		auto save = IOLoginData::buildPlayerSave(player);
+		if (!save) {
+			return false;
+		}
+		saves.push_back(std::move(*save));
+	}
+
+	struct FlushGuard {
+		std::unordered_set<uint32_t>& inFlight;
+		const std::unordered_set<uint32_t>& guids;
+		~FlushGuard()
+		{
+			for (uint32_t guid : guids) {
+				inFlight.erase(guid);
+			}
+		}
+	} guard{flushInFlight, guids};
+	flushInFlight.insert(guids.begin(), guids.end());
+
+	// Only SQL belongs inside the retryable transaction. In particular, do not
+	// call flushPlayerSave here: it would start/commit a transaction per player.
+	if (!DBTransaction::executeWithinTransactionRollbackOnFailure([&db, &saves]() {
+		for (const auto& save : saves) {
+			for (const auto& query : save.queries) {
+				if (!db.executeQuery(query)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	})) {
+		return false;
+	}
+	for (size_t i = 0; i < players.size(); ++i) {
+		const auto& save = saves[i];
+		players[i]->acknowledgeStorageDirty(Player::StorageDirtySnapshot{
+		    save.storageSnapshotId, save.snapshotModifiedKeys, save.snapshotRemovedKeys});
+		players[i]->acknowledgeBestiaryDirty(Player::BestiaryDirtySnapshot{
+		    save.bestiarySnapshotId, save.snapshotModifiedBestiaryRaceIds});
+	}
+	return true;
+}
+
 void SaveManager::drainPlayerFlushAsync(uint32_t guid, std::function<void(bool)> callback)
 {
 	g_dispatcher.addTask([this, guid, callback = std::move(callback)]() mutable {

--- a/src/save_manager.h
+++ b/src/save_manager.h
@@ -26,6 +26,8 @@ public:
 	bool savePlayer(Player* player);
 	void saveMapAsync();
 	bool savePlayerSync(Player* player);
+	// All-or-nothing synchronous batch. Never queues behind another save.
+	bool savePlayersSync(const std::vector<Player*>& players);
 
 	// Dispatcher-thread only, like the save queue bookkeeping itself.
 	[[nodiscard]] bool hasPendingPlayerSave(uint32_t guid) const noexcept

--- a/src/save_manager.h
+++ b/src/save_manager.h
@@ -27,6 +27,12 @@ public:
 	void saveMapAsync();
 	bool savePlayerSync(Player* player);
 
+	// Dispatcher-thread only, like the save queue bookkeeping itself.
+	[[nodiscard]] bool hasPendingPlayerSave(uint32_t guid) const noexcept
+	{
+		return flushInFlight.contains(guid) || pendingFlushes.contains(guid);
+	}
+
 	/**
 	 * @brief Non-blocking: invokes callback(bool) when pending save operations for
 	 * the given GUID have been fully persisted to the database (or on timeout).

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -12,12 +12,15 @@
 #include "../inbox.h"
 #include "../item.h"
 #include "../luascript.h"
+#include "../movement.h"
 #include "../player.h"
 #include "../scriptmanager.h"
 #include "../storeinbox.h"
 #include "../vocation.h"
+#include "../zones.h"
 
 #include "test_support.h"
+#include <cstddef>
 #include <memory>
 
 extern bool isValidItemPointer(Item* item);
@@ -50,6 +53,31 @@ public:
 	lua_State* L = nullptr;
 	bool prevWarnUnsafe{false};
 	bool prevConvertUnsafe{false};
+};
+
+struct MoveEventsFixture
+{
+	LuaFixture lua;
+	MoveEvents events;
+	MoveEvents* previous = g_moveEvents;
+
+	MoveEventsFixture() { g_moveEvents = &events; }
+	~MoveEventsFixture() { g_moveEvents = previous; }
+};
+
+// These players are placed directly on tiles, without online registry/DB state.
+struct TilePlayersGuard
+{
+	std::vector<std::shared_ptr<Player>> players;
+	~TilePlayersGuard()
+	{
+		for (const auto& player : players) {
+			if (auto tile = player->getTileShared()) {
+				tile->removeThing(player.get(), 0);
+			}
+			player->setParent(nullptr);
+		}
+	}
 };
 
 struct ItemTypePropertyGuard
@@ -294,6 +322,8 @@ struct OfflineSleeperState
 {
 	uint32_t guid = 0;
 	uint32_t loadedGuid = 0;
+	bool failLoad = false;
+	bool failSave = false;
 	int loadCount = 0;
 	int saveCount = 0;
 	int32_t savedHealth = 0;
@@ -311,7 +341,7 @@ protected:
 	{
 		++state.loadCount;
 		state.loadedGuid = guid;
-		if (guid != state.guid) {
+		if (state.failLoad || guid != state.guid) {
 			return false;
 		}
 
@@ -332,6 +362,9 @@ protected:
 	bool saveOfflineSleeper(Player* player) const override
 	{
 		++state.saveCount;
+		if (state.failSave) {
+			return false;
+		}
 		state.savedHealth = player->getHealth();
 		state.savedMana = player->getMana();
 		state.savedSoul = player->getSoul();
@@ -401,8 +434,8 @@ TEST_CASE(item_get_door_returns_nullptr_for_regular_item_and_valid_shared_ptr_fo
 	// Regular Item returns nullptr
 	auto regularItem = std::make_shared<Item>(100);
 	CHECK(regularItem->getDoor() == nullptr);
-	const auto& constRegularItem = regularItem;
-	CHECK(constRegularItem->getDoor() == nullptr);
+	const Item& constRegularItem = *regularItem;
+	CHECK(constRegularItem.getDoor() == nullptr);
 
 	// Door returns valid shared_ptr and preserves identity
 	auto door = std::make_shared<Door>(0);
@@ -415,8 +448,8 @@ TEST_CASE(item_get_door_returns_nullptr_for_regular_item_and_valid_shared_ptr_fo
 	CHECK(nonConstDoor.get() == rawDoor);
 	CHECK(nonConstDoor->getDoorId() == 45);
 
-	const auto& constDoor = door;
-	std::shared_ptr<const Door> constDoorRef = constDoor->getDoor();
+	const Door& constDoor = *door;
+	std::shared_ptr<const Door> constDoorRef = constDoor.getDoor();
 	CHECK(constDoorRef != nullptr);
 	CHECK(constDoorRef == door);
 	CHECK(constDoorRef.get() == rawDoor);
@@ -459,8 +492,8 @@ TEST_CASE(item_get_bed_returns_nullptr_for_regular_item_and_valid_shared_ptr_for
 	// Regular Item returns nullptr
 	auto regularItem = std::make_shared<Item>(100);
 	CHECK(regularItem->getBed() == nullptr);
-	const auto& constRegularItem = regularItem;
-	CHECK(constRegularItem->getBed() == nullptr);
+	const Item& constRegularItem = *regularItem;
+	CHECK(constRegularItem.getBed() == nullptr);
 
 	// BedItem returns valid shared_ptr and preserves identity
 	auto bed = std::make_shared<BedItem>(694);
@@ -471,8 +504,8 @@ TEST_CASE(item_get_bed_returns_nullptr_for_regular_item_and_valid_shared_ptr_for
 	CHECK(nonConstBed == bed);
 	CHECK(nonConstBed.get() == rawBed);
 
-	const auto& constBed = bed;
-	std::shared_ptr<const BedItem> constBedRef = constBed->getBed();
+	const BedItem& constBed = *bed;
+	std::shared_ptr<const BedItem> constBedRef = constBed.getBed();
 	CHECK(constBedRef != nullptr);
 	CHECK(constBedRef == bed);
 	CHECK(constBedRef.get() == rawBed);
@@ -1547,6 +1580,10 @@ TEST_CASE(orphan_house_tile_fails_closed_for_players_and_allows_map_cleanup)
 	uint32_t destinationFlags = 0;
 	CHECK(orphanTile->queryDestination(destinationIndex, *player, &destinationItem, destinationFlags, 0) ==
 	      &Tile::nullptr_tile);
+	// Forced placement must not attach the player to the sentinel tile or
+	// dereference the nonexistent quadtree node at its fallback coordinates.
+	CHECK(!g_game.map.placeCreature(pos, player.get(), false, true));
+	CHECK(player->getParent() == nullptr);
 
 	// A nested container must not bypass the expired House permissions.
 	bool prevOnlyInvited = ConfigManager::getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS);
@@ -1796,6 +1833,161 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 	CHECK(weakBed.expired());
 }
 
+namespace {
+
+void checkFailedOfflineBedRemoval(bool failSave, bool removeWholeTile, bool removePartner)
+{
+	ensureItemTypes();
+	ensureVocations();
+
+	// Keep injected state and partner directions alive until map cleanup, even
+	// when a CHECK throws while an occupied bed is still attached to its tile.
+	OfflineSleeperState offlineState;
+	offlineState.guid = 913;
+	ItemTypePropertyGuard bedTypeGuard(694);
+	ItemTypePropertyGuard partnerTypeGuard(695);
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+	Item::items.getItemType(695).bedPartnerDir = DIRECTION_NORTH;
+	MapTileGuard tileGuard;
+	struct FailureGuard {
+		OfflineSleeperState& state;
+		~FailureGuard() { state.failLoad = state.failSave = false; }
+	} failureGuard{offlineState};
+
+	const Position bedPos{172, 170, 7};
+	const Position partnerPos{172, 171, 7};
+	constexpr ZoneId zoneId = 913;
+	auto house = std::make_shared<House>(913);
+	for (const auto& pos : {bedPos, partnerPos}) {
+		tileGuard.track(pos.x, pos.y, pos.z);
+		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->setZoneIds({zoneId});
+		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
+	}
+
+	auto bed = std::make_shared<OfflineTestBedItem>(694, offlineState);
+	auto partnerBed = std::make_shared<OfflineTestBedItem>(695, offlineState);
+	g_game.map.getTile(bedPos)->internalAddThing(bed.get());
+	g_game.map.getTile(partnerPos)->internalAddThing(partnerBed.get());
+	TilePlayersGuard players{{makeTestPlayer(offlineState.guid, "OfflineSleepingPlayer")}};
+	auto player = players.players.front();
+	CHECK(player->setVocation(0));
+	// No online registration: exercise the real sleep/regen logic without DB.
+	g_game.map.getTile(bedPos)->internalAddThing(player.get());
+	CHECK(bed->sleep(player.get()));
+	player->getTile()->removeThing(player.get(), 0);
+	player->setParent(nullptr);
+	CHECK(g_game.getPlayerByGUID(offlineState.guid) == nullptr);
+
+	PropWriteStream writeStream;
+	writeStream.write<uint32_t>(static_cast<uint32_t>(std::time(nullptr) - 1800));
+	const auto sleepStart = writeStream.getStream();
+	for (const auto& half : {bed, partnerBed}) {
+		PropStream readStream;
+		readStream.init(sleepStart.data(), sleepStart.size());
+		CHECK(half->readAttr(ATTR_SLEEPSTART, readStream) == ATTR_READ_CONTINUE);
+	}
+	auto sleepAttributes = [](const BedItem& half) {
+		PropWriteStream stream;
+		half.serializeAttr(stream);
+		return std::string(stream.getStream());
+	};
+	const auto bedAttributes = sleepAttributes(*bed);
+	const auto partnerAttributes = sleepAttributes(*partnerBed);
+	const auto bedId = bed->getID();
+	const auto partnerId = partnerBed->getID();
+	const std::string bedDescription(bed->getSpecialDescription());
+	const std::string partnerDescription(partnerBed->getSpecialDescription());
+	const Position targetPos = removePartner ? partnerPos : bedPos;
+	auto targetBed = removePartner ? partnerBed : bed;
+	Tile* targetTile = g_game.map.getTile(targetPos);
+	Item* ground = targetTile->getGround();
+
+	offlineState.failLoad = !failSave;
+	offlineState.failSave = failSave;
+	CHECK(g_game.internalRemoveItem(targetBed.get(), -1, true, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE) ==
+	      RETURNVALUE_NOERROR);
+	CHECK(offlineState.loadCount == 0);
+	CHECK(offlineState.saveCount == 0);
+	CHECK(!targetBed->wakeUp(nullptr));
+	if (removeWholeTile) {
+		CHECK(!g_game.map.removeTile(targetPos));
+	} else {
+		CHECK(g_game.internalRemoveItem(targetBed.get(), -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE) ==
+		      RETURNVALUE_NOTPOSSIBLE);
+	}
+	g_game.cleanup();
+
+	CHECK(offlineState.loadCount == 2);
+	CHECK(offlineState.saveCount == (failSave ? 2 : 0));
+	CHECK(offlineState.savedHealth == 0);
+	CHECK(offlineState.savedMana == 0);
+	CHECK(offlineState.savedSoul == 0);
+	CHECK(g_game.map.getTile(targetPos) == targetTile);
+	CHECK(targetTile->getGround() == ground);
+	CHECK(targetTile->getThingIndex(targetBed.get()) != -1);
+	CHECK(!targetBed->isRemoved());
+	CHECK(house->getBeds().size() == 2);
+	CHECK(house->getTileCount() == 2);
+	CHECK(g_game.getBedBySleeper(offlineState.guid) == bed);
+	CHECK(bed->getSleeper() == offlineState.guid);
+	CHECK(partnerBed->getSleeper() == offlineState.guid);
+	CHECK(sleepAttributes(*bed) == bedAttributes);
+	CHECK(sleepAttributes(*partnerBed) == partnerAttributes);
+	CHECK(bed->getID() == bedId);
+	CHECK(partnerBed->getID() == partnerId);
+	CHECK(bed->getSpecialDescription() == bedDescription);
+	CHECK(partnerBed->getSpecialDescription() == partnerDescription);
+	CHECK(Zones::getZonesByPosition(targetPos) == std::vector<ZoneId>{zoneId});
+
+	// Recovery must grant the original session once and only then remove it.
+	offlineState.failLoad = offlineState.failSave = false;
+	if (removeWholeTile) {
+		CHECK(g_game.map.removeTile(targetPos));
+		CHECK(g_game.map.getTile(targetPos) == nullptr);
+		CHECK(Zones::getZonesByPosition(targetPos).empty());
+	} else {
+		CHECK(g_game.internalRemoveItem(targetBed.get(), -1, false, FLAG_NOLIMIT | FLAG_IGNORECANREMOVE) ==
+		      RETURNVALUE_NOERROR);
+		CHECK(g_game.map.getTile(targetPos) == targetTile);
+	}
+	g_game.cleanup();
+	CHECK(offlineState.loadCount == 3);
+	CHECK(offlineState.saveCount == (failSave ? 3 : 1));
+	CHECK(offlineState.savedHealth == 70);
+	CHECK(offlineState.savedMana == 70);
+	CHECK(offlineState.savedSoul == 2);
+	CHECK(targetBed->isRemoved());
+	CHECK(house->getBeds().size() == 1);
+	CHECK(bed->getSleeper() == 0);
+	CHECK(partnerBed->getSleeper() == 0);
+	CHECK(g_game.getBedBySleeper(offlineState.guid) == nullptr);
+	CHECK(targetBed->wakeUp(nullptr));
+	CHECK(offlineState.loadCount == 3);
+	CHECK(offlineState.saveCount == (failSave ? 3 : 1));
+}
+
+} // namespace
+
+TEST_CASE(offline_bed_load_failure_preserves_sleep_until_removal_retry)
+{
+	for (bool removeWholeTile : {false, true}) {
+		for (bool removePartner : {false, true}) {
+			checkFailedOfflineBedRemoval(false, removeWholeTile, removePartner);
+		}
+	}
+}
+
+TEST_CASE(offline_bed_save_failure_preserves_sleep_until_removal_retry)
+{
+	for (bool removeWholeTile : {false, true}) {
+		for (bool removePartner : {false, true}) {
+			checkFailedOfflineBedRemoval(true, removeWholeTile, removePartner);
+		}
+	}
+}
+
 TEST_CASE(lua_tile_userdata_is_invalidated_after_map_removal)
 {
 	ensureItemTypes();
@@ -1988,6 +2180,200 @@ TEST_CASE(lua_house_shared_userdata_preserves_identity_and_idempotent_gc)
 	                    "collectgarbage('collect')") == LUA_OK);
 	CHECK(weakHouse.expired());
 	CHECK(player->getEditHouse(windowTextId, listId) == nullptr);
+}
+
+TEST_CASE(house_access_list_kicks_survive_tile_and_creature_removal_callbacks)
+{
+	ensureItemTypes();
+	MapTileGuard tileGuard;
+	MoveEventsFixture fixture;
+	const bool previousOwnedByAccount = ConfigManager::getBoolean(ConfigManager::HOUSE_OWNED_BY_ACCOUNT);
+	struct AccountOwnershipGuard {
+		bool previous;
+		~AccountOwnershipGuard() { ConfigManager::setBoolean(ConfigManager::HOUSE_OWNED_BY_ACCOUNT, previous); }
+	} accountGuard{previousOwnedByAccount};
+	ConfigManager::setBoolean(ConfigManager::HOUSE_OWNED_BY_ACCOUNT, false);
+
+	const Position firstPos{180, 180, 7};
+	const Position secondPos{181, 180, 7};
+	const Position exitPos{182, 180, 7};
+	auto house = std::make_shared<House>(930);
+	house->setEntryPos(exitPos);
+	for (const auto& pos : {firstPos, secondPos}) {
+		tileGuard.track(pos.x, pos.y, pos.z);
+		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+		tile->internalAddThing(std::make_shared<Item>(100).get());
+		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
+	}
+	tileGuard.track(exitPos.x, exitPos.y, exitPos.z);
+	auto exitTile = std::make_unique<DynamicTile>(exitPos.x, exitPos.y, exitPos.z);
+	exitTile->internalAddThing(std::make_shared<Item>(100).get());
+	g_game.map.setTile(exitPos.x, exitPos.y, exitPos.z, std::move(exitTile));
+
+	TilePlayersGuard players{{makeTestPlayer(930, "FirstGuest"), makeTestPlayer(931, "SecondGuest"),
+	                          makeTestPlayer(932, "ThirdGuest")}};
+	g_game.map.getTile(firstPos)->internalAddThing(players.players[0].get());
+	g_game.map.getTile(firstPos)->internalAddThing(players.players[1].get());
+	g_game.map.getTile(secondPos)->internalAddThing(players.players[2].get());
+
+	bool callbackRan = false;
+	auto event = std::make_unique<MoveEvent>(fixture.events.getScriptInterfacePtr());
+	event->setEventType(MOVE_EVENT_STEP_OUT);
+	event->addPosList(firstPos);
+	event->stepFunction = [&](Creature*, Item*, const Position&) {
+		if (!callbackRan) {
+			callbackRan = true;
+			// Remove another entry from the live creature vector and erase the
+			// current house-list node before the original kick returns.
+			CHECK(g_game.internalTeleport(players.players[1].get(), exitPos, true, 0, CONST_ME_NONE) ==
+			      RETURNVALUE_NOERROR);
+			g_game.map.removeTile(firstPos);
+		}
+		return 1;
+	};
+	CHECK(fixture.events.registerLuaEvent(event.release()));
+
+	house->setAccessList(GUEST_LIST, "");
+	CHECK(callbackRan);
+	CHECK(g_game.map.getTile(firstPos) == nullptr);
+	CHECK(house->getTileCount() == 1);
+	for (const auto& player : players.players) {
+		CHECK(player->getPosition() == exitPos);
+	}
+}
+
+TEST_CASE(removal_callbacks_can_remove_and_recreate_the_source_tile)
+{
+	ensureItemTypes();
+	for (bool removeWholeTile : {false, true}) {
+		MapTileGuard tileGuard;
+		MoveEventsFixture fixture;
+		const Position pos{190, 190, 7};
+		tileGuard.track(pos.x, pos.y, pos.z);
+		auto house = std::make_shared<House>(940);
+		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+		tile->internalAddThing(std::make_shared<Item>(100).get());
+		auto originalItem = std::make_shared<Item>(2160);
+		tile->internalAddThing(originalItem.get());
+		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
+		std::weak_ptr<Tile> oldTile = g_game.map.getTile(pos)->weak_from_this();
+
+		auto replacementItem = std::make_shared<Item>(2160);
+		bool callbackRan = false;
+		auto event = std::make_unique<MoveEvent>(fixture.events.getScriptInterfacePtr());
+		event->setEventType(MOVE_EVENT_REMOVE_ITEM);
+		event->addPosList(pos);
+		event->moveFunction = [&](Item*, Item*, const Position&) {
+			if (!callbackRan) {
+				callbackRan = true;
+				g_game.map.removeTile(pos);
+				CHECK(g_game.map.getTile(pos) == nullptr);
+				CHECK(!oldTile.expired()); // The outer notification still uses this object.
+				auto replacement = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+				replacement->internalAddThing(std::make_shared<Item>(100).get());
+				replacement->internalAddThing(replacementItem.get());
+				g_game.map.setTile(pos.x, pos.y, pos.z, std::move(replacement));
+			}
+			return 1;
+		};
+		CHECK(fixture.events.registerLuaEvent(event.release()));
+
+		if (removeWholeTile) {
+			g_game.map.removeTile(pos);
+		} else {
+			CHECK(g_game.internalRemoveItem(originalItem.get()) == RETURNVALUE_NOERROR);
+		}
+		CHECK(callbackRan);
+		CHECK(oldTile.expired());
+		CHECK(originalItem->isRemoved());
+		CHECK(g_game.map.getTile(pos) != nullptr);
+		CHECK(replacementItem->getParent() == g_game.map.getTile(pos));
+		CHECK(house->getTileCount() == 1);
+	}
+	g_game.cleanup();
+}
+
+TEST_CASE(map_removal_does_not_remove_items_moved_away_by_callbacks)
+{
+	ensureItemTypes();
+	ItemTypePropertyGuard itemTypeGuard(2160);
+	Item::items.getItemType(2160).stackable = false;
+	Item::items.getItemType(2160).moveable = true;
+	MapTileGuard tileGuard;
+	MoveEventsFixture fixture;
+	const Position sourcePos{191, 190, 7};
+	const Position destinationPos{192, 190, 7};
+	for (const auto& pos : {sourcePos, destinationPos}) {
+		tileGuard.track(pos.x, pos.y, pos.z);
+		auto tile = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
+		tile->internalAddThing(std::make_shared<Item>(100).get());
+		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
+	}
+	Tile* source = g_game.map.getTile(sourcePos);
+	source->internalAddThing(std::make_shared<Item>(2160).get());
+	source->internalAddThing(std::make_shared<Item>(2160).get());
+	const auto movedItem = (*source->getItemList())[1];
+	bool callbackRan = false;
+	auto event = std::make_unique<MoveEvent>(fixture.events.getScriptInterfacePtr());
+	event->setEventType(MOVE_EVENT_REMOVE_ITEM);
+	event->addPosList(sourcePos);
+	event->moveFunction = [&](Item*, Item*, const Position&) {
+		if (!callbackRan) {
+			callbackRan = true;
+			CHECK(g_game.internalMoveItem(source, g_game.map.getTile(destinationPos), INDEX_WHEREEVER,
+			                              movedItem.get(), movedItem->getItemCount(), nullptr, FLAG_NOLIMIT) ==
+			      RETURNVALUE_NOERROR);
+		}
+		return 1;
+	};
+	CHECK(fixture.events.registerLuaEvent(event.release()));
+
+	g_game.map.removeTile(sourcePos);
+	CHECK(callbackRan);
+	CHECK(movedItem->getParent() == g_game.map.getTile(destinationPos));
+	CHECK(!movedItem->isRemoved());
+	g_game.cleanup();
+}
+
+TEST_CASE(lua_tile_equality_rejects_reused_addresses_and_missing_ownership_tokens)
+{
+	LuaFixture fixture;
+	lua_State* L = fixture.L;
+	alignas(DynamicTile) std::byte storage[sizeof(DynamicTile)];
+	auto makeTile = [&] {
+		return std::shared_ptr<DynamicTile>(
+		    std::construct_at(reinterpret_cast<DynamicTile*>(storage), 195, 195, 7),
+		    [](DynamicTile* tile) { std::destroy_at(tile); });
+	};
+	auto tile = makeTile();
+	Lua::pushUserdata<Tile>(L, tile.get());
+	Lua::setMetatable(L, -1, "Tile");
+	lua_setglobal(L, "oldTile");
+	tile.reset();
+	tile = makeTile(); // Deterministic ABA: a different object at exactly the same address.
+	for (const char* name : {"newTile", "newTileAlias"}) {
+		Lua::pushUserdata<Tile>(L, tile.get());
+		Lua::setMetatable(L, -1, "Tile");
+		lua_setglobal(L, name);
+	}
+	CHECK(luaL_dostring(L,
+	                    "assert(oldTile:getPosition() == nil)\n"
+	                    "assert(oldTile ~= newTile and newTile ~= oldTile)\n"
+	                    "assert(newTile == newTileAlias)\n"
+	                    "local gc = rawgetmetatable('Tile').__gc\n"
+	                    "gc(oldTile)\n"
+	                    "gc(oldTile)\n"
+	                    "assert(oldTile:getPosition() == nil)") == LUA_OK);
+
+	// An unvalidated raw pointer must not bypass the weak-token check, and
+	// lua_getiuservalue's nil result must be popped even when no slot exists.
+	*static_cast<Tile**>(lua_newuserdatauv(L, sizeof(Tile*), 0)) = tile.get();
+	luaL_getmetatable(L, "Tile");
+	lua_setmetatable(L, -2);
+	const int top = lua_gettop(L);
+	CHECK(Lua::getUserdata<Tile>(L, -1) == nullptr);
+	CHECK(lua_gettop(L) == top);
+	lua_pop(L, 1);
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -3,14 +3,18 @@
 #include "../bed.h"
 #include "../chat.h"
 #include "../configmanager.h"
+#include "../depotchest.h"
+#include "../depotlocker.h"
 #include "../events.h"
 #include "../game.h"
 #include "../globalevent.h"
 #include "../house.h"
+#include "../inbox.h"
 #include "../item.h"
 #include "../luascript.h"
 #include "../player.h"
 #include "../scriptmanager.h"
+#include "../storeinbox.h"
 #include "../vocation.h"
 
 #include "test_support.h"
@@ -285,6 +289,58 @@ std::shared_ptr<Player> makeTestPlayer(uint32_t guid, std::string_view name)
 	player->setGroup(std::make_shared<Group>());
 	return player;
 }
+
+struct OfflineSleeperState
+{
+	uint32_t guid = 0;
+	uint32_t loadedGuid = 0;
+	int loadCount = 0;
+	int saveCount = 0;
+	int32_t savedHealth = 0;
+	uint32_t savedMana = 0;
+	uint8_t savedSoul = 0;
+};
+
+class OfflineTestBedItem final : public BedItem
+{
+public:
+	OfflineTestBedItem(uint16_t id, OfflineSleeperState& state) : BedItem(id), state(state) {}
+
+protected:
+	bool loadOfflineSleeper(Player* player, uint32_t guid) const override
+	{
+		++state.loadCount;
+		state.loadedGuid = guid;
+		if (guid != state.guid) {
+			return false;
+		}
+
+		player->setGUID(guid);
+		player->setName("OfflineSleepingPlayer");
+		player->setGroup(std::make_shared<Group>());
+		if (!player->setVocation(0)) {
+			return false;
+		}
+		player->setMaxHealth(100);
+		player->setHealth(10);
+		player->setMaxMana(100);
+		player->setMana(10);
+		return player->addCondition(
+		    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_REGENERATION, -1, 0));
+	}
+
+	bool saveOfflineSleeper(Player* player) const override
+	{
+		++state.saveCount;
+		state.savedHealth = player->getHealth();
+		state.savedMana = player->getMana();
+		state.savedSoul = player->getSoul();
+		return true;
+	}
+
+private:
+	OfflineSleeperState& state;
+};
 
 TEST_CASE(door_can_use_and_access_list_behavior)
 {
@@ -1303,7 +1359,7 @@ TEST_CASE(bed_reparenting_between_houses_and_destruction_lifetime)
 	houseB->setOwner(0);
 }
 
-TEST_CASE(flag_nolimit_vs_can_remove_semantics)
+TEST_CASE(map_cleanup_flag_is_distinct_from_flag_nolimit)
 {
 	ensureItemTypes();
 	const Position pos{144, 144, 7};
@@ -1325,14 +1381,20 @@ TEST_CASE(flag_nolimit_vs_can_remove_semantics)
 	CHECK(!bed->canRemove());
 	CHECK(house->getBeds().size() == 1);
 
-	// Normal removal without FLAG_NOLIMIT fails because canRemove() is false
+	// Normal removal fails because canRemove() is false.
 	ReturnValue normalRet = g_game.internalRemoveItem(bed.get(), 1, false, 0);
 	CHECK(normalRet == RETURNVALUE_NOTPOSSIBLE);
 	CHECK(!bed->isRemoved());
 	CHECK(house->getBeds().size() == 1);
 
-	// Forced removal with FLAG_NOLIMIT bypasses canRemove() constraint
-	ReturnValue forcedRet = g_game.internalRemoveItem(bed.get(), 1, false, FLAG_NOLIMIT);
+	// FLAG_NOLIMIT controls cylinder limits; it must not bypass Item::canRemove().
+	ReturnValue noLimitRet = g_game.internalRemoveItem(bed.get(), 1, false, FLAG_NOLIMIT);
+	CHECK(noLimitRet == RETURNVALUE_NOTPOSSIBLE);
+	CHECK(!bed->isRemoved());
+	CHECK(house->getBeds().size() == 1);
+
+	// Map teardown uses the explicit internal cleanup flag.
+	ReturnValue forcedRet = g_game.internalRemoveItem(bed.get(), 1, false, FLAG_IGNORECANREMOVE);
 	CHECK(forcedRet == RETURNVALUE_NOERROR);
 	CHECK(bed->isRemoved());
 	CHECK(house->getBeds().empty());
@@ -1340,6 +1402,46 @@ TEST_CASE(flag_nolimit_vs_can_remove_semantics)
 	bed.reset();
 	g_game.cleanup();
 	CHECK(weakBed.expired());
+}
+
+TEST_CASE(flag_nolimit_does_not_remove_special_nonremovable_containers)
+{
+	ensureItemTypes();
+	const Position pos{145, 145, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(pos.x, pos.y, pos.z);
+
+	auto tile = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
+	tile->setGround(std::make_shared<Item>(100));
+	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
+	Tile* rawTile = g_game.map.getTile(pos);
+	CHECK(rawTile != nullptr);
+
+	std::vector<std::shared_ptr<Item>> specialItems{
+	    std::make_shared<Inbox>(ITEM_INBOX),
+	    std::make_shared<StoreInbox>(ITEM_STORE_INBOX),
+	    std::make_shared<DepotChest>(ITEM_DEPOT),
+	    std::make_shared<DepotLocker>(ITEM_LOCKER),
+	};
+	std::vector<std::weak_ptr<Item>> weakItems;
+	weakItems.reserve(specialItems.size());
+
+	for (const auto& item : specialItems) {
+		CHECK(!item->canRemove());
+		rawTile->internalAddThing(item.get());
+		CHECK(item->getParent() == rawTile);
+		CHECK(g_game.internalRemoveItem(item.get(), -1, false, FLAG_NOLIMIT) == RETURNVALUE_NOTPOSSIBLE);
+		CHECK(item->getParent() == rawTile);
+		weakItems.emplace_back(item);
+	}
+
+	// The dedicated Map cleanup path can still tear down the tile completely.
+	specialItems.clear();
+	g_game.map.removeTile(pos);
+	g_game.cleanup();
+	for (const auto& weakItem : weakItems) {
+		CHECK(weakItem.expired());
+	}
 }
 
 TEST_CASE(house_reassigns_door_and_bed_without_stale_back_references)
@@ -1392,21 +1494,23 @@ TEST_CASE(house_reassigns_door_and_bed_without_stale_back_references)
 	CHECK(houseB->getBedCount() == 0);
 }
 
-TEST_CASE(container_on_orphan_house_tile_does_not_dereference_expired_house)
+TEST_CASE(orphan_house_tile_fails_closed_for_players_and_allows_map_cleanup)
 {
 	ensureItemTypes();
 	const Position pos{150, 150, 7};
 	MapTileGuard tileGuard;
 	tileGuard.track(150, 150, 7);
 
-	std::shared_ptr<HouseTile> orphanTile;
+	HouseTile* orphanTile = nullptr;
+	std::weak_ptr<Thing> weakTile;
 	{
 		auto house = std::make_shared<House>(903);
 		auto houseTile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
 		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(houseTile));
-		orphanTile = std::static_pointer_cast<HouseTile>(g_game.map.getTile(pos)->weak_from_this().lock());
+		orphanTile = g_game.map.getTile(pos)->getHouseTile();
+		weakTile = orphanTile->weak_from_this();
 	}
-	// House is now destroyed; orphanTile->getHouse() is nullptr
+	// House is now destroyed while the map still owns the HouseTile.
 	CHECK(orphanTile != nullptr);
 	CHECK(orphanTile->getHouse() == nullptr);
 
@@ -1420,22 +1524,57 @@ TEST_CASE(container_on_orphan_house_tile_does_not_dereference_expired_house)
 	auto container = std::make_shared<Container>(ITEM_BAG, 10);
 	orphanTile->internalAddThing(container.get());
 
-	auto item = std::make_shared<Item>(100);
-	container->addItem(item);
+	auto nestedItem = std::make_shared<Item>(100);
+	container->addItem(nestedItem);
+	auto incomingItem = std::make_shared<Item>(100);
+
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(10);
+	orphanTile->internalAddThing(door.get());
+	auto bed = std::make_shared<BedItem>(694);
+	orphanTile->internalAddThing(bed.get());
+	CHECK(door->getHouse() == nullptr);
+	CHECK(bed->getHouse() == nullptr);
 
 	auto player = makeTestPlayer(10, "OrphanHousePlayer");
 
-	// Test queryAdd and queryRemove with ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS enabled
+	// Direct entry and actor-driven item operations fail closed.
+	CHECK(orphanTile->queryAdd(0, *player, 1, FLAG_NOLIMIT, player.get()) == RETURNVALUE_NOTPOSSIBLE);
+	CHECK(orphanTile->queryAdd(0, *incomingItem, 1, 0, player.get()) == RETURNVALUE_NOTPOSSIBLE);
+	CHECK(orphanTile->queryRemove(*door, 1, 0, player.get()) == RETURNVALUE_NOTPOSSIBLE);
+	int32_t destinationIndex = 0;
+	Item* destinationItem = nullptr;
+	uint32_t destinationFlags = 0;
+	CHECK(orphanTile->queryDestination(destinationIndex, *player, &destinationItem, destinationFlags, 0) ==
+	      &Tile::nullptr_tile);
+
+	// A nested container must not bypass the expired House permissions.
 	bool prevOnlyInvited = ConfigManager::getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS);
 	ConfigManager::setBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, true);
-
-	auto addRet = container->queryAdd(0, *item, 1, 0, player.get());
-	CHECK(addRet == RETURNVALUE_NOERROR);
-
-	auto removeRet = container->queryRemove(*item, 1, 0, player.get());
-	CHECK(removeRet == RETURNVALUE_NOERROR);
-
+	CHECK(container->queryAdd(0, *incomingItem, 1, 0, player.get()) == RETURNVALUE_NOTPOSSIBLE);
+	CHECK(container->queryRemove(*nestedItem, 1, 0, player.get()) == RETURNVALUE_NOTPOSSIBLE);
+	// Actor-less maintenance remains available.
+	CHECK(container->queryRemove(*nestedItem, 1, 0, nullptr) == RETURNVALUE_NOERROR);
 	ConfigManager::setBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, prevOnlyInvited);
+
+	std::weak_ptr<Container> weakContainer = container;
+	std::weak_ptr<Item> weakNestedItem = nestedItem;
+	std::weak_ptr<Door> weakDoor = door;
+	std::weak_ptr<BedItem> weakBed = bed;
+	ground.reset();
+	container.reset();
+	nestedItem.reset();
+	incomingItem.reset();
+	door.reset();
+	bed.reset();
+
+	g_game.map.removeTile(pos);
+	g_game.cleanup();
+	CHECK(weakTile.expired());
+	CHECK(weakContainer.expired());
+	CHECK(weakNestedItem.expired());
+	CHECK(weakDoor.expired());
+	CHECK(weakBed.expired());
 }
 
 TEST_CASE(house_tile_registry_is_unregistered_when_map_tile_is_removed)
@@ -1554,9 +1693,11 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 
 	const Position startPos{169, 170, 7};
 	const Position bedPos{170, 170, 7};
+	const Position partnerPos{170, 171, 7};
 	MapTileGuard tileGuard;
 	tileGuard.track(startPos.x, startPos.y, startPos.z);
 	tileGuard.track(bedPos.x, bedPos.y, bedPos.z);
+	tileGuard.track(partnerPos.x, partnerPos.y, partnerPos.z);
 
 	auto startTile = std::make_unique<DynamicTile>(startPos.x, startPos.y, startPos.z);
 	startTile->setGround(std::make_shared<Item>(100));
@@ -1566,21 +1707,23 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 	auto houseTile = std::make_unique<HouseTile>(bedPos.x, bedPos.y, bedPos.z, house);
 	houseTile->setGround(std::make_shared<Item>(100));
 	g_game.map.setTile(bedPos.x, bedPos.y, bedPos.z, std::move(houseTile));
+	auto partnerTile = std::make_unique<HouseTile>(partnerPos.x, partnerPos.y, partnerPos.z, house);
+	partnerTile->setGround(std::make_shared<Item>(100));
+	g_game.map.setTile(partnerPos.x, partnerPos.y, partnerPos.z, std::move(partnerTile));
 
 	ItemTypePropertyGuard bedTypeGuard(694);
 	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
-	auto bed = std::make_shared<BedItem>(694);
+	OfflineSleeperState offlineState;
+	offlineState.guid = 912;
+	auto bed = std::make_shared<OfflineTestBedItem>(694, offlineState);
+	auto partnerBed = std::make_shared<BedItem>(694);
 	std::weak_ptr<BedItem> weakBed = bed;
 	g_game.map.getTile(bedPos)->internalAddThing(bed.get());
+	g_game.map.getTile(partnerPos)->internalAddThing(partnerBed.get());
+	CHECK(house->getBeds().size() == 2);
 
 	auto player = makeTestPlayer(912, "SleepingPlayer");
 	CHECK(player->setVocation(0));
-	player->setMaxHealth(100);
-	player->setHealth(10);
-	player->setMaxMana(100);
-	player->setMana(10);
-	CHECK(player->addCondition(
-	    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_REGENERATION, -1, 0)));
 
 	GlobalEvents globalEvents;
 	GlobalEvents* previousGlobalEvents = g_globalEvents;
@@ -1606,18 +1749,9 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 
 	CHECK(g_game.internalPlaceCreature(player.get(), startPos, false, true));
 
-	struct PlayerRemovalGuard {
-		Player* player;
-		~PlayerRemovalGuard()
-		{
-			if (player && !player->isRemoved()) {
-				g_game.removeCreature(player);
-			}
-		}
-	} playerRemovalGuard{player.get()};
-
 	CHECK(bed->sleep(player.get()));
 	CHECK(bed->getSleeper() == player->getGUID());
+	CHECK(partnerBed->getSleeper() == player->getGUID());
 	CHECK(g_game.getBedBySleeper(player->getGUID()) == bed);
 
 	PropWriteStream writeStream;
@@ -1628,25 +1762,38 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 	readStream.init(serialized.data(), serialized.size());
 	CHECK(bed->readAttr(ATTR_SLEEPSTART, readStream) == ATTR_READ_CONTINUE);
 
-	// Keep the test player online, but away from the tile being removed. This
-	// exercises the same wake-up path used when an online sleeper is found.
-	g_game.map.moveCreature(*player, *g_game.map.getTile(startPos), true);
-	CHECK(player->getPosition() == startPos);
+	// Remove the sleeper from the online registries before removing the bed. The
+	// Map teardown must therefore execute BedItem::wakeUp(nullptr), including
+	// the real regeneration routine and the injected offline load/save boundary.
+	CHECK(g_game.removeCreature(player.get()));
+	CHECK(player->isRemoved());
+	CHECK(g_game.getPlayerByGUID(player->getGUID()) == nullptr);
 
-	bed.reset();
 	g_game.map.removeTile(bedPos);
 	g_game.cleanup();
 
-	CHECK(weakBed.expired());
-	CHECK(player->getHealth() == 70);
-	CHECK(player->getMana() == 70);
-	CHECK(player->getSoul() == 2);
+	CHECK(offlineState.loadCount == 1);
+	CHECK(offlineState.saveCount == 1);
+	CHECK(offlineState.loadedGuid == player->getGUID());
+	CHECK(offlineState.savedHealth == 70);
+	CHECK(offlineState.savedMana == 70);
+	CHECK(offlineState.savedSoul == 2);
+	CHECK(bed->getSleeper() == 0);
+	CHECK(partnerBed->getSleeper() == 0);
+	CHECK(house->getBeds().size() == 1);
 	CHECK(g_game.getBedBySleeper(player->getGUID()) == nullptr);
 
-	// A later login lookup must not regenerate a second time.
-	CHECK(player->getHealth() == 70);
-	CHECK(player->getMana() == 70);
-	CHECK(player->getSoul() == 2);
+	// A later login/wake lookup cannot regenerate the removed session twice.
+	bed->wakeUp(nullptr);
+	CHECK(offlineState.loadCount == 1);
+	CHECK(offlineState.saveCount == 1);
+	CHECK(offlineState.savedHealth == 70);
+	CHECK(offlineState.savedMana == 70);
+	CHECK(offlineState.savedSoul == 2);
+
+	bed.reset();
+	g_game.cleanup();
+	CHECK(weakBed.expired());
 }
 
 TEST_CASE(lua_tile_userdata_is_invalidated_after_map_removal)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -274,6 +274,54 @@ TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_null_or_destroyed)
 	CHECK(houseTile->getHouse() == nullptr);
 }
 
+TEST_CASE(item_get_bed_returns_nullptr_for_regular_item_and_valid_shared_ptr_for_bed_item)
+{
+	// Regular Item returns nullptr
+	auto regularItem = std::make_shared<Item>(100);
+	CHECK(regularItem->getBed() == nullptr);
+	const auto& constRegularItem = regularItem;
+	CHECK(constRegularItem->getBed() == nullptr);
+
+	// BedItem returns valid shared_ptr and preserves identity
+	auto bed = std::make_shared<BedItem>(694);
+	BedItem* rawBed = bed.get();
+
+	std::shared_ptr<BedItem> nonConstBed = bed->getBed();
+	CHECK(nonConstBed != nullptr);
+	CHECK(nonConstBed == bed);
+	CHECK(nonConstBed.get() == rawBed);
+
+	const auto& constBed = bed;
+	std::shared_ptr<const BedItem> constBedRef = constBed->getBed();
+	CHECK(constBedRef != nullptr);
+	CHECK(constBedRef == bed);
+	CHECK(constBedRef.get() == rawBed);
+
+	// Lifetime extension
+	bed.reset();
+	CHECK(nonConstBed != nullptr);
+	CHECK(nonConstBed.get() == rawBed);
+	CHECK(constBedRef != nullptr);
+	CHECK(constBedRef.get() == rawBed);
+}
+
+TEST_CASE(housetile_update_house_registers_bed_item_using_get_bed)
+{
+	auto house = std::make_shared<House>(550);
+	auto houseTile = std::make_unique<HouseTile>(110, 110, 7, house);
+	house->addTile(houseTile.get());
+
+	auto bed = std::make_shared<BedItem>(694);
+	CHECK(bed->getHouse() == nullptr);
+
+	// Adding bed to houseTile updates house registration
+	houseTile->internalAddThing(0, bed.get());
+
+	CHECK(bed->getHouse() != nullptr);
+	CHECK(bed->getHouse() == house);
+	CHECK(!bed->canRemove());
+}
+
 TEST_CASE(bed_get_house_returns_valid_shared_ptr_and_preserves_identity)
 {
 	auto bed = std::make_shared<BedItem>(0);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1,11 +1,36 @@
 #include "../otpch.h"
 
+#include "../configmanager.h"
+#include "../house.h"
 #include "../item.h"
+#include "../luascript.h"
 
 #include "test_support.h"
 #include <memory>
 
 extern bool isValidItemPointer(Item* item);
+extern LuaEnvironment g_luaEnvironment;
+
+namespace {
+
+class LuaFixture
+{
+public:
+	LuaFixture()
+	{
+		ConfigManager::setBoolean(ConfigManager::WARN_UNSAFE_SCRIPTS, false);
+		ConfigManager::setBoolean(ConfigManager::CONVERT_UNSAFE_SCRIPTS, false);
+		CHECK(g_luaEnvironment.initState());
+		L = g_luaEnvironment.getLuaState();
+		CHECK(L != nullptr);
+	}
+
+	~LuaFixture() { g_luaEnvironment.closeState(); }
+
+	lua_State* L = nullptr;
+};
+
+} // namespace
 
 TEST_CASE(item_lifetime_registry_tracks_destroyed_item)
 {
@@ -17,6 +42,118 @@ TEST_CASE(item_lifetime_registry_tracks_destroyed_item)
 	}
 
 	CHECK(!isValidItemPointer(rawItem));
+}
+
+TEST_CASE(house_transfer_item_keeps_identity_until_reset)
+{
+	auto house = std::make_shared<House>(1);
+	house->setName("Lifetime Test House");
+
+	auto first = house->getTransferItem();
+	auto second = house->getTransferItem();
+
+	CHECK(first != nullptr);
+	CHECK(second == first);
+
+	house->resetTransferItem();
+	auto replacement = house->getTransferItem();
+
+	CHECK(replacement != nullptr);
+	CHECK(replacement != first);
+}
+
+TEST_CASE(house_transfer_item_trade_cancel_resets_document)
+{
+	auto house = std::make_shared<House>(2);
+	house->setName("Cancel Test House");
+
+	auto transferItem = house->getTransferItem();
+	CHECK(transferItem != nullptr);
+
+	transferItem->onTradeEvent(ON_TRADE_CANCEL, nullptr);
+	auto replacement = house->getTransferItem();
+
+	CHECK(replacement != nullptr);
+	CHECK(replacement != transferItem);
+}
+
+TEST_CASE(container_get_item_by_index_preserves_item_lifetime)
+{
+	auto container = std::make_shared<Container>(0, 2);
+	auto insertedItem = std::make_shared<Item>(0);
+	Item* rawItem = insertedItem.get();
+	CHECK(container->addItem(insertedItem));
+	insertedItem.reset();
+
+	auto item = container->getItemByIndex(0);
+	CHECK(item != nullptr);
+	CHECK(item.get() == rawItem);
+	CHECK(container->getItemByIndex(container->size()) == nullptr);
+
+	container->removeThing(rawItem, rawItem->getItemCount());
+	CHECK(container->empty());
+	CHECK(isValidItemPointer(item.get()));
+	CHECK(item->getID() == 0);
+}
+
+TEST_CASE(container_iterator_preserves_item_lifetime)
+{
+	auto container = std::make_shared<Container>(0, 1);
+	auto insertedItem = std::make_shared<Item>(0);
+	Item* rawItem = insertedItem.get();
+	CHECK(container->addItem(insertedItem));
+	insertedItem.reset();
+
+	std::shared_ptr<Item> item;
+	{
+		auto iterator = container->iterator();
+		CHECK(iterator.hasNext());
+		item = *iterator;
+		CHECK(item.get() == rawItem);
+		iterator.advance();
+		CHECK(!iterator.hasNext());
+		CHECK(*iterator == nullptr);
+	}
+
+	container->removeThing(rawItem, rawItem->getItemCount());
+	CHECK(container->empty());
+	CHECK(isValidItemPointer(item.get()));
+	CHECK(item->getID() == 0);
+}
+
+TEST_CASE(lua_container_item_userdata_preserves_item_lifetime)
+{
+	LuaFixture fixture;
+	auto container = std::make_shared<Container>(0, 1);
+	auto insertedItem = std::make_shared<Item>(0);
+	Item* rawItem = insertedItem.get();
+	std::weak_ptr<Item> weakItem = insertedItem;
+	CHECK(container->addItem(insertedItem));
+	insertedItem.reset();
+
+	Lua::pushSharedPtr(fixture.L, std::static_pointer_cast<Item>(container));
+	Lua::setItemMetatable(fixture.L, -1, container.get());
+	lua_setglobal(fixture.L, "lifetimeTestContainer");
+
+	CHECK(luaL_dostring(fixture.L,
+	                    "heldItem = lifetimeTestContainer:getItem(0)\n"
+	                    "return heldItem:getId()") == LUA_OK);
+	CHECK(lua_tointeger(fixture.L, -1) == 0);
+	lua_pop(fixture.L, 1);
+
+	container->removeThing(rawItem, rawItem->getItemCount());
+	CHECK(container->empty());
+	CHECK(!weakItem.expired());
+	CHECK(luaL_dostring(fixture.L, "return heldItem:getId()") == LUA_OK);
+	CHECK(lua_tointeger(fixture.L, -1) == 0);
+	lua_pop(fixture.L, 1);
+
+	CHECK(luaL_dostring(fixture.L,
+	                    "heldItem = nil\n"
+	                    "lifetimeTestContainer = nil\n"
+	                    "collectgarbage('collect')\n"
+	                    "collectgarbage('collect')") == LUA_OK);
+	CHECK(weakItem.expired());
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1862,4 +1862,132 @@ TEST_CASE(lua_tile_userdata_is_invalidated_after_map_removal)
 	lua_gc(L, LUA_GCCOLLECT, 0);
 }
 
+TEST_CASE(lua_tile_house_userdata_preserves_house_lifetime_until_gc)
+{
+	ensureItemTypes();
+	LuaFixture fixture;
+	lua_State* L = fixture.L;
+	std::weak_ptr<House> weakHouse;
+	std::weak_ptr<HouseTile> weakTile;
+
+	{
+		Houses houses;
+		auto house = houses.addHouse(920);
+		house->setName("Lua Lifetime House");
+		house->setRent(250);
+		weakHouse = house;
+		auto tile = std::make_shared<HouseTile>(170, 170, 7, house);
+		house->addTile(tile);
+		weakTile = tile;
+
+		Lua::pushUserdata<Tile>(L, tile.get());
+		Lua::setMetatable(L, -1, "Tile");
+		lua_setglobal(L, "lifetimeHouseTile");
+		CHECK(luaL_dostring(L, "heldHouse = lifetimeHouseTile:getHouse()") == LUA_OK);
+
+		lua_getglobal(L, "heldHouse");
+		CHECK(lua_rawlen(L, -1) == sizeof(std::shared_ptr<House>));
+		CHECK(Lua::getSharedUserdata<House>(L, -1) == house.get());
+		CHECK(Lua::getSharedUserdata<const House>(L, -1) == house.get());
+		lua_pop(L, 1);
+	}
+
+	// Both the native registry and the tile are gone; only Lua owns the house.
+	CHECK(weakTile.expired());
+	CHECK(!weakHouse.expired());
+	CHECK(luaL_dostring(L,
+	                    "collectgarbage('collect')\n"
+	                    "assert(lifetimeHouseTile:getHouse() == nil)\n"
+	                    "assert(getmetatable(heldHouse) == House)\n"
+	                    "assert(heldHouse:getId() == 920)\n"
+	                    "assert(heldHouse:getName() == 'Lua Lifetime House')\n"
+	                    "assert(heldHouse:getRent() == 250)\n"
+	                    "assert(heldHouse:setRent(500))\n"
+	                    "assert(heldHouse:getRent() == 500)\n"
+	                    "assert(heldHouse:getTileCount() == 0)") == LUA_OK);
+	CHECK(!weakHouse.expired());
+
+	CHECK(luaL_dostring(L,
+	                    "heldHouse = nil\n"
+	                    "lifetimeHouseTile = nil\n"
+	                    "collectgarbage('collect')\n"
+	                    "collectgarbage('collect')") == LUA_OK);
+	CHECK(weakHouse.expired());
+}
+
+TEST_CASE(lua_house_shared_userdata_preserves_identity_and_idempotent_gc)
+{
+	ensureItemTypes();
+	LuaFixture fixture;
+	lua_State* L = fixture.L;
+	auto house = std::make_shared<House>(921);
+	std::weak_ptr<House> weakHouse = house;
+	auto tile = std::make_shared<HouseTile>(171, 171, 7, house);
+	// Equal IDs must not make distinct House objects compare equal.
+	auto otherHouse = std::make_shared<House>(921);
+	auto otherTile = std::make_shared<HouseTile>(172, 172, 7, otherHouse);
+	auto player = makeTestPlayer(921, "LuaHousePlayer");
+
+	Lua::pushUserdata<Tile>(L, tile.get());
+	Lua::setMetatable(L, -1, "Tile");
+	lua_setglobal(L, "houseTile");
+	Lua::pushUserdata<Tile>(L, otherTile.get());
+	Lua::setMetatable(L, -1, "Tile");
+	lua_setglobal(L, "otherHouseTile");
+	Lua::pushUserdata<Player>(L, player.get());
+	Lua::setMetatable(L, -1, "Player");
+	lua_setglobal(L, "houseTestPlayer");
+	lua_pushinteger(L, GUEST_LIST);
+	lua_setglobal(L, "houseGuestList");
+
+	CHECK(luaL_dostring(L,
+	                    "houseA = houseTile:getHouse()\n"
+	                    "houseB = houseTile:getHouse()\n"
+	                    "houseC = otherHouseTile:getHouse()\n"
+	                    "assert(not rawequal(houseA, houseB))\n"
+	                    "assert(houseA == houseB)\n"
+	                    "assert(houseA ~= houseC)\n"
+	                    "assert(houseA ~= houseTile and houseTile ~= houseA)\n"
+	                    "assert(House.getId(houseTile) == nil)\n"
+	                    "assert(House.getRent(houseTile) == nil)\n"
+	                    "assert(houseTestPlayer:setEditHouse(houseA, houseGuestList))\n"
+	                    "assert(houseTestPlayer:sendHouseWindow(houseB, houseGuestList))\n"
+	                    "assert(houseTestPlayer:setEditHouse(houseTile, houseGuestList) == nil)\n"
+	                    "assert(houseTestPlayer:sendHouseWindow(houseTile, houseGuestList) == nil)") == LUA_OK);
+	uint32_t windowTextId = 0;
+	uint32_t listId = 0;
+	CHECK(player->getEditHouse(windowTextId, listId) == house.get());
+	CHECK(listId == GUEST_LIST);
+	house.reset();
+	CHECK(weakHouse.use_count() == 2);
+
+	CHECK(luaL_dostring(L,
+	                    "local gc = rawgetmetatable('House').__gc\n"
+	                    "assert(type(gc) == 'function')\n"
+	                    "gc(houseA)\n"
+	                    "gc(houseA)\n"
+	                    "assert(houseA:getId() == nil)\n"
+	                    "assert(houseA:getRent() == nil)\n"
+	                    "assert(houseA:setRent(1) == nil)\n"
+	                    "assert(houseA ~= houseB)\n"
+	                    "assert(houseB:getId() == 921)") == LUA_OK);
+	CHECK(weakHouse.use_count() == 1);
+
+	CHECK(luaL_dostring(L,
+	                    "local gc = rawgetmetatable('House').__gc\n"
+	                    "gc(houseB)\n"
+	                    "gc(houseB)\n"
+	                    "assert(houseB:getId() == nil)\n"
+	                    "assert(houseTile:getHouse() == nil)\n"
+	                    "assert(houseTestPlayer:setEditHouse(houseB, houseGuestList) == nil)\n"
+	                    "assert(houseTestPlayer:sendHouseWindow(houseB, houseGuestList) == nil)\n"
+	                    "houseA = nil\n"
+	                    "houseB = nil\n"
+	                    "houseC = nil\n"
+	                    "collectgarbage('collect')\n"
+	                    "collectgarbage('collect')") == LUA_OK);
+	CHECK(weakHouse.expired());
+	CHECK(player->getEditHouse(windowTextId, listId) == nullptr);
+}
+
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1,18 +1,24 @@
 #include "../otpch.h"
 
 #include "../bed.h"
+#include "../chat.h"
 #include "../configmanager.h"
+#include "../events.h"
 #include "../game.h"
+#include "../globalevent.h"
 #include "../house.h"
 #include "../item.h"
 #include "../luascript.h"
 #include "../player.h"
+#include "../scriptmanager.h"
+#include "../vocation.h"
 
 #include "test_support.h"
 #include <memory>
 
 extern bool isValidItemPointer(Item* item);
 extern LuaEnvironment g_luaEnvironment;
+extern Vocations g_vocations;
 
 namespace {
 
@@ -253,6 +259,19 @@ void ensureItemTypes()
 		const auto itemFile = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
 		                      "data/items/items.otb";
 		return Item::items.loadFromOtb(itemFile.string());
+	}();
+	CHECK(loaded);
+}
+
+void ensureVocations()
+{
+	static const bool loaded = [] {
+		const auto originalPath = std::filesystem::current_path();
+		const auto projectPath = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
+		std::filesystem::current_path(projectPath);
+		const bool result = g_vocations.loadFromXml();
+		std::filesystem::current_path(originalPath);
+		return result;
 	}();
 	CHECK(loaded);
 }
@@ -1526,6 +1545,108 @@ TEST_CASE(house_door_bed_tile_pruning_prevents_unbounded_registry_growth)
 	CHECK(house->getBedCount() == 1);
 	CHECK(house->getTiles().size() == 1);
 	CHECK(house->getTileCount() == 1);
+}
+
+TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
+{
+	ensureItemTypes();
+	ensureVocations();
+
+	const Position startPos{169, 170, 7};
+	const Position bedPos{170, 170, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(startPos.x, startPos.y, startPos.z);
+	tileGuard.track(bedPos.x, bedPos.y, bedPos.z);
+
+	auto startTile = std::make_unique<DynamicTile>(startPos.x, startPos.y, startPos.z);
+	startTile->setGround(std::make_shared<Item>(100));
+	g_game.map.setTile(startPos.x, startPos.y, startPos.z, std::move(startTile));
+
+	auto house = std::make_shared<House>(912);
+	auto houseTile = std::make_unique<HouseTile>(bedPos.x, bedPos.y, bedPos.z, house);
+	houseTile->setGround(std::make_shared<Item>(100));
+	g_game.map.setTile(bedPos.x, bedPos.y, bedPos.z, std::move(houseTile));
+
+	ItemTypePropertyGuard bedTypeGuard(694);
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+	auto bed = std::make_shared<BedItem>(694);
+	std::weak_ptr<BedItem> weakBed = bed;
+	g_game.map.getTile(bedPos)->internalAddThing(bed.get());
+
+	auto player = makeTestPlayer(912, "SleepingPlayer");
+	CHECK(player->setVocation(0));
+	player->setMaxHealth(100);
+	player->setHealth(10);
+	player->setMaxMana(100);
+	player->setMana(10);
+	CHECK(player->addCondition(
+	    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_REGENERATION, -1, 0)));
+
+	GlobalEvents globalEvents;
+	GlobalEvents* previousGlobalEvents = g_globalEvents;
+	g_globalEvents = &globalEvents;
+	struct GlobalEventsGuard {
+		GlobalEvents* previous;
+		~GlobalEventsGuard() { g_globalEvents = previous; }
+	} globalEventsGuard{previousGlobalEvents};
+	Events events;
+	Events* previousEvents = g_events;
+	g_events = &events;
+	struct EventsGuard {
+		Events* previous;
+		~EventsGuard() { g_events = previous; }
+	} eventsGuard{previousEvents};
+	Chat chat;
+	Chat* previousChat = g_chat;
+	g_chat = &chat;
+	struct ChatGuard {
+		Chat* previous;
+		~ChatGuard() { g_chat = previous; }
+	} chatGuard{previousChat};
+
+	CHECK(g_game.internalPlaceCreature(player.get(), startPos, false, true));
+
+	struct PlayerRemovalGuard {
+		Player* player;
+		~PlayerRemovalGuard()
+		{
+			if (player && !player->isRemoved()) {
+				g_game.removeCreature(player);
+			}
+		}
+	} playerRemovalGuard{player.get()};
+
+	CHECK(bed->sleep(player.get()));
+	CHECK(bed->getSleeper() == player->getGUID());
+	CHECK(g_game.getBedBySleeper(player->getGUID()) == bed);
+
+	PropWriteStream writeStream;
+	const auto sleepStart = static_cast<uint32_t>(std::time(nullptr) - 1800);
+	writeStream.write<uint32_t>(sleepStart);
+	const std::string_view serialized = writeStream.getStream();
+	PropStream readStream;
+	readStream.init(serialized.data(), serialized.size());
+	CHECK(bed->readAttr(ATTR_SLEEPSTART, readStream) == ATTR_READ_CONTINUE);
+
+	// Keep the test player online, but away from the tile being removed. This
+	// exercises the same wake-up path used when an online sleeper is found.
+	g_game.map.moveCreature(*player, *g_game.map.getTile(startPos), true);
+	CHECK(player->getPosition() == startPos);
+
+	bed.reset();
+	g_game.map.removeTile(bedPos);
+	g_game.cleanup();
+
+	CHECK(weakBed.expired());
+	CHECK(player->getHealth() == 70);
+	CHECK(player->getMana() == 70);
+	CHECK(player->getSoul() == 2);
+	CHECK(g_game.getBedBySleeper(player->getGUID()) == nullptr);
+
+	// A later login lookup must not regenerate a second time.
+	CHECK(player->getHealth() == 70);
+	CHECK(player->getMana() == 70);
+	CHECK(player->getSoul() == 2);
 }
 
 TEST_CASE(lua_tile_userdata_is_invalidated_after_map_removal)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -134,6 +134,33 @@ TEST_CASE(houses_add_house_preserves_lifetime_beyond_houses_scope)
 	CHECK(house->getId() == 100);
 }
 
+TEST_CASE(houses_get_house_by_player_id_preserves_lifetime_and_semantics)
+{
+	Houses houses;
+	auto house1 = houses.addHouse(101);
+	auto house2 = houses.addHouse(102);
+
+	CHECK(house1 != nullptr);
+	CHECK(house2 != nullptr);
+	CHECK(house1->getOwner() == 0);
+	CHECK(house2->getOwner() == 0);
+
+	// Searching for non-existent owner returns nullptr
+	CHECK(houses.getHouseByPlayerId(999) == nullptr);
+	CHECK(houses.getHouseByPlayerId(1) == nullptr);
+
+	// Const access test
+	const Houses& constHouses = houses;
+	CHECK(constHouses.getHouseByPlayerId(999) == nullptr);
+
+	// Searching for owner 0 finds the first house with owner 0
+	auto unowned = constHouses.getHouseByPlayerId(0);
+	CHECK(unowned != nullptr);
+	CHECK(unowned->getId() == 101);
+	CHECK(unowned == house1);
+	CHECK(unowned.get() == house1.get());
+}
+
 TEST_CASE(door_get_house_returns_valid_shared_ptr_and_preserves_identity)
 {
 	auto house = std::make_shared<House>(100);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -92,10 +92,9 @@ TEST_CASE(house_transfer_item_trade_cancel_resets_document)
 TEST_CASE(houses_get_house_preserves_house_lifetime)
 {
 	std::shared_ptr<House> house;
-	std::shared_ptr<House> addedHouse;
 	{
 		Houses houses;
-		addedHouse = houses.addHouse(42);
+		auto addedHouse = houses.addHouse(42);
 		house = houses.getHouse(42);
 
 		CHECK(house != nullptr);
@@ -105,7 +104,6 @@ TEST_CASE(houses_get_house_preserves_house_lifetime)
 	}
 
 	CHECK(house != nullptr);
-	CHECK(house == addedHouse);
 	CHECK(house->getId() == 42);
 }
 
@@ -499,6 +497,7 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 
 	auto bed1 = std::make_shared<BedItem>(694);
 	auto bed2 = std::make_shared<BedItem>(695);
+	std::weak_ptr<BedItem> weakBed2 = bed2;
 
 	auto tile1 = std::make_unique<DynamicTile>(100, 100, 7);
 	auto tile2 = std::make_unique<DynamicTile>(100, 101, 7);
@@ -525,13 +524,25 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 	CHECK(partnerReverse == bed1);
 	CHECK(partnerReverse.get() == bed1.get());
 	CHECK(partnerReverse->getID() == 694);
+	partnerReverse.reset();
 
-	// Test lifetime preservation when item is cleared from partner tile
+	// Reset bed2 ownership; partner and tile2 are now the holders
+	bed2.reset();
+	CHECK(!weakBed2.expired());
+
+	// Clear partner from tile
 	rawTile2->getItemList()->clear();
 	CHECK(rawTile2->getBedItem() == nullptr);
 	CHECK(bed1->getNextBedItem() == nullptr);
+
+	// partner returned earlier keeps the object alive
+	CHECK(!weakBed2.expired());
 	CHECK(partner != nullptr);
 	CHECK(partner->getID() == 695);
+
+	// Releasing partner must expire the weak pointer
+	partner.reset();
+	CHECK(weakBed2.expired());
 
 	Item::items.getItemType(694).bedPartnerDir = origDir694;
 	Item::items.getItemType(695).bedPartnerDir = origDir695;
@@ -835,6 +846,127 @@ TEST_CASE(lua_container_item_userdata_preserves_item_lifetime)
 	                    "collectgarbage('collect')\n"
 	                    "collectgarbage('collect')") == LUA_OK);
 	CHECK(weakItem.expired());
+}
+
+TEST_CASE(player_remove_item_of_type_inventory_and_container_lifetime)
+{
+	ensureItemTypes();
+	Item::items.getItemType(100).moveable = true;
+
+	auto player = makeTestPlayer(100, "RemoveItemPlayer");
+
+	// Non-stackable items spread across inventory and backpack container
+	auto backpack = std::make_shared<Container>(ITEM_BAG, 10);
+	static_cast<Cylinder*>(player.get())->internalAddThing(CONST_SLOT_BACKPACK, backpack.get());
+
+	auto invItem = std::make_shared<Item>(100);
+	std::weak_ptr<Item> weakInvItem = invItem;
+	static_cast<Cylinder*>(player.get())->internalAddThing(CONST_SLOT_RIGHT, invItem.get());
+	invItem.reset();
+
+	auto contItem1 = std::make_shared<Item>(100);
+	std::weak_ptr<Item> weakContItem1 = contItem1;
+	backpack->addItem(contItem1);
+	contItem1.reset();
+
+	auto contItem2 = std::make_shared<Item>(100);
+	std::weak_ptr<Item> weakContItem2 = contItem2;
+	backpack->addItem(contItem2);
+	contItem2.reset();
+
+	CHECK(player->getItemTypeCount(100) == 3);
+	CHECK(!weakInvItem.expired());
+	CHECK(!weakContItem1.expired());
+	CHECK(!weakContItem2.expired());
+
+	// Remove 2 non-stackable items of type 100 (backpack in slot 3 is scanned before right-hand in slot 6)
+	CHECK(player->removeItemOfType(100, 2, -1));
+	CHECK(player->getItemTypeCount(100) == 1);
+	g_game.cleanup();
+	CHECK(weakContItem1.expired());
+	CHECK(weakContItem2.expired());
+	CHECK(!weakInvItem.expired());
+
+	// Remove remaining 1 (removes from right-hand inventory slot)
+	CHECK(player->removeItemOfType(100, 1, -1));
+	CHECK(player->getItemTypeCount(100) == 0);
+	g_game.cleanup();
+	CHECK(weakInvItem.expired());
+}
+
+TEST_CASE(player_remove_item_of_type_stackable_partial_and_multi_container)
+{
+	ensureItemTypes();
+	Item::items.getItemType(2160).stackable = true;
+	Item::items.getItemType(2160).moveable = true;
+
+	auto player = makeTestPlayer(101, "StackablePlayer");
+
+	auto backpack = std::make_shared<Container>(ITEM_BAG, 10);
+	static_cast<Cylinder*>(player.get())->internalAddThing(CONST_SLOT_BACKPACK, backpack.get());
+
+	auto stack1 = std::make_shared<Item>(2160, 50);
+	std::weak_ptr<Item> weakStack1 = stack1;
+	backpack->addItem(stack1);
+	stack1.reset();
+
+	auto stack2 = std::make_shared<Item>(2160, 100);
+	std::weak_ptr<Item> weakStack2 = stack2;
+	backpack->addItem(stack2);
+	stack2.reset();
+
+	CHECK(player->getItemTypeCount(2160) == 150);
+
+	// Remove 75 items: stack1 (50) is fully removed, stack2 (100) is reduced to 75
+	CHECK(player->removeItemOfType(2160, 75, -1));
+	CHECK(player->getItemTypeCount(2160) == 75);
+	g_game.cleanup();
+	CHECK(weakStack1.expired());
+	CHECK(!weakStack2.expired());
+
+	// Remove remaining 75
+	CHECK(player->removeItemOfType(2160, 75, -1));
+	CHECK(player->getItemTypeCount(2160) == 0);
+	g_game.cleanup();
+	CHECK(weakStack2.expired());
+}
+
+TEST_CASE(game_internal_remove_items_robust_against_concurrent_pre_removal)
+{
+	ensureItemTypes();
+	Item::items.getItemType(100).moveable = true;
+
+	auto player = makeTestPlayer(102, "PreRemovePlayer");
+	auto container = std::make_shared<Container>(ITEM_BAG, 5);
+	static_cast<Cylinder*>(player.get())->internalAddThing(CONST_SLOT_BACKPACK, container.get());
+
+	auto item1 = std::make_shared<Item>(100);
+	auto item2 = std::make_shared<Item>(100);
+	auto item3 = std::make_shared<Item>(100);
+
+	std::weak_ptr<Item> weak1 = item1;
+	std::weak_ptr<Item> weak2 = item2;
+	std::weak_ptr<Item> weak3 = item3;
+
+	container->addItem(item1);
+	container->addItem(item2);
+	container->addItem(item3);
+
+	// Pre-remove item2 before calling internalRemoveItems on the batch
+	container->removeThing(item2.get(), 1);
+	CHECK(item2->isRemoved());
+
+	// Collect batch and execute removal
+	{
+		std::vector<std::shared_ptr<Item>> batch = {std::move(item1), std::move(item2), std::move(item3)};
+		g_game.internalRemoveItems(std::move(batch), 3, false);
+	}
+
+	g_game.cleanup();
+	CHECK(weak1.expired());
+	CHECK(weak2.expired());
+	CHECK(weak3.expired());
+	CHECK(container->empty());
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -515,11 +515,74 @@ TEST_CASE(house_get_door_by_number_returns_nullptr_when_door_is_destroyed)
 		door->setDoorId(20);
 		house->addDoor(door.get());
 		CHECK(house->getDoorByNumber(20) != nullptr);
+		door->onRemoved();
 		// door goes out of scope and is destroyed
 	}
 
-	// weak_from_this().lock() fails -> returns nullptr
 	CHECK(house->getDoorByNumber(20) == nullptr);
+}
+
+TEST_CASE(house_get_door_by_position_finds_door_and_preserves_identity_and_lifetime)
+{
+	ensureItemTypes();
+
+	const Position doorPos{105, 105, 7};
+	auto house = std::make_shared<House>(502);
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(30);
+	Door* rawDoor = door.get();
+
+	auto tile = std::make_unique<DynamicTile>(doorPos.x, doorPos.y, doorPos.z);
+	g_game.map.setTile(doorPos.x, doorPos.y, doorPos.z, std::move(tile));
+	Tile* rawTile = g_game.map.getTile(doorPos);
+	rawTile->internalAddThing(door.get());
+
+	house->addDoor(door.get());
+
+	// Found by position & identity
+	std::shared_ptr<Door> retrievedDoor = house->getDoorByPosition(doorPos);
+	CHECK(retrievedDoor != nullptr);
+	CHECK(retrievedDoor.get() == rawDoor);
+	CHECK(retrievedDoor == door);
+	CHECK(retrievedDoor->getDoorId() == 30);
+
+	// Non-existent position
+	CHECK(house->getDoorByPosition(Position{999, 999, 7}) == nullptr);
+
+	// Release original owner
+	door.reset();
+	CHECK(retrievedDoor != nullptr);
+	CHECK(retrievedDoor.get() == rawDoor);
+
+	// Remove door from house
+	house->removeDoor(rawDoor);
+	CHECK(house->getDoorByPosition(doorPos) == nullptr);
+
+	// retrievedDoor remains alive
+	CHECK(retrievedDoor != nullptr);
+	CHECK(retrievedDoor.get() == rawDoor);
+	CHECK(retrievedDoor->getDoorId() == 30);
+}
+
+TEST_CASE(house_get_door_by_position_returns_nullptr_when_door_is_destroyed)
+{
+	const Position doorPos{106, 106, 7};
+	auto house = std::make_shared<House>(503);
+
+	{
+		auto door = std::make_shared<Door>(0);
+		auto tile = std::make_unique<DynamicTile>(doorPos.x, doorPos.y, doorPos.z);
+		Tile* rawTile = tile.get();
+		rawTile->internalAddThing(door.get());
+
+		house->addDoor(door.get());
+		CHECK(house->getDoorByPosition(doorPos) != nullptr);
+
+		door->onRemoved();
+		// door goes out of scope and is destroyed
+	}
+
+	CHECK(house->getDoorByPosition(doorPos) == nullptr);
 }
 
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -4,6 +4,7 @@
 #include "../house.h"
 #include "../item.h"
 #include "../luascript.h"
+#include "../player.h"
 
 #include "test_support.h"
 #include <memory>
@@ -131,6 +132,84 @@ TEST_CASE(houses_add_house_preserves_lifetime_beyond_houses_scope)
 
 	CHECK(house != nullptr);
 	CHECK(house->getId() == 100);
+}
+
+TEST_CASE(door_get_house_returns_valid_shared_ptr_and_preserves_identity)
+{
+	auto house = std::make_shared<House>(100);
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(1);
+
+	CHECK(door->getHouse() == nullptr);
+
+	house->addDoor(door.get());
+
+	auto retrievedHouse = door->getHouse();
+	CHECK(retrievedHouse != nullptr);
+	CHECK(retrievedHouse == house);
+	CHECK(retrievedHouse->getId() == 100);
+	CHECK(house->getDoors().size() == 1);
+	CHECK(house->getDoorByNumber(1) == door.get());
+}
+
+TEST_CASE(door_get_house_returns_nullptr_when_house_is_destroyed)
+{
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(2);
+
+	{
+		auto house = std::make_shared<House>(200);
+		house->addDoor(door.get());
+		CHECK(door->getHouse() != nullptr);
+		CHECK(door->getHouse()->getId() == 200);
+	}
+
+	CHECK(door->getHouse() == nullptr);
+	// onRemoved when house is destroyed should be safe and not throw/crash
+	door->onRemoved();
+	CHECK(door->getHouse() == nullptr);
+}
+
+void ensureItemTypes()
+{
+	static const bool loaded = [] {
+		const auto itemFile = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() /
+		                      "data/items/items.otb";
+		return Item::items.loadFromOtb(itemFile.string());
+	}();
+	CHECK(loaded);
+}
+
+std::shared_ptr<Player> makeTestPlayer(uint32_t guid, std::string_view name)
+{
+	ensureItemTypes();
+	auto player = std::make_shared<Player>(nullptr);
+	player->setGUID(guid);
+	player->setName(name);
+	player->setGroup(std::make_shared<Group>());
+	return player;
+}
+
+TEST_CASE(door_can_use_and_access_list_behavior)
+{
+	auto house = std::make_shared<House>(300);
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(3);
+	house->addDoor(door.get());
+
+	auto player = makeTestPlayer(1, "TestPlayer");
+
+	// Uninvited player on restricted door cannot use
+	CHECK(!door->canUse(player.get()));
+
+	// Door with wildcard access list allows player
+	door->setAccessList("*");
+	CHECK(door->canUse(player.get()));
+
+	// When house is reset/destroyed, door allows usage freely
+	house.reset();
+	CHECK(door->getHouse() == nullptr);
+	CHECK(door->canUse(player.get()));
 }
 
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -289,8 +289,8 @@ TEST_CASE(door_can_use_and_access_list_behavior)
 TEST_CASE(housetile_get_house_returns_valid_shared_ptr_and_preserves_identity)
 {
 	auto house = std::make_shared<House>(500);
-	auto houseTile = std::make_unique<HouseTile>(100, 100, 7, house);
-	house->addTile(houseTile.get());
+	auto houseTile = std::make_shared<HouseTile>(100, 100, 7, house);
+	house->addTile(houseTile);
 
 	auto retrievedHouse = houseTile->getHouse();
 	CHECK(retrievedHouse != nullptr);
@@ -302,15 +302,15 @@ TEST_CASE(housetile_get_house_returns_valid_shared_ptr_and_preserves_identity)
 TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_null_or_destroyed)
 {
 	// Null/empty shared_ptr
-	auto nullHouseTile = std::make_unique<HouseTile>(102, 102, 7, nullptr);
+	auto nullHouseTile = std::make_shared<HouseTile>(102, 102, 7, nullptr);
 	CHECK(nullHouseTile->getHouse() == nullptr);
 
 	// Expiration after House dies
-	std::unique_ptr<HouseTile> houseTile;
+	std::shared_ptr<HouseTile> houseTile;
 	{
 		auto house = std::make_shared<House>(600);
-		houseTile = std::make_unique<HouseTile>(101, 101, 7, house);
-		house->addTile(houseTile.get());
+		houseTile = std::make_shared<HouseTile>(101, 101, 7, house);
+		house->addTile(houseTile);
 		CHECK(houseTile->getHouse() != nullptr);
 		CHECK(houseTile->getHouse()->getId() == 600);
 	}
@@ -355,8 +355,8 @@ TEST_CASE(item_get_door_returns_nullptr_for_regular_item_and_valid_shared_ptr_fo
 TEST_CASE(housetile_update_house_registers_door_using_get_door_and_handles_destruction)
 {
 	auto house = std::make_shared<House>(560);
-	auto houseTile = std::make_unique<HouseTile>(112, 112, 7, house);
-	house->addTile(houseTile.get());
+	auto houseTile = std::make_shared<HouseTile>(112, 112, 7, house);
+	house->addTile(houseTile);
 
 	auto door = std::make_shared<Door>(0);
 	door->setDoorId(77);
@@ -410,8 +410,8 @@ TEST_CASE(item_get_bed_returns_nullptr_for_regular_item_and_valid_shared_ptr_for
 TEST_CASE(housetile_update_house_registers_bed_item_using_get_bed)
 {
 	auto house = std::make_shared<House>(550);
-	auto houseTile = std::make_unique<HouseTile>(110, 110, 7, house);
-	house->addTile(houseTile.get());
+	auto houseTile = std::make_shared<HouseTile>(110, 110, 7, house);
+	house->addTile(houseTile);
 
 	auto bed = std::make_shared<BedItem>(694);
 	CHECK(bed->getHouse() == nullptr);
@@ -1015,6 +1015,106 @@ TEST_CASE(game_internal_remove_items_robust_against_concurrent_pre_removal)
 	CHECK(weak2.expired());
 	CHECK(weak3.expired());
 	CHECK(container->empty());
+}
+
+TEST_CASE(house_bed_list_drops_destroyed_bed)
+{
+	auto house = std::make_shared<House>(705);
+	auto bed = std::make_shared<BedItem>(694);
+	BedItem* rawBed = bed.get();
+
+	house->addBed(rawBed);
+	CHECK(house->getBeds().size() == 1);
+	CHECK(bed->getHouse() == house);
+
+	// Removing bed triggers onRemoved, which removes bed from house bedsList
+	bed->onRemoved();
+	CHECK(house->getBeds().empty());
+	CHECK(bed->getHouse() == nullptr);
+
+	// Destroying bed leaves no dangling pointers; setOwner must be safe
+	bed.reset();
+	house->setOwner(0, false);
+	CHECK(house->getBeds().empty());
+}
+
+TEST_CASE(house_tile_list_survives_map_tile_removal)
+{
+	ensureItemTypes();
+	const Position tilePos{120, 120, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(120, 120, 7);
+
+	auto house = std::make_shared<House>(706);
+	auto houseTile = std::make_unique<HouseTile>(tilePos.x, tilePos.y, tilePos.z, house);
+
+	g_game.map.setTile(tilePos.x, tilePos.y, tilePos.z, std::move(houseTile));
+	CHECK(house->getTileCount() == 1);
+
+	// Remove tile via Map::removeTile()
+	g_game.map.removeTile(tilePos);
+	CHECK(g_game.map.getTile(tilePos) == nullptr);
+
+	// houseTiles weak_ptr is expired; getTileCount and setOwner must safely ignore / clean it
+	CHECK(house->getTileCount() == 0);
+	house->setOwner(0, false);
+	CHECK(house->getTileCount() == 0);
+}
+
+TEST_CASE(get_bed_by_sleeper_keeps_bed_alive_for_caller)
+{
+	auto bed = std::make_shared<BedItem>(694);
+	BedItem* rawBed = bed.get();
+	std::weak_ptr<BedItem> weakBed = bed;
+
+	g_game.setBedSleeper(rawBed, 12345);
+
+	// Caller retrieves strong shared_ptr
+	std::shared_ptr<BedItem> callerBed = g_game.getBedBySleeper(12345);
+	CHECK(callerBed != nullptr);
+	CHECK(callerBed.get() == rawBed);
+	CHECK(callerBed == bed);
+
+	// Original bed owner releases ownership; caller keeps it alive
+	bed.reset();
+	CHECK(!weakBed.expired());
+	CHECK(callerBed != nullptr);
+	CHECK(callerBed.get() == rawBed);
+
+	// Caller releases reference; bed is now destroyed and getter returns nullptr
+	callerBed.reset();
+	CHECK(weakBed.expired());
+	CHECK(g_game.getBedBySleeper(12345) == nullptr);
+
+	g_game.removeBedSleeper(12345);
+}
+
+TEST_CASE(house_door_set_drops_tile_destroyed_door)
+{
+	ensureItemTypes();
+	const Position doorPos{121, 121, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(121, 121, 7);
+
+	auto house = std::make_shared<House>(707);
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(88);
+
+	auto tile = std::make_unique<DynamicTile>(doorPos.x, doorPos.y, doorPos.z);
+	g_game.map.setTile(doorPos.x, doorPos.y, doorPos.z, std::move(tile));
+	Tile* rawTile = g_game.map.getTile(doorPos);
+	rawTile->internalAddThing(door.get());
+
+	house->addDoor(door.get());
+	CHECK(house->getDoors().size() == 1);
+	CHECK(house->getDoorByNumber(88) == door);
+
+	// Map::removeTile removes and destroys tile contents, triggering Door::onRemoved()
+	door.reset();
+	g_game.map.removeTile(doorPos);
+
+	CHECK(house->getDoors().empty());
+	CHECK(house->getDoorByNumber(88) == nullptr);
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -58,11 +58,15 @@ public:
 struct MoveEventsFixture
 {
 	LuaFixture lua;
-	MoveEvents events;
-	MoveEvents* previous = g_moveEvents;
+	std::unique_ptr<MoveEvents> previous;
+	MoveEvents& events;
 
-	MoveEventsFixture() { g_moveEvents = &events; }
-	~MoveEventsFixture() { g_moveEvents = previous; }
+	MoveEventsFixture() : previous(std::make_unique<MoveEvents>()), events(*previous)
+	{
+		g_moveEvents.swap(previous);
+	}
+	// Restore the original owner; destroy the test events before closing Lua.
+	~MoveEventsFixture() { g_moveEvents.swap(previous); }
 };
 
 struct PlayerWorldEventsFixture
@@ -2576,7 +2580,7 @@ TEST_CASE(map_removal_does_not_remove_items_moved_away_by_callbacks)
 	Tile* source = g_game.map.getTile(sourcePos);
 	source->internalAddThing(std::make_shared<Item>(2160).get());
 	source->internalAddThing(std::make_shared<Item>(2160).get());
-	const auto movedItem = (*source->getItemList())[1];
+	const auto movedItem = source->getItemList()->at(1);
 	bool callbackRan = false;
 	auto event = std::make_unique<MoveEvent>(fixture.events.getScriptInterfacePtr());
 	event->setEventType(MOVE_EVENT_REMOVE_ITEM);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -47,11 +47,13 @@ struct ItemTypePropertyGuard
 	uint16_t itemId;
 	bool origMoveable;
 	bool origStackable;
+	Direction origBedPartnerDir;
 
 	explicit ItemTypePropertyGuard(uint16_t id)
 	    : itemId(id),
 	      origMoveable(Item::items.getItemType(id).moveable),
-	      origStackable(Item::items.getItemType(id).stackable)
+	      origStackable(Item::items.getItemType(id).stackable),
+	      origBedPartnerDir(Item::items.getItemType(id).bedPartnerDir)
 	{
 	}
 
@@ -59,6 +61,7 @@ struct ItemTypePropertyGuard
 	{
 		Item::items.getItemType(itemId).moveable = origMoveable;
 		Item::items.getItemType(itemId).stackable = origStackable;
+		Item::items.getItemType(itemId).bedPartnerDir = origBedPartnerDir;
 	}
 };
 
@@ -524,14 +527,14 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 {
 	ensureItemTypes();
 
+	ItemTypePropertyGuard guard694(694);
+	ItemTypePropertyGuard guard695(695);
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+	Item::items.getItemType(695).bedPartnerDir = DIRECTION_NORTH;
+
 	MapTileGuard tileGuard;
 	tileGuard.track(100, 100, 7);
 	tileGuard.track(100, 101, 7);
-
-	const auto origDir694 = Item::items.getItemType(694).bedPartnerDir;
-	const auto origDir695 = Item::items.getItemType(695).bedPartnerDir;
-	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
-	Item::items.getItemType(695).bedPartnerDir = DIRECTION_NORTH;
 
 	auto bed1 = std::make_shared<BedItem>(694);
 	auto bed2 = std::make_shared<BedItem>(695);
@@ -581,21 +584,18 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 	// Releasing partner must expire the weak pointer
 	partner.reset();
 	CHECK(weakBed2.expired());
-
-	Item::items.getItemType(694).bedPartnerDir = origDir694;
-	Item::items.getItemType(695).bedPartnerDir = origDir695;
 }
 
 TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
 {
 	ensureItemTypes();
 
+	ItemTypePropertyGuard guard694(694);
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+
 	MapTileGuard tileGuard;
 	tileGuard.track(200, 200, 7);
 	tileGuard.track(200, 201, 7);
-
-	const auto origDir694 = Item::items.getItemType(694).bedPartnerDir;
-	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
 
 	auto bed = std::make_shared<BedItem>(694);
 	auto tile = std::make_unique<DynamicTile>(200, 200, 7);
@@ -613,8 +613,6 @@ TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
 
 	// Target tile exists but has no bed -> returns nullptr
 	CHECK(bed->getNextBedItem() == nullptr);
-
-	Item::items.getItemType(694).bedPartnerDir = origDir694;
 }
 
 TEST_CASE(tile_get_bed_item_returns_nullptr_when_no_bed)
@@ -753,15 +751,15 @@ TEST_CASE(house_get_door_by_position_finds_door_and_preserves_identity_and_lifet
 	ensureItemTypes();
 
 	const Position doorPos{105, 105, 7};
-	MapTileGuard tileGuard;
-	tileGuard.track(105, 105, 7);
-
 	auto house = std::make_shared<House>(502);
 	auto door = std::make_shared<Door>(0);
 	door->setDoorId(30);
 	Door* rawDoor = door.get();
 
 	CHECK(g_game.map.getTile(doorPos) == nullptr);
+	MapTileGuard tileGuard;
+	tileGuard.track(105, 105, 7);
+
 	auto tile = std::make_unique<DynamicTile>(doorPos.x, doorPos.y, doorPos.z);
 	g_game.map.setTile(doorPos.x, doorPos.y, doorPos.z, std::move(tile));
 	Tile* rawTile = g_game.map.getTile(doorPos);
@@ -792,6 +790,7 @@ TEST_CASE(house_get_door_by_position_finds_door_and_preserves_identity_and_lifet
 	CHECK(retrievedDoor != nullptr);
 	CHECK(retrievedDoor.get() == rawDoor);
 	CHECK(retrievedDoor->getDoorId() == 30);
+	retrievedDoor.reset();
 }
 
 TEST_CASE(house_get_door_by_position_returns_nullptr_when_door_is_destroyed)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1690,7 +1690,9 @@ TEST_CASE(lua_tile_userdata_is_invalidated_after_map_removal)
 	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tileB));
 	Tile* rawTileB = g_game.map.getTile(pos);
 	CHECK(rawTileB != nullptr);
-	CHECK(rawTileB != rawTileA);
+	// The allocator may immediately reuse Tile A's address for Tile B. Object
+	// identity is verified by the weak Lua userdata checks below, not by comparing
+	// raw addresses from non-overlapping lifetimes.
 
 	// Push Tile B to Lua
 	Lua::pushUserdata<Tile>(L, rawTileB);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -390,6 +390,68 @@ TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
 	CHECK(bed->getNextBedItem() == nullptr);
 }
 
+TEST_CASE(tile_get_bed_item_returns_nullptr_when_no_bed)
+{
+	ensureItemTypes();
+
+	auto tile = std::make_unique<DynamicTile>(50, 50, 7);
+	CHECK(tile->getBedItem() == nullptr);
+
+	auto regularItem = std::make_shared<Item>(0);
+	tile->internalAddThing(regularItem.get());
+	CHECK(tile->getBedItem() == nullptr);
+}
+
+TEST_CASE(tile_get_bed_item_from_ground_preserves_identity_and_lifetime)
+{
+	ensureItemTypes();
+
+	auto tile = std::make_unique<DynamicTile>(51, 51, 7);
+	auto bedGround = std::make_shared<BedItem>(694);
+	BedItem* rawBed = bedGround.get();
+
+	tile->internalAddThing(bedGround.get());
+	tile->setFlag(TILESTATE_BED);
+
+	std::shared_ptr<BedItem> retrievedBed = tile->getBedItem();
+	CHECK(retrievedBed != nullptr);
+	CHECK(retrievedBed.get() == rawBed);
+	CHECK(retrievedBed == bedGround);
+
+	// Removing ground from tile keeps retrievedBed alive for caller
+	tile->setGround(nullptr);
+	tile->resetFlag(TILESTATE_BED);
+	CHECK(tile->getBedItem() == nullptr);
+	CHECK(retrievedBed != nullptr);
+	CHECK(retrievedBed.get() == rawBed);
+	CHECK(retrievedBed->getID() == 694);
+}
+
+TEST_CASE(tile_get_bed_item_from_item_list_preserves_identity_and_lifetime)
+{
+	ensureItemTypes();
+
+	auto tile = std::make_unique<DynamicTile>(52, 52, 7);
+	auto bed = std::make_shared<BedItem>(694);
+	BedItem* rawBed = bed.get();
+
+	tile->internalAddThing(bed.get());
+
+	std::shared_ptr<BedItem> retrievedBed = tile->getBedItem();
+	CHECK(retrievedBed != nullptr);
+	CHECK(retrievedBed == bed);
+	CHECK(retrievedBed.get() == rawBed);
+	CHECK(retrievedBed->getID() == 694);
+
+	// Clearing tile items preserves retrievedBed reference
+	tile->getItemList()->clear();
+	tile->resetFlag(TILESTATE_BED);
+	CHECK(tile->getBedItem() == nullptr);
+	CHECK(retrievedBed != nullptr);
+	CHECK(retrievedBed.get() == rawBed);
+	CHECK(retrievedBed->getID() == 694);
+}
+
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)
 {
 	auto container = std::make_shared<Container>(0, 2);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -411,6 +411,17 @@ TEST_CASE(bed_get_house_returns_nullptr_when_house_is_destroyed_and_can_remove)
 	CHECK(bed->canRemove());
 }
 
+TEST_CASE(house_add_bed_ignores_nullptr_and_set_owner_succeeds)
+{
+	auto house = std::make_shared<House>(702);
+	house->addBed(nullptr);
+	CHECK(house->getBeds().empty());
+
+	// setOwner should not crash or dereference nullptr in bedsList
+	house->setOwner(0, false);
+	CHECK(house->getOwner() == 0);
+}
+
 TEST_CASE(bed_get_house_preserves_lifetime_for_caller)
 {
 	auto bed = std::make_shared<BedItem>(0);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -2681,4 +2681,465 @@ TEST_CASE(lua_tile_equality_rejects_reused_addresses_and_missing_ownership_token
 	lua_pop(L, 1);
 }
 
+namespace {
+
+struct QuickLootLifetimeFixture
+{
+	PlayerWorldEventsFixture events;
+	MapTileGuard tiles;
+	ItemTypePropertyGuard lootType{2160};
+	const bool previousEnabled = ConfigManager::getBoolean(ConfigManager::QUICK_LOOT_ENABLED);
+	const Position playerPos{200, 200, 7};
+	const Position corpsePos{201, 200, 7};
+	std::shared_ptr<Player> player;
+	std::shared_ptr<Container> backpack;
+	std::shared_ptr<Container> corpse;
+
+	explicit QuickLootLifetimeFixture(uint16_t capacity = 8)
+	{
+		ConfigManager::setBoolean(ConfigManager::QUICK_LOOT_ENABLED, true);
+		auto& type = Item::items.getItemType(2160);
+		type.moveable = true;
+		type.pickupable = true;
+		type.stackable = false; // Track identities, independently of OTB stack settings.
+		for (const auto& pos : {playerPos, corpsePos}) {
+			tiles.track(pos.x, pos.y, pos.z);
+			auto tile = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
+			tile->internalAddThing(makeTestGround().get());
+			g_game.map.setTile(pos, std::move(tile));
+		}
+		player = makeTestPlayer(960, "QuickLootLifetimePlayer");
+		player->setCapacity(1000000);
+		CHECK(g_game.internalPlaceCreature(player.get(), playerPos, false, true));
+		backpack = std::make_shared<Container>(ITEM_BACKPACK, capacity);
+		static_cast<Cylinder&>(*player).internalAddThing(CONST_SLOT_BACKPACK, backpack.get());
+		corpse = std::make_shared<Container>(ITEM_BAG, 16);
+		corpse->setCorpseOwner(player->getID());
+		g_game.map.getTile(corpsePos)->internalAddThing(corpse.get());
+	}
+
+	~QuickLootLifetimeFixture()
+	{
+		if (player && !player->isRemoved()) {
+			g_game.removeCreature(player.get());
+		}
+		ConfigManager::setBoolean(ConfigManager::QUICK_LOOT_ENABLED, previousEnabled);
+	}
+
+	std::shared_ptr<Item> addLoot(Container* destination = nullptr)
+	{
+		auto item = std::make_shared<Item>(2160);
+		(destination ? destination : corpse.get())->internalAddThing(item.get());
+		return item;
+	}
+
+	void collect() { g_game.playerQuickLootCorpse(player->getID(), corpse.get()); }
+};
+
+} // namespace
+
+TEST_CASE(quickloot_nested_items_move_once_and_release_after_cleanup)
+{
+	ensureItemTypes();
+	std::vector<std::weak_ptr<Item>> weakItems;
+	{
+		QuickLootLifetimeFixture fixture;
+		auto nested = std::make_shared<Container>(ITEM_BAG, 8);
+		fixture.corpse->internalAddThing(nested.get());
+		for (size_t i = 0; i < 6; ++i) {
+			weakItems.push_back(fixture.addLoot(i % 2 ? nested.get() : nullptr));
+		}
+		fixture.collect();
+		for (const auto& weak : weakItems) {
+			auto item = weak.lock();
+			CHECK(item && item->getTopParent() == fixture.player.get());
+		}
+		const auto count = fixture.backpack->getItemTypeCount(2160);
+		CHECK(count == 6);
+		fixture.collect();
+		CHECK(fixture.backpack->getItemTypeCount(2160) == count);
+		CHECK(fixture.corpse->getItemTypeCount(2160) == 0);
+	}
+	g_game.cleanup();
+	for (const auto& weak : weakItems) {
+		CHECK(weak.expired());
+	}
+}
+
+TEST_CASE(quickloot_full_destination_preserves_items_and_can_retry)
+{
+	ensureItemTypes();
+	QuickLootLifetimeFixture fixture(1);
+	auto filler = fixture.addLoot(fixture.backpack.get());
+	auto loot = fixture.addLoot();
+	fixture.collect();
+	CHECK(loot->getParent() == fixture.corpse.get());
+	CHECK(fixture.corpse->size() == 1);
+	CHECK(fixture.backpack->size() == 1);
+	CHECK(g_game.internalRemoveItem(filler.get()) == RETURNVALUE_NOERROR);
+	fixture.collect();
+	CHECK(loot->getParent() == fixture.backpack.get());
+	CHECK(fixture.corpse->empty());
+	CHECK(fixture.backpack->size() == 1);
+	fixture.collect();
+	CHECK(fixture.backpack->size() == 1);
+}
+
+TEST_CASE(quickloot_rejects_foreign_or_disabled_corpses_without_moving_items)
+{
+	ensureItemTypes();
+	QuickLootLifetimeFixture fixture;
+	auto loot = fixture.addLoot();
+	fixture.corpse->setCorpseOwner(fixture.player->getID() + 100);
+	fixture.collect();
+	CHECK(loot->getParent() == fixture.corpse.get());
+	CHECK(fixture.backpack->empty());
+	fixture.corpse->setCorpseOwner(fixture.player->getID());
+	fixture.corpse->setCustomAttribute("QuickLootDisabled", true);
+	fixture.collect();
+	CHECK(loot->getParent() == fixture.corpse.get());
+	CHECK(fixture.backpack->empty());
+}
+
+TEST_CASE(quickloot_tile_removed_by_movement_callback_stops_the_batch)
+{
+	ensureItemTypes();
+	QuickLootLifetimeFixture fixture;
+	struct MaxCorpsesGuard {
+		int64_t previous = ConfigManager::getInteger(ConfigManager::QUICK_LOOT_MAX_CORPSES);
+		~MaxCorpsesGuard() { ConfigManager::setInteger(ConfigManager::QUICK_LOOT_MAX_CORPSES, previous); }
+	} maxGuard;
+	ConfigManager::setInteger(ConfigManager::QUICK_LOOT_MAX_CORPSES, 10);
+	fixture.addLoot();
+	auto second = std::make_shared<Container>(ITEM_BAG, 8);
+	second->setCorpseOwner(fixture.player->getID());
+	fixture.addLoot(second.get());
+	g_game.map.getTile(fixture.corpsePos)->internalAddThing(second.get());
+	const std::weak_ptr<Tile> weakTile = g_game.map.getTile(fixture.corpsePos)->weak_from_this();
+	bool callbackRan = false;
+	auto event = std::make_unique<MoveEvent>(fixture.events.movement.events.getScriptInterfacePtr());
+	event->setEventType(MOVE_EVENT_REMOVE_ITEM);
+	event->addPosList(fixture.corpsePos);
+	event->moveFunction = [&](Item*, Item*, const Position&) {
+		if (!callbackRan) {
+			callbackRan = true;
+			CHECK(g_game.map.removeTile(fixture.corpsePos));
+		}
+		return 1;
+	};
+	CHECK(fixture.events.movement.events.registerLuaEvent(event.release()));
+	g_game.playerQuickLoot(fixture.player->getID(), fixture.corpsePos, fixture.corpse->getClientID(), 1, true);
+	CHECK(callbackRan);
+	CHECK(g_game.map.getTile(fixture.corpsePos) == nullptr);
+	CHECK(weakTile.expired());
+	CHECK(fixture.backpack->getItemTypeCount(2160) == 1);
+}
+
+namespace {
+
+struct AutoLootLifetimeFixture : QuickLootLifetimeFixture
+{
+	const bool previousAutoloot = ConfigManager::getBoolean(ConfigManager::AUTOLOOT_ENABLED);
+	const bool previousBank = ConfigManager::getBoolean(ConfigManager::AUTOLOOT_AUTO_BANK);
+	const bool previousPouch = ConfigManager::getBoolean(ConfigManager::AUTOLOOT_GOLD_POUCH);
+
+	AutoLootLifetimeFixture()
+	{
+		ConfigManager::setBoolean(ConfigManager::AUTOLOOT_ENABLED, true);
+		ConfigManager::setBoolean(ConfigManager::AUTOLOOT_AUTO_BANK, false);
+		ConfigManager::setBoolean(ConfigManager::AUTOLOOT_GOLD_POUCH, false);
+		lua_State* L = events.movement.lua.L;
+		Lua::pushUserdata<Player>(L, player.get());
+		Lua::setMetatable(L, -1, "Player");
+		lua_setglobal(L, "looter");
+		CHECK(luaL_dostring(L, "assert(looter:setAutoLootEnabled(true))") == LUA_OK);
+		player->parseAutoLootWindow("*");
+	}
+	~AutoLootLifetimeFixture()
+	{
+		ConfigManager::setBoolean(ConfigManager::AUTOLOOT_ENABLED, previousAutoloot);
+		ConfigManager::setBoolean(ConfigManager::AUTOLOOT_AUTO_BANK, previousBank);
+		ConfigManager::setBoolean(ConfigManager::AUTOLOOT_GOLD_POUCH, previousPouch);
+	}
+};
+
+class OwnerTransitionTestHouse final : public House
+{
+public:
+	using House::House;
+	int ownerWrites = 0;
+	bool failLookup = false;
+	bool failWrite = false;
+
+protected:
+	OwnerData initializeOwnerDataFromDatabase(uint32_t guid, HouseType_t) override
+	{
+		if (failLookup) {
+			throw std::runtime_error("Test owner lookup failure");
+		}
+		return {guid, 700, "TestOwner", guid, "TestGuild"};
+	}
+	bool updateOwnerInDatabase(uint32_t, bool) override
+	{
+		++ownerWrites;
+		for (const auto& bed : getBeds()) {
+			CHECK(bed->getSleeper() == 0);
+		}
+		return !failWrite;
+	}
+};
+
+void checkHouseOwnerBedFailure(bool failSave)
+{
+	ensureItemTypes();
+	ensureVocations();
+	OfflineSleeperState states[2];
+	states[0].guid = 970;
+	states[1].guid = 971;
+	for (auto& state : states) {
+		state.batchStates = {&states[0], &states[1]};
+	}
+	PlayerWorldEventsFixture fixture;
+	MapTileGuard tiles;
+	struct FailureGuard {
+		OfflineSleeperState* states;
+		~FailureGuard() { states[1].failLoad = states[1].failSave = false; }
+	} failureGuard{states};
+	auto house = std::make_shared<OwnerTransitionTestHouse>(970);
+	CHECK(house->setOwner(970, false));
+	house->setProtected(true);
+	house->setAccessList(GUEST_LIST, "*");
+	house->setPayRentWarnings(3);
+	house->setPaidUntil(12345);
+	TilePlayersGuard players{{makeTestPlayer(970, "FirstOwnerSleeper"), makeTestPlayer(971, "SecondOwnerSleeper")}};
+	std::vector<std::shared_ptr<BedItem>> beds;
+	std::vector<std::string> before;
+	for (size_t i = 0; i < 2; ++i) {
+		const Position pos{static_cast<uint16_t>(220 + i * 3), 220, 7};
+		tiles.track(pos.x, pos.y, pos.z);
+		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+		tile->internalAddThing(makeTestGround().get());
+		g_game.map.setTile(pos, std::move(tile));
+		auto bed = std::make_shared<OfflineTestBedItem>(694, states[i]);
+		auto* source = g_game.map.getTile(pos);
+		source->internalAddThing(bed.get());
+		source->internalAddThing(players.players[i].get());
+		CHECK(bed->sleep(players.players[i].get()));
+		source->removeThing(players.players[i].get(), 0);
+		players.players[i]->setParent(nullptr);
+		PropWriteStream age;
+		age.write<uint32_t>(static_cast<uint32_t>(std::time(nullptr) - 1800));
+		PropStream input;
+		input.init(age.getStream().data(), age.getStream().size());
+		CHECK(bed->readAttr(ATTR_SLEEPSTART, input) == ATTR_READ_CONTINUE);
+		PropWriteStream attributes;
+		bed->serializeAttr(attributes);
+		before.emplace_back(attributes.getStream());
+		beds.push_back(std::move(bed));
+	}
+	states[1].failLoad = !failSave;
+	states[1].failSave = failSave;
+	CHECK(!house->setOwner(0));
+	// Lua callers must receive the failure too, not a false success.
+	lua_State* L = fixture.movement.lua.L;
+	Lua::pushSharedPtr(L, std::static_pointer_cast<House>(house));
+	Lua::setMetatable(L, -1, "House");
+	lua_setglobal(L, "ownerHouse");
+	CHECK(luaL_dostring(L, "assert(ownerHouse:setOwnerGuid(0) == false)") == LUA_OK);
+	CHECK(house->ownerWrites == 0);
+	CHECK(house->getOwner() == 970);
+	CHECK(house->getOwnerAccountId() == 700);
+	CHECK(house->getOwnerName() == "TestOwner");
+	CHECK(house->getProtected());
+	CHECK(house->getAccessList(GUEST_LIST).value() == "*");
+	CHECK(house->getPayRentWarnings() == 3);
+	CHECK(house->getPaidUntil() == 12345);
+	for (size_t i = 0; i < 2; ++i) {
+		CHECK(states[i].loadCount == 2);
+		CHECK(states[i].committedSaveCount == 0);
+		PropWriteStream attributes;
+		beds[i]->serializeAttr(attributes);
+		CHECK(attributes.getStream() == before[i]);
+		CHECK(g_game.getBedBySleeper(states[i].guid) == beds[i]);
+	}
+	states[1].failLoad = states[1].failSave = false;
+	CHECK(house->setOwner(0));
+	CHECK(house->ownerWrites == 1);
+	CHECK(house->getOwner() == 0);
+	for (size_t i = 0; i < 2; ++i) {
+		CHECK(states[i].committedSaveCount == 1);
+		CHECK(states[i].savedHealth == 70);
+		CHECK(beds[i]->getSleeper() == 0);
+		CHECK(g_game.getBedBySleeper(states[i].guid) == nullptr);
+	}
+	CHECK(house->setOwner(0));
+	CHECK(house->ownerWrites == 1);
+}
+
+} // namespace
+
+TEST_CASE(autoloot_nested_items_use_their_actual_parent_without_duplicates)
+{
+	ensureItemTypes();
+	AutoLootLifetimeFixture fixture;
+	auto nested = std::make_shared<Container>(ITEM_BAG, 8);
+	fixture.corpse->internalAddThing(nested.get());
+	auto first = fixture.addLoot(nested.get());
+	auto second = fixture.addLoot();
+	fixture.player->lootCorpse(fixture.corpse.get());
+	CHECK(first->getTopParent() == fixture.player.get());
+	CHECK(second->getTopParent() == fixture.player.get());
+	CHECK(fixture.corpse->empty());
+	CHECK(fixture.backpack->getItemTypeCount(2160) == 2);
+	fixture.player->lootCorpse(fixture.corpse.get());
+	CHECK(fixture.backpack->getItemTypeCount(2160) == 2);
+}
+
+TEST_CASE(autoloot_source_removed_by_callback_does_not_move_detached_loot)
+{
+	ensureItemTypes();
+	AutoLootLifetimeFixture fixture;
+	fixture.addLoot();
+	fixture.addLoot();
+	bool callbackRan = false;
+	auto event = std::make_unique<MoveEvent>(fixture.events.movement.events.getScriptInterfacePtr());
+	event->setEventType(MOVE_EVENT_REMOVE_ITEM);
+	event->addPosList(fixture.corpsePos);
+	event->moveFunction = [&](Item*, Item*, const Position&) {
+		if (!callbackRan) {
+			callbackRan = true;
+			CHECK(g_game.map.removeTile(fixture.corpsePos));
+		}
+		return 1;
+	};
+	CHECK(fixture.events.movement.events.registerLuaEvent(event.release()));
+	fixture.player->lootCorpse(fixture.corpse.get());
+	CHECK(callbackRan);
+	CHECK(g_game.map.getTile(fixture.corpsePos) == nullptr);
+	CHECK(fixture.backpack->getItemTypeCount(2160) == 1);
+}
+
+TEST_CASE(autoloot_filtered_nested_leaf_moves_without_moving_its_container)
+{
+	ensureItemTypes();
+	AutoLootLifetimeFixture fixture;
+	struct ListGuard {
+		const int64_t previousFree = ConfigManager::getInteger(ConfigManager::AUTOLOOT_MAXITEMS_FREE);
+		const int64_t previousPremium = ConfigManager::getInteger(ConfigManager::AUTOLOOT_MAXITEMS_PREMIUM);
+		~ListGuard()
+		{
+			Item::items.nameToItems.erase("pr264 lifetime loot");
+			ConfigManager::setInteger(ConfigManager::AUTOLOOT_MAXITEMS_FREE, previousFree);
+			ConfigManager::setInteger(ConfigManager::AUTOLOOT_MAXITEMS_PREMIUM, previousPremium);
+		}
+	} guard;
+	CHECK(Item::items.nameToItems.emplace("pr264 lifetime loot", 2160).second);
+	ConfigManager::setInteger(ConfigManager::AUTOLOOT_MAXITEMS_FREE, 5);
+	ConfigManager::setInteger(ConfigManager::AUTOLOOT_MAXITEMS_PREMIUM, 5);
+	fixture.player->parseAutoLootWindow("pr264 lifetime loot");
+	auto nested = std::make_shared<Container>(ITEM_BAG, 8);
+	fixture.corpse->internalAddThing(nested.get());
+	auto loot = fixture.addLoot(nested.get());
+	fixture.player->lootCorpse(fixture.corpse.get());
+	CHECK(loot->getParent() == fixture.backpack.get());
+	CHECK(nested->getParent() == fixture.corpse.get());
+	CHECK(nested->empty());
+	fixture.player->lootCorpse(fixture.corpse.get());
+	CHECK(fixture.backpack->getItemTypeCount(2160) == 1);
+}
+
+TEST_CASE(browse_field_removal_recreation_and_close_release_original_tile)
+{
+	ensureItemTypes();
+	QuickLootLifetimeFixture fixture;
+	auto* original = g_game.map.getTile(fixture.corpsePos);
+	const std::weak_ptr<Tile> weakOriginal = original->weak_from_this();
+	g_game.playerBrowseField(fixture.player->getID(), fixture.corpsePos);
+	auto browse = g_game.getBrowseFieldContainer(original, fixture.player->getInstanceID());
+	CHECK(browse);
+	CHECK(g_game.getBrowseFieldTile(browse.get()).get() == original);
+	CHECK(g_game.map.removeTile(fixture.corpsePos));
+	CHECK(browse->empty());
+	auto replacement = std::make_unique<DynamicTile>(fixture.corpsePos.x, fixture.corpsePos.y, fixture.corpsePos.z);
+	replacement->internalAddThing(makeTestGround().get());
+	g_game.map.setTile(fixture.corpsePos, std::move(replacement));
+	CHECK(g_game.getBrowseFieldContainer(g_game.map.getTile(fixture.corpsePos)) == nullptr);
+	const uint8_t cid = 0x0F - static_cast<uint8_t>((fixture.corpsePos.x % 3) * 3 + (fixture.corpsePos.y % 3));
+	fixture.player->closeContainer(cid);
+	g_game.cleanupBrowseFields();
+	browse.reset();
+	g_game.cleanup();
+	CHECK(weakOriginal.expired());
+	CHECK(g_game.map.getTile(fixture.corpsePos) != nullptr);
+}
+
+TEST_CASE(house_owner_bed_load_failure_preserves_the_entire_batch)
+{
+	checkHouseOwnerBedFailure(false);
+}
+
+TEST_CASE(house_owner_bed_save_failure_preserves_the_entire_batch)
+{
+	checkHouseOwnerBedFailure(true);
+}
+
+TEST_CASE(house_transfer_failure_releases_the_stale_document_identity)
+{
+	ensureItemTypes();
+	auto house = std::make_shared<OwnerTransitionTestHouse>(971);
+	CHECK(house->setOwner(971, false));
+	auto transferItem = house->getTransferItem();
+	CHECK(transferItem);
+	auto recipient = makeTestPlayer(972, "FailedHouseRecipient");
+	house->failLookup = true;
+	transferItem->onTradeEvent(ON_TRADE_TRANSFER, recipient.get());
+	CHECK(transferItem->getParent() == nullptr);
+	auto replacement = house->getTransferItem();
+	CHECK(replacement);
+	CHECK(replacement != transferItem);
+	CHECK(house->getOwner() == 971);
+}
+
+TEST_CASE(house_depot_transfer_survives_removal_of_a_queued_subcontainer)
+{
+	ensureItemTypes();
+	QuickLootLifetimeFixture fixture;
+	auto house = std::make_shared<OwnerTransitionTestHouse>(972);
+	CHECK(house->setOwner(fixture.player->getGUID(), false));
+	house->setTownId(1);
+	const Position pos{230, 230, 7};
+	fixture.tiles.track(pos.x, pos.y, pos.z);
+	auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+	tile->internalAddThing(makeTestGround().get());
+	g_game.map.setTile(pos, std::move(tile));
+	auto root = std::make_shared<Container>(ITEM_BAG, 8);
+	g_game.map.getTile(pos)->internalAddThing(root.get());
+	auto trigger = fixture.addLoot(root.get());
+	auto queued = std::make_shared<Container>(ITEM_BAG, 8);
+	fixture.addLoot(queued.get());
+	root->internalAddThing(queued.get()); // Visited and queued before trigger.
+	const std::weak_ptr<Container> weakQueued = queued;
+	queued.reset();
+	auto callbackRan = std::make_shared<bool>(false);
+	auto event = std::make_unique<MoveEvent>(fixture.events.movement.events.getScriptInterfacePtr());
+	event->setEventType(MOVE_EVENT_REMOVE_ITEM);
+	event->addPosList(pos);
+	event->moveFunction = [trigger, weakQueued, callbackRan](Item* item, Item*, const Position&) {
+		if (item == trigger.get() && !*callbackRan) {
+			*callbackRan = true;
+			auto victim = weakQueued.lock();
+			CHECK(victim);
+			CHECK(g_game.internalRemoveItem(victim.get()) == RETURNVALUE_NOERROR);
+			g_game.cleanup();
+		}
+		return 1;
+	};
+	CHECK(fixture.events.movement.events.registerLuaEvent(event.release()));
+	CHECK(house->setOwner(0, true, fixture.player.get()));
+	CHECK(*callbackRan);
+	CHECK(weakQueued.expired());
+	CHECK(trigger->getParent() == fixture.player->getInbox(1));
+	CHECK(root->getParent() == fixture.player->getInbox(1));
+}
+
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1903,6 +1903,16 @@ void checkFailedOfflineBedRemoval(bool failSave, bool removeWholeTile, bool remo
 	auto targetBed = removePartner ? partnerBed : bed;
 	Tile* targetTile = g_game.map.getTile(targetPos);
 	Item* ground = targetTile->getGround();
+	// Down-items added after the bed are visited first by the removal loop.
+	// They must survive a failed wake, not just the occupied bed itself.
+	const std::vector<std::shared_ptr<Item>> downItems{
+	    std::make_shared<Item>(2160), std::make_shared<Item>(2160)};
+	for (const auto& item : downItems) {
+		targetTile->internalAddThing(item.get());
+		CHECK(targetTile->getThingIndex(item.get()) < targetTile->getThingIndex(targetBed.get()));
+	}
+	const auto* itemList = targetTile->getItemList();
+	const std::vector<std::shared_ptr<Item>> itemsBefore(itemList->begin(), itemList->end());
 
 	offlineState.failLoad = !failSave;
 	offlineState.failSave = failSave;
@@ -1927,6 +1937,12 @@ void checkFailedOfflineBedRemoval(bool failSave, bool removeWholeTile, bool remo
 	CHECK(g_game.map.getTile(targetPos) == targetTile);
 	CHECK(targetTile->getGround() == ground);
 	CHECK(targetTile->getThingIndex(targetBed.get()) != -1);
+	itemList = targetTile->getItemList();
+	CHECK(std::vector<std::shared_ptr<Item>>(itemList->begin(), itemList->end()) == itemsBefore);
+	for (const auto& item : downItems) {
+		CHECK(!item->isRemoved());
+		CHECK(item->getParent() == targetTile);
+	}
 	CHECK(!targetBed->isRemoved());
 	CHECK(house->getBeds().size() == 2);
 	CHECK(house->getTileCount() == 2);
@@ -1959,6 +1975,12 @@ void checkFailedOfflineBedRemoval(bool failSave, bool removeWholeTile, bool remo
 	CHECK(offlineState.savedMana == 70);
 	CHECK(offlineState.savedSoul == 2);
 	CHECK(targetBed->isRemoved());
+	for (const auto& item : downItems) {
+		CHECK(item->isRemoved() == removeWholeTile);
+		if (!removeWholeTile) {
+			CHECK(item->getParent() == targetTile);
+		}
+	}
 	CHECK(house->getBeds().size() == 1);
 	CHECK(bed->getSleeper() == 0);
 	CHECK(partnerBed->getSleeper() == 0);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -178,7 +178,8 @@ TEST_CASE(door_get_house_returns_valid_shared_ptr_and_preserves_identity)
 	CHECK(retrievedHouse == house);
 	CHECK(retrievedHouse->getId() == 100);
 	CHECK(house->getDoors().size() == 1);
-	CHECK(house->getDoorByNumber(1) == door.get());
+	CHECK(house->getDoorByNumber(1) == door);
+	CHECK(house->getDoorByNumber(1).get() == door.get());
 }
 
 TEST_CASE(door_get_house_returns_nullptr_when_house_is_destroyed)
@@ -410,18 +411,27 @@ TEST_CASE(tile_get_bed_item_from_ground_preserves_identity_and_lifetime)
 	auto bedGround = std::make_shared<BedItem>(694);
 	BedItem* rawBed = bedGround.get();
 
-	tile->internalAddThing(bedGround.get());
+	tile->setGround(bedGround);
 	tile->setFlag(TILESTATE_BED);
+
+	// Assert bed is stored as ground and not in item list
+	CHECK(tile->getGround() == rawBed);
+	CHECK(tile->getItemList() == nullptr || tile->getItemList()->empty());
 
 	std::shared_ptr<BedItem> retrievedBed = tile->getBedItem();
 	CHECK(retrievedBed != nullptr);
 	CHECK(retrievedBed.get() == rawBed);
 	CHECK(retrievedBed == bedGround);
 
-	// Removing ground from tile keeps retrievedBed alive for caller
+	// Release test-created shared_ptr owner before removing from tile
+	bedGround.reset();
+
+	// Remove from actual storage location (ground)
 	tile->setGround(nullptr);
 	tile->resetFlag(TILESTATE_BED);
 	CHECK(tile->getBedItem() == nullptr);
+
+	// Validate retrievedBed remains alive and preserves identity
 	CHECK(retrievedBed != nullptr);
 	CHECK(retrievedBed.get() == rawBed);
 	CHECK(retrievedBed->getID() == 694);
@@ -437,19 +447,79 @@ TEST_CASE(tile_get_bed_item_from_item_list_preserves_identity_and_lifetime)
 
 	tile->internalAddThing(bed.get());
 
+	// Assert bed is stored in item list and not as ground
+	CHECK(tile->getGround() == nullptr);
+	CHECK(tile->getItemList() != nullptr);
+	CHECK(!tile->getItemList()->empty());
+
 	std::shared_ptr<BedItem> retrievedBed = tile->getBedItem();
 	CHECK(retrievedBed != nullptr);
 	CHECK(retrievedBed == bed);
 	CHECK(retrievedBed.get() == rawBed);
 	CHECK(retrievedBed->getID() == 694);
 
-	// Clearing tile items preserves retrievedBed reference
+	// Release test-created shared_ptr owner before removing from tile
+	bed.reset();
+
+	// Remove from actual storage location (item list)
 	tile->getItemList()->clear();
 	tile->resetFlag(TILESTATE_BED);
 	CHECK(tile->getBedItem() == nullptr);
+
+	// Validate retrievedBed remains alive and preserves identity
 	CHECK(retrievedBed != nullptr);
 	CHECK(retrievedBed.get() == rawBed);
 	CHECK(retrievedBed->getID() == 694);
+}
+
+TEST_CASE(house_get_door_by_number_finds_door_and_preserves_identity_and_lifetime)
+{
+	auto house = std::make_shared<House>(500);
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(10);
+	Door* rawDoor = door.get();
+
+	house->addDoor(door.get());
+
+	// Door found & identity
+	std::shared_ptr<Door> retrievedDoor = house->getDoorByNumber(10);
+	CHECK(retrievedDoor != nullptr);
+	CHECK(retrievedDoor.get() == rawDoor);
+	CHECK(retrievedDoor == door);
+	CHECK(retrievedDoor->getDoorId() == 10);
+
+	// Door non-existent
+	CHECK(house->getDoorByNumber(999) == nullptr);
+
+	// Release original owner
+	door.reset();
+	CHECK(retrievedDoor != nullptr);
+	CHECK(retrievedDoor.get() == rawDoor);
+
+	// Remove door from house
+	house->removeDoor(rawDoor);
+	CHECK(house->getDoorByNumber(10) == nullptr);
+
+	// retrievedDoor remains alive
+	CHECK(retrievedDoor != nullptr);
+	CHECK(retrievedDoor.get() == rawDoor);
+	CHECK(retrievedDoor->getDoorId() == 10);
+}
+
+TEST_CASE(house_get_door_by_number_returns_nullptr_when_door_is_destroyed)
+{
+	auto house = std::make_shared<House>(501);
+
+	{
+		auto door = std::make_shared<Door>(0);
+		door->setDoorId(20);
+		house->addDoor(door.get());
+		CHECK(house->getDoorByNumber(20) != nullptr);
+		// door goes out of scope and is destroyed
+	}
+
+	// weak_from_this().lock() fails -> returns nullptr
+	CHECK(house->getDoorByNumber(20) == nullptr);
 }
 
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -239,6 +239,33 @@ TEST_CASE(door_can_use_and_access_list_behavior)
 	CHECK(door->canUse(player.get()));
 }
 
+TEST_CASE(housetile_get_house_returns_valid_shared_ptr_and_preserves_identity)
+{
+	auto house = std::make_shared<House>(500);
+	auto houseTile = std::make_unique<HouseTile>(100, 100, 7, house.get());
+	house->addTile(houseTile.get());
+
+	auto retrievedHouse = houseTile->getHouse();
+	CHECK(retrievedHouse != nullptr);
+	CHECK(retrievedHouse == house);
+	CHECK(retrievedHouse->getId() == 500);
+	CHECK(retrievedHouse.get() == house.get());
+}
+
+TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_destroyed)
+{
+	std::unique_ptr<HouseTile> houseTile;
+	{
+		auto house = std::make_shared<House>(600);
+		houseTile = std::make_unique<HouseTile>(101, 101, 7, house.get());
+		house->addTile(houseTile.get());
+		CHECK(houseTile->getHouse() != nullptr);
+		CHECK(houseTile->getHouse()->getId() == 600);
+	}
+
+	CHECK(houseTile->getHouse() == nullptr);
+}
+
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)
 {
 	auto container = std::make_shared<Container>(0, 2);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -42,6 +42,40 @@ public:
 	bool prevConvertUnsafe{false};
 };
 
+struct ItemTypePropertyGuard
+{
+	uint16_t itemId;
+	bool origMoveable;
+	bool origStackable;
+
+	explicit ItemTypePropertyGuard(uint16_t id)
+	    : itemId(id),
+	      origMoveable(Item::items.getItemType(id).moveable),
+	      origStackable(Item::items.getItemType(id).stackable)
+	{
+	}
+
+	~ItemTypePropertyGuard()
+	{
+		Item::items.getItemType(itemId).moveable = origMoveable;
+		Item::items.getItemType(itemId).stackable = origStackable;
+	}
+};
+
+struct MapTileGuard
+{
+	std::vector<Position> positions;
+
+	void track(uint16_t x, uint16_t y, uint8_t z) { positions.emplace_back(x, y, z); }
+
+	~MapTileGuard()
+	{
+		for (const auto& pos : positions) {
+			g_game.map.removeTile(pos);
+		}
+	}
+};
+
 } // namespace
 
 TEST_CASE(item_lifetime_registry_tracks_destroyed_item)
@@ -490,6 +524,10 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 {
 	ensureItemTypes();
 
+	MapTileGuard tileGuard;
+	tileGuard.track(100, 100, 7);
+	tileGuard.track(100, 101, 7);
+
 	const auto origDir694 = Item::items.getItemType(694).bedPartnerDir;
 	const auto origDir695 = Item::items.getItemType(695).bedPartnerDir;
 	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
@@ -551,6 +589,10 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
 {
 	ensureItemTypes();
+
+	MapTileGuard tileGuard;
+	tileGuard.track(200, 200, 7);
+	tileGuard.track(200, 201, 7);
 
 	const auto origDir694 = Item::items.getItemType(694).bedPartnerDir;
 	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
@@ -851,6 +893,7 @@ TEST_CASE(lua_container_item_userdata_preserves_item_lifetime)
 TEST_CASE(player_remove_item_of_type_inventory_and_container_lifetime)
 {
 	ensureItemTypes();
+	ItemTypePropertyGuard guard100(100);
 	Item::items.getItemType(100).moveable = true;
 
 	auto player = makeTestPlayer(100, "RemoveItemPlayer");
@@ -897,6 +940,7 @@ TEST_CASE(player_remove_item_of_type_inventory_and_container_lifetime)
 TEST_CASE(player_remove_item_of_type_stackable_partial_and_multi_container)
 {
 	ensureItemTypes();
+	ItemTypePropertyGuard guard2160(2160);
 	Item::items.getItemType(2160).stackable = true;
 	Item::items.getItemType(2160).moveable = true;
 
@@ -934,6 +978,7 @@ TEST_CASE(player_remove_item_of_type_stackable_partial_and_multi_container)
 TEST_CASE(game_internal_remove_items_robust_against_concurrent_pre_removal)
 {
 	ensureItemTypes();
+	ItemTypePropertyGuard guard100(100);
 	Item::items.getItemType(100).moveable = true;
 
 	auto player = makeTestPlayer(102, "PreRemovePlayer");

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -2,6 +2,7 @@
 
 #include "../bed.h"
 #include "../configmanager.h"
+#include "../game.h"
 #include "../house.h"
 #include "../item.h"
 #include "../luascript.h"
@@ -319,6 +320,74 @@ TEST_CASE(bed_get_house_preserves_lifetime_for_caller)
 	callerHouseRef.reset();
 	CHECK(bed->getHouse() == nullptr);
 	CHECK(bed->canRemove());
+}
+
+TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetime)
+{
+	ensureItemTypes();
+
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+	Item::items.getItemType(695).bedPartnerDir = DIRECTION_NORTH;
+
+	auto bed1 = std::make_shared<BedItem>(694);
+	auto bed2 = std::make_shared<BedItem>(695);
+
+	auto tile1 = std::make_unique<DynamicTile>(100, 100, 7);
+	auto tile2 = std::make_unique<DynamicTile>(100, 101, 7);
+
+	Tile* rawTile1 = tile1.get();
+	Tile* rawTile2 = tile2.get();
+
+	g_game.map.setTile(100, 100, 7, std::move(tile1));
+	g_game.map.setTile(100, 101, 7, std::move(tile2));
+
+	rawTile1->internalAddThing(bed1.get());
+	rawTile2->internalAddThing(bed2.get());
+
+	// Test partner detection and identity
+	auto partner = bed1->getNextBedItem();
+	CHECK(partner != nullptr);
+	CHECK(partner == bed2);
+	CHECK(partner.get() == bed2.get());
+	CHECK(partner->getID() == 695);
+
+	// Test reverse partner
+	auto partnerReverse = bed2->getNextBedItem();
+	CHECK(partnerReverse != nullptr);
+	CHECK(partnerReverse == bed1);
+	CHECK(partnerReverse.get() == bed1.get());
+	CHECK(partnerReverse->getID() == 694);
+
+	// Test lifetime preservation when item is cleared from partner tile
+	rawTile2->getItemList()->clear();
+	CHECK(rawTile2->getBedItem() == nullptr);
+	CHECK(bed1->getNextBedItem() == nullptr);
+	CHECK(partner != nullptr);
+	CHECK(partner->getID() == 695);
+}
+
+TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
+{
+	ensureItemTypes();
+
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+
+	auto bed = std::make_shared<BedItem>(694);
+	auto tile = std::make_unique<DynamicTile>(200, 200, 7);
+	Tile* rawTile = tile.get();
+
+	g_game.map.setTile(200, 200, 7, std::move(tile));
+	rawTile->internalAddThing(bed.get());
+
+	// Target tile (200, 201, 7) does not exist -> returns nullptr
+	CHECK(bed->getNextBedItem() == nullptr);
+
+	// Create target tile without a bed item
+	auto emptyTile = std::make_unique<DynamicTile>(200, 201, 7);
+	g_game.map.setTile(200, 201, 7, std::move(emptyTile));
+
+	// Target tile exists but has no bed -> returns nullptr
+	CHECK(bed->getNextBedItem() == nullptr);
 }
 
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -65,6 +65,31 @@ struct MoveEventsFixture
 	~MoveEventsFixture() { g_moveEvents = previous; }
 };
 
+struct PlayerWorldEventsFixture
+{
+	// Construct Lua first and destroy it after all interfaces using that state.
+	MoveEventsFixture movement;
+	GlobalEvents globalEvents;
+	Events events;
+	Chat chat;
+	GlobalEvents* previousGlobalEvents = g_globalEvents;
+	Events* previousEvents = g_events;
+	Chat* previousChat = g_chat;
+
+	PlayerWorldEventsFixture()
+	{
+		g_globalEvents = &globalEvents;
+		g_events = &events;
+		g_chat = &chat;
+	}
+	~PlayerWorldEventsFixture()
+	{
+		g_globalEvents = previousGlobalEvents;
+		g_events = previousEvents;
+		g_chat = previousChat;
+	}
+};
+
 // These players are placed directly on tiles, without online registry/DB state.
 struct TilePlayersGuard
 {
@@ -326,9 +351,11 @@ struct OfflineSleeperState
 	bool failSave = false;
 	int loadCount = 0;
 	int saveCount = 0;
+	int committedSaveCount = 0;
 	int32_t savedHealth = 0;
 	uint32_t savedMana = 0;
 	uint8_t savedSoul = 0;
+	std::vector<OfflineSleeperState*> batchStates;
 };
 
 class OfflineTestBedItem final : public BedItem
@@ -359,15 +386,34 @@ protected:
 		    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_REGENERATION, -1, 0));
 	}
 
-	bool saveOfflineSleeper(Player* player) const override
+	bool saveOfflineSleepers(const std::vector<Player*>& players) const override
 	{
-		++state.saveCount;
-		if (state.failSave) {
-			return false;
+		// Simulate the same atomic boundary as SaveManager: a later write
+		// failure must not commit any earlier player's regenerated state.
+		std::vector<std::pair<Player*, OfflineSleeperState*>> pending;
+		for (Player* player : players) {
+			OfflineSleeperState* target = player->getGUID() == state.guid ? &state : nullptr;
+			for (auto* candidate : state.batchStates) {
+				if (candidate->guid == player->getGUID()) {
+					target = candidate;
+					break;
+				}
+			}
+			if (!target) {
+				return false;
+			}
+			++target->saveCount;
+			if (target->failSave) {
+				return false;
+			}
+			pending.emplace_back(player, target);
 		}
-		state.savedHealth = player->getHealth();
-		state.savedMana = player->getMana();
-		state.savedSoul = player->getSoul();
+		for (const auto& [player, target] : pending) {
+			++target->committedSaveCount;
+			target->savedHealth = player->getHealth();
+			target->savedMana = player->getMana();
+			target->savedSoul = player->getSoul();
+		}
 		return true;
 	}
 
@@ -2007,6 +2053,202 @@ TEST_CASE(offline_bed_save_failure_preserves_sleep_until_removal_retry)
 		for (bool removePartner : {false, true}) {
 			checkFailedOfflineBedRemoval(true, removeWholeTile, removePartner);
 		}
+	}
+}
+
+namespace {
+
+void checkAtomicBedTeardown(bool failSave, bool firstOnline)
+{
+	ensureItemTypes();
+	ensureVocations();
+	OfflineSleeperState states[2];
+	states[0].guid = 914;
+	states[1].guid = 915;
+	for (auto& state : states) {
+		state.batchStates = {&states[0], &states[1]};
+	}
+	ItemTypePropertyGuard firstTypeGuard(694);
+	ItemTypePropertyGuard secondTypeGuard(695);
+	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
+	Item::items.getItemType(695).bedPartnerDir = DIRECTION_EAST;
+	int removalCallbacks = 0;
+	MapTileGuard tileGuard;
+	PlayerWorldEventsFixture fixture;
+	struct FailureGuard {
+		OfflineSleeperState* states;
+		~FailureGuard()
+		{
+			for (size_t i = 0; i < 2; ++i) {
+				states[i].failLoad = states[i].failSave = false;
+			}
+		}
+	} failureGuard{states};
+	const Position pos{174, 170, 7};
+	const Position firstPartnerPos{174, 171, 7};
+	const Position secondPartnerPos{175, 170, 7};
+	const Position onlinePos{176, 170, 7};
+	constexpr ZoneId zoneId = 914;
+	auto house = std::make_shared<House>(914);
+	for (const auto& tilePos : {pos, firstPartnerPos, secondPartnerPos}) {
+		tileGuard.track(tilePos.x, tilePos.y, tilePos.z);
+		auto tile = std::make_unique<HouseTile>(tilePos.x, tilePos.y, tilePos.z, house);
+		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->setZoneIds({zoneId});
+		g_game.map.setTile(tilePos.x, tilePos.y, tilePos.z, std::move(tile));
+	}
+	tileGuard.track(onlinePos.x, onlinePos.y, onlinePos.z);
+	auto onlineTile = std::make_unique<DynamicTile>(onlinePos.x, onlinePos.y, onlinePos.z);
+	onlineTile->internalAddThing(std::make_shared<Item>(100).get());
+	g_game.map.setTile(onlinePos.x, onlinePos.y, onlinePos.z, std::move(onlineTile));
+	auto* source = g_game.map.getTile(pos);
+	auto firstBed = std::make_shared<OfflineTestBedItem>(694, states[0]);
+	auto secondBed = std::make_shared<OfflineTestBedItem>(695, states[1]);
+	auto firstPartner = std::make_shared<BedItem>(694);
+	auto secondPartner = std::make_shared<BedItem>(695);
+	g_game.map.getTile(firstPartnerPos)->internalAddThing(firstPartner.get());
+	g_game.map.getTile(secondPartnerPos)->internalAddThing(secondPartner.get());
+	// Insertion at the beginning of down-items makes the successful bed first.
+	source->internalAddThing(secondBed.get());
+	source->internalAddThing(firstBed.get());
+	CHECK(source->getThingIndex(firstBed.get()) < source->getThingIndex(secondBed.get()));
+	TilePlayersGuard players{{makeTestPlayer(914, "FirstBatchSleeper"), makeTestPlayer(915, "SecondBatchSleeper")}};
+	for (size_t i = 0; i < 2; ++i) {
+		auto player = players.players[i];
+		CHECK(player->setVocation(0));
+		player->setMaxHealth(100);
+		player->setHealth(10);
+		player->setMaxMana(100);
+		player->setMana(10);
+		CHECK(player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_REGENERATION, -1, 0)));
+		source->internalAddThing(player.get());
+		CHECK((i == 0 ? firstBed : secondBed)->sleep(player.get()));
+		player->getTile()->removeThing(player.get(), 0);
+		player->setParent(nullptr);
+	}
+	struct OnlineGuard {
+		std::shared_ptr<Player> player;
+		~OnlineGuard()
+		{
+			if (player && !player->isRemoved()) {
+				g_game.removeCreature(player.get());
+			}
+		}
+	} onlineGuard;
+	if (firstOnline) {
+		CHECK(g_game.internalPlaceCreature(players.players[0].get(), onlinePos, false, true));
+		onlineGuard.player = players.players[0];
+		CHECK(g_game.getPlayerByGUID(states[0].guid) == onlineGuard.player);
+	}
+
+	const std::vector<std::shared_ptr<BedItem>> allBeds{firstBed, secondBed, firstPartner, secondPartner};
+	PropWriteStream writeStream;
+	writeStream.write<uint32_t>(static_cast<uint32_t>(std::time(nullptr) - 1800));
+	const auto sleepStart = writeStream.getStream();
+	std::vector<std::string> attributesBefore;
+	std::vector<std::string> descriptionsBefore;
+	std::vector<uint16_t> idsBefore;
+	auto sleepAttributes = [](const BedItem& bed) {
+		PropWriteStream stream;
+		bed.serializeAttr(stream);
+		return std::string(stream.getStream());
+	};
+	for (const auto& bed : allBeds) {
+		PropStream readStream;
+		readStream.init(sleepStart.data(), sleepStart.size());
+		CHECK(bed->readAttr(ATTR_SLEEPSTART, readStream) == ATTR_READ_CONTINUE);
+		attributesBefore.push_back(sleepAttributes(*bed));
+		descriptionsBefore.emplace_back(bed->getSpecialDescription());
+		idsBefore.push_back(bed->getID());
+	}
+	auto item = std::make_shared<Item>(2160);
+	source->internalAddThing(item.get());
+	const auto* items = source->getItemList();
+	const std::vector<std::shared_ptr<Item>> itemsBefore(items->begin(), items->end());
+	auto event = std::make_unique<MoveEvent>(fixture.movement.events.getScriptInterfacePtr());
+	event->setEventType(MOVE_EVENT_REMOVE_ITEM);
+	event->addPosList(pos);
+	event->moveFunction = [&](Item*, Item*, const Position&) {
+		++removalCallbacks;
+		return 1;
+	};
+	CHECK(fixture.movement.events.registerLuaEvent(event.release()));
+
+	states[1].failLoad = !failSave;
+	states[1].failSave = failSave;
+	CHECK(!g_game.map.removeTile(pos));
+	g_game.cleanup();
+	CHECK(removalCallbacks == 0);
+	CHECK(states[0].loadCount == (firstOnline ? 0 : 1));
+	CHECK(states[1].loadCount == 1);
+	CHECK(states[0].saveCount == (failSave && !firstOnline ? 1 : 0));
+	CHECK(states[1].saveCount == (failSave ? 1 : 0));
+	for (const auto& state : states) {
+		CHECK(state.committedSaveCount == 0);
+		CHECK(state.savedHealth == 0);
+		CHECK(state.savedMana == 0);
+		CHECK(state.savedSoul == 0);
+	}
+	CHECK(g_game.map.getTile(pos) == source);
+	CHECK(std::vector<std::shared_ptr<Item>>(source->getItemList()->begin(), source->getItemList()->end()) == itemsBefore);
+	CHECK(item->getParent() == source);
+	CHECK(house->getBeds().size() == 4);
+	CHECK(Zones::getZonesByPosition(pos) == std::vector<ZoneId>{zoneId});
+	CHECK(g_game.getBedBySleeper(states[0].guid) == firstBed);
+	CHECK(g_game.getBedBySleeper(states[1].guid) == secondBed);
+	for (size_t i = 0; i < allBeds.size(); ++i) {
+		CHECK(sleepAttributes(*allBeds[i]) == attributesBefore[i]);
+		CHECK(allBeds[i]->getSpecialDescription() == descriptionsBefore[i]);
+		CHECK(allBeds[i]->getID() == idsBefore[i]);
+	}
+	CHECK(players.players[0]->getHealth() == 10);
+	CHECK(players.players[0]->getMana() == 10);
+	CHECK(players.players[0]->getSoul() == 0);
+
+	states[1].failLoad = states[1].failSave = false;
+	CHECK(g_game.map.removeTile(pos));
+	g_game.cleanup();
+	CHECK(g_game.map.getTile(pos) == nullptr);
+	CHECK(item->isRemoved());
+	CHECK(removalCallbacks > 0);
+	CHECK(Zones::getZonesByPosition(pos).empty());
+	for (size_t i = firstOnline ? 1 : 0; i < 2; ++i) {
+		CHECK(states[i].loadCount == 2);
+		CHECK(states[i].committedSaveCount == 1);
+		CHECK(states[i].savedHealth == 70);
+		CHECK(states[i].savedMana == 70);
+		CHECK(states[i].savedSoul == 2);
+	}
+	if (firstOnline) {
+		CHECK(states[0].loadCount == 0);
+		CHECK(states[0].saveCount == 0);
+		CHECK(players.players[0]->getHealth() == 70);
+		CHECK(players.players[0]->getMana() == 70);
+		CHECK(players.players[0]->getSoul() == 2);
+	}
+	CHECK(house->getBeds().size() == 2);
+	for (const auto& bed : allBeds) {
+		CHECK(bed->getSleeper() == 0);
+	}
+	CHECK(g_game.getBedBySleeper(states[0].guid) == nullptr);
+	CHECK(g_game.getBedBySleeper(states[1].guid) == nullptr);
+	CHECK(BedItem::wakeUpAll(allBeds));
+	CHECK(states[1].committedSaveCount == 1);
+}
+
+} // namespace
+
+TEST_CASE(map_bed_batch_load_failure_leaves_all_sleepers_unchanged)
+{
+	for (bool firstOnline : {false, true}) {
+		checkAtomicBedTeardown(false, firstOnline);
+	}
+}
+
+TEST_CASE(map_bed_batch_save_failure_leaves_all_sleepers_unchanged)
+{
+	for (bool firstOnline : {false, true}) {
+		checkAtomicBedTeardown(true, firstOnline);
 	}
 }
 

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -323,6 +323,38 @@ TEST_CASE(bed_get_house_preserves_lifetime_for_caller)
 	CHECK(bed->canRemove());
 }
 
+TEST_CASE(bed_set_house_preserves_identity_and_handles_nullptr_and_expiration)
+{
+	auto bed = std::make_shared<BedItem>(0);
+	CHECK(bed->getHouse() == nullptr);
+
+	auto house = std::make_shared<House>(900);
+	House* rawHouse = house.get();
+
+	// Set house via shared_ptr
+	bed->setHouse(house);
+	std::shared_ptr<House> retrievedHouse = bed->getHouse();
+	CHECK(retrievedHouse != nullptr);
+	CHECK(retrievedHouse == house);
+	CHECK(retrievedHouse.get() == rawHouse);
+	CHECK(retrievedHouse->getId() == 900);
+
+	// Set nullptr explicitly
+	bed->setHouse(nullptr);
+	CHECK(bed->getHouse() == nullptr);
+	CHECK(bed->canRemove());
+
+	// Test expiration
+	{
+		auto tempHouse = std::make_shared<House>(901);
+		bed->setHouse(tempHouse);
+		CHECK(bed->getHouse() != nullptr);
+		CHECK(bed->getHouse()->getId() == 901);
+	}
+	CHECK(bed->getHouse() == nullptr);
+	CHECK(bed->canRemove());
+}
+
 TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetime)
 {
 	ensureItemTypes();

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1442,4 +1442,154 @@ TEST_CASE(house_tile_registry_is_unregistered_when_map_tile_is_removed)
 	}
 }
 
+TEST_CASE(door_and_bed_remove_with_expired_first_element_regression)
+{
+	auto house = std::make_shared<House>(910);
+
+	// Create two doors
+	auto door1 = std::make_shared<Door>(0);
+	door1->setDoorId(1);
+	auto door2 = std::make_shared<Door>(0);
+	door2->setDoorId(2);
+
+	// Add both doors
+	house->addDoor(door1.get());
+	house->addDoor(door2.get());
+	CHECK(house->getDoors().size() == 2);
+
+	// Expire door1 (first element in doorList)
+	door1.reset();
+	g_game.cleanup();
+
+	// Now remove door2 (valid door, while first element is expired)
+	// This must not trigger iterator decrement UB (--it on begin()) and must successfully remove door2
+	house->removeDoor(door2.get());
+	CHECK(house->getDoors().empty());
+
+	// Create two beds
+	auto bed1 = std::make_shared<BedItem>(694);
+	auto bed2 = std::make_shared<BedItem>(694);
+
+	// Add both beds
+	house->addBed(bed1.get());
+	house->addBed(bed2.get());
+	CHECK(house->getBeds().size() == 2);
+
+	// Expire bed1 (first element in bedsList)
+	bed1.reset();
+	g_game.cleanup();
+
+	// Now remove bed2 (valid bed, while first element is expired)
+	// Must not trigger iterator decrement UB and must successfully remove bed2
+	house->removeBed(bed2.get());
+	CHECK(house->getBeds().empty());
+}
+
+TEST_CASE(house_door_bed_tile_pruning_prevents_unbounded_registry_growth)
+{
+	auto house = std::make_shared<House>(911);
+
+	// Repeat add -> expire -> add cycle multiple times
+	for (int i = 0; i < 5; ++i) {
+		auto door = std::make_shared<Door>(0);
+		door->setDoorId(100 + i);
+		house->addDoor(door.get());
+
+		auto bed = std::make_shared<BedItem>(694);
+		house->addBed(bed.get());
+
+		auto tile = std::make_shared<HouseTile>(10 + i, 10 + i, 7, house);
+		house->addTile(tile);
+
+		// Expire previous items
+		door.reset();
+		bed.reset();
+		tile.reset();
+		g_game.cleanup();
+	}
+
+	// Now add one new live door, bed, and tile
+	auto liveDoor = std::make_shared<Door>(0);
+	liveDoor->setDoorId(999);
+	house->addDoor(liveDoor.get());
+
+	auto liveBed = std::make_shared<BedItem>(694);
+	house->addBed(liveBed.get());
+
+	auto liveTile = std::make_shared<HouseTile>(50, 50, 7, house);
+	house->addTile(liveTile);
+
+	// addDoor, addBed, addTile pruned the dead entries, so the live counts are exactly 1
+	CHECK(house->getDoors().size() == 1);
+	CHECK(house->getDoorCount() == 1);
+	CHECK(house->getBeds().size() == 1);
+	CHECK(house->getBedCount() == 1);
+	CHECK(house->getTiles().size() == 1);
+	CHECK(house->getTileCount() == 1);
+}
+
+TEST_CASE(lua_tile_userdata_is_invalidated_after_map_removal)
+{
+	ensureItemTypes();
+	LuaFixture fixture;
+	lua_State* L = fixture.L;
+
+	const Position pos{160, 160, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(160, 160, 7);
+
+	// 1. Create Tile A on map
+	auto tileA = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
+	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tileA));
+	Tile* rawTileA = g_game.map.getTile(pos);
+	CHECK(rawTileA != nullptr);
+
+	// Push Tile A to Lua
+	Lua::pushUserdata<Tile>(L, rawTileA);
+	Lua::setMetatable(L, -1, "Tile");
+	lua_setglobal(L, "tileA");
+
+	// Verify Lua can read Tile A
+	lua_getglobal(L, "tileA");
+	Tile* luaTileA = Lua::getUserdata<Tile>(L, -1);
+	CHECK(luaTileA == rawTileA);
+	lua_pop(L, 1);
+
+	// 2. Remove Tile A from map
+	g_game.map.removeTile(pos);
+
+	// Verify old userdata for Tile A is now invalidated
+	lua_getglobal(L, "tileA");
+	Tile* invalidatedTileA = Lua::getUserdata<Tile>(L, -1);
+	CHECK(invalidatedTileA == nullptr);
+	lua_pop(L, 1);
+
+	// 3. Create new Tile B at the same position
+	auto tileB = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
+	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tileB));
+	Tile* rawTileB = g_game.map.getTile(pos);
+	CHECK(rawTileB != nullptr);
+	CHECK(rawTileB != rawTileA);
+
+	// Push Tile B to Lua
+	Lua::pushUserdata<Tile>(L, rawTileB);
+	Lua::setMetatable(L, -1, "Tile");
+	lua_setglobal(L, "tileB");
+
+	// Verify old userdata tileA remains invalidated (no ABA)
+	lua_getglobal(L, "tileA");
+	Tile* staleTileA = Lua::getUserdata<Tile>(L, -1);
+	CHECK(staleTileA == nullptr);
+	lua_pop(L, 1);
+
+	// Verify new userdata tileB is valid
+	lua_getglobal(L, "tileB");
+	Tile* validTileB = Lua::getUserdata<Tile>(L, -1);
+	CHECK(validTileB == rawTileB);
+	lua_pop(L, 1);
+
+	// Run Lua GC to verify proper destruction of weak userdata
+	lua_gc(L, LUA_GCCOLLECT, 0);
+}
+
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -274,6 +274,64 @@ TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_null_or_destroyed)
 	CHECK(houseTile->getHouse() == nullptr);
 }
 
+TEST_CASE(item_get_door_returns_nullptr_for_regular_item_and_valid_shared_ptr_for_door)
+{
+	// Regular Item returns nullptr
+	auto regularItem = std::make_shared<Item>(100);
+	CHECK(regularItem->getDoor() == nullptr);
+	const auto& constRegularItem = regularItem;
+	CHECK(constRegularItem->getDoor() == nullptr);
+
+	// Door returns valid shared_ptr and preserves identity
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(45);
+	Door* rawDoor = door.get();
+
+	std::shared_ptr<Door> nonConstDoor = door->getDoor();
+	CHECK(nonConstDoor != nullptr);
+	CHECK(nonConstDoor == door);
+	CHECK(nonConstDoor.get() == rawDoor);
+	CHECK(nonConstDoor->getDoorId() == 45);
+
+	const auto& constDoor = door;
+	std::shared_ptr<const Door> constDoorRef = constDoor->getDoor();
+	CHECK(constDoorRef != nullptr);
+	CHECK(constDoorRef == door);
+	CHECK(constDoorRef.get() == rawDoor);
+	CHECK(constDoorRef->getDoorId() == 45);
+
+	// Lifetime extension
+	door.reset();
+	CHECK(nonConstDoor != nullptr);
+	CHECK(nonConstDoor.get() == rawDoor);
+	CHECK(constDoorRef != nullptr);
+	CHECK(constDoorRef.get() == rawDoor);
+}
+
+TEST_CASE(housetile_update_house_registers_door_using_get_door_and_handles_destruction)
+{
+	auto house = std::make_shared<House>(560);
+	auto houseTile = std::make_unique<HouseTile>(112, 112, 7, house);
+	house->addTile(houseTile.get());
+
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(77);
+	CHECK(door->getHouse() == nullptr);
+
+	// Adding door with valid doorId to houseTile updates house registration
+	houseTile->internalAddThing(0, door.get());
+
+	CHECK(door->getHouse() != nullptr);
+	CHECK(door->getHouse() == house);
+	CHECK(house->getDoors().size() == 1);
+	CHECK(house->getDoorByNumber(77) == door);
+
+	// Safe removal / destruction
+	door->onRemoved();
+	CHECK(house->getDoorByNumber(77) == nullptr);
+	CHECK(house->getDoors().empty());
+}
+
 TEST_CASE(item_get_bed_returns_nullptr_for_regular_item_and_valid_shared_ptr_for_bed_item)
 {
 	// Regular Item returns nullptr

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -47,12 +47,14 @@ struct ItemTypePropertyGuard
 	uint16_t itemId;
 	bool origMoveable;
 	bool origStackable;
+	bool origPickupable;
 	Direction origBedPartnerDir;
 
 	explicit ItemTypePropertyGuard(uint16_t id)
 	    : itemId(id),
 	      origMoveable(Item::items.getItemType(id).moveable),
 	      origStackable(Item::items.getItemType(id).stackable),
+	      origPickupable(Item::items.getItemType(id).pickupable),
 	      origBedPartnerDir(Item::items.getItemType(id).bedPartnerDir)
 	{
 	}
@@ -61,6 +63,7 @@ struct ItemTypePropertyGuard
 	{
 		Item::items.getItemType(itemId).moveable = origMoveable;
 		Item::items.getItemType(itemId).stackable = origStackable;
+		Item::items.getItemType(itemId).pickupable = origPickupable;
 		Item::items.getItemType(itemId).bedPartnerDir = origBedPartnerDir;
 	}
 };
@@ -1187,6 +1190,256 @@ TEST_CASE(map_remove_tile_safely_removes_all_items_without_iterator_invalidation
 	CHECK(house->getDoors().empty());
 	CHECK(house->getBeds().empty());
 	CHECK(house->getTileCount() == 0);
+}
+
+TEST_CASE(door_reparenting_between_houses_and_destruction_lifetime)
+{
+	auto houseA = std::make_shared<House>(801);
+	auto houseB = std::make_shared<House>(802);
+	auto houseTileA = std::make_shared<HouseTile>(140, 140, 7, houseA);
+	auto houseTileB = std::make_shared<HouseTile>(141, 141, 7, houseB);
+	houseA->addTile(houseTileA);
+	houseB->addTile(houseTileB);
+
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(101);
+	std::weak_ptr<Door> weakDoor = door;
+
+	// Add door to houseTileA
+	houseTileA->internalAddThing(0, door.get());
+	CHECK(door->getHouse() == houseA);
+	CHECK(houseA->getDoors().size() == 1);
+	CHECK(houseA->getDoorByNumber(101) == door);
+	CHECK(houseB->getDoors().empty());
+	CHECK(houseB->getDoorByNumber(101) == nullptr);
+
+	// Move door to houseTileB: simulate move from tileA to tileB
+	houseTileA->removeThing(door.get(), 1);
+	houseTileB->internalAddThing(0, door.get());
+	CHECK(door->getHouse() == houseB);
+	CHECK(houseA->getDoors().empty());
+	CHECK(houseA->getDoorByNumber(101) == nullptr);
+	CHECK(houseB->getDoors().size() == 1);
+	CHECK(houseB->getDoorByNumber(101) == door);
+
+	// Resetting houseA owner must succeed without touching the door
+	houseA->setOwner(0);
+	CHECK(houseA->getDoors().empty());
+
+	// Destroy door: remove from tile and call onRemoved()
+	houseTileB->removeThing(door.get(), 1);
+	door->onRemoved();
+	door.reset();
+	g_game.cleanup();
+
+	CHECK(weakDoor.expired());
+	CHECK(houseB->getDoors().empty());
+	CHECK(houseB->getDoorByNumber(101) == nullptr);
+
+	// Resetting houseB owner must succeed without any UAF
+	houseB->setOwner(0);
+}
+
+TEST_CASE(bed_reparenting_between_houses_and_destruction_lifetime)
+{
+	auto houseA = std::make_shared<House>(803);
+	auto houseB = std::make_shared<House>(804);
+	auto houseTileA = std::make_shared<HouseTile>(142, 142, 7, houseA);
+	auto houseTileB = std::make_shared<HouseTile>(143, 143, 7, houseB);
+	houseA->addTile(houseTileA);
+	houseB->addTile(houseTileB);
+
+	auto bed = std::make_shared<BedItem>(694);
+	std::weak_ptr<BedItem> weakBed = bed;
+
+	// Add bed to houseTileA
+	houseTileA->internalAddThing(0, bed.get());
+	CHECK(bed->getHouse() == houseA);
+	CHECK(!bed->canRemove());
+	CHECK(houseA->getBeds().size() == 1);
+	CHECK(houseB->getBeds().empty());
+
+	// Move bed to houseTileB: simulate move from tileA to tileB
+	houseTileA->removeThing(bed.get(), 1);
+	houseTileB->internalAddThing(0, bed.get());
+	CHECK(bed->getHouse() == houseB);
+	CHECK(!bed->canRemove());
+	CHECK(houseA->getBeds().empty());
+	CHECK(houseB->getBeds().size() == 1);
+
+	// Resetting houseA owner must succeed without touching the bed
+	houseA->setOwner(0);
+	CHECK(houseA->getBeds().empty());
+
+	// Destroy bed: remove from tile and call onRemoved()
+	houseTileB->removeThing(bed.get(), 1);
+	bed->onRemoved();
+	bed.reset();
+	g_game.cleanup();
+
+	CHECK(weakBed.expired());
+	CHECK(houseB->getBeds().empty());
+
+	// Resetting houseB owner must succeed without any UAF
+	houseB->setOwner(0);
+}
+
+TEST_CASE(flag_nolimit_vs_can_remove_semantics)
+{
+	ensureItemTypes();
+	const Position pos{144, 144, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(144, 144, 7);
+
+	auto house = std::make_shared<House>(805);
+	auto houseTile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(houseTile));
+
+	Tile* rawTile = g_game.map.getTile(pos);
+	CHECK(rawTile != nullptr);
+
+	auto bed = std::make_shared<BedItem>(694);
+	std::weak_ptr<BedItem> weakBed = bed;
+	rawTile->internalAddThing(0, bed.get());
+	house->addBed(bed.get());
+
+	CHECK(!bed->canRemove());
+	CHECK(house->getBeds().size() == 1);
+
+	// Normal removal without FLAG_NOLIMIT fails because canRemove() is false
+	ReturnValue normalRet = g_game.internalRemoveItem(bed.get(), 1, false, 0);
+	CHECK(normalRet == RETURNVALUE_NOTPOSSIBLE);
+	CHECK(!bed->isRemoved());
+	CHECK(house->getBeds().size() == 1);
+
+	// Forced removal with FLAG_NOLIMIT bypasses canRemove() constraint
+	ReturnValue forcedRet = g_game.internalRemoveItem(bed.get(), 1, false, FLAG_NOLIMIT);
+	CHECK(forcedRet == RETURNVALUE_NOERROR);
+	CHECK(bed->isRemoved());
+	CHECK(house->getBeds().empty());
+
+	bed.reset();
+	g_game.cleanup();
+	CHECK(weakBed.expired());
+}
+
+TEST_CASE(house_reassigns_door_and_bed_without_stale_back_references)
+{
+	auto houseA = std::make_shared<House>(901);
+	auto houseB = std::make_shared<House>(902);
+
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(1);
+	auto bed = std::make_shared<BedItem>(694);
+
+	// Register in House A
+	houseA->addDoor(door.get());
+	houseA->addBed(bed.get());
+
+	CHECK(houseA->getDoors().size() == 1);
+	CHECK(houseA->getBeds().size() == 1);
+	CHECK(door->getHouse() == houseA);
+	CHECK(bed->getHouse() == houseA);
+
+	// Reassign to House B
+	houseB->addDoor(door.get());
+	houseB->addBed(bed.get());
+
+	CHECK(houseA->getDoors().empty());
+	CHECK(houseA->getBeds().empty());
+	CHECK(houseB->getDoors().size() == 1);
+	CHECK(houseB->getBeds().size() == 1);
+	CHECK(door->getHouse() == houseB);
+	CHECK(bed->getHouse() == houseB);
+
+	// Remove from House B and destroy
+	door->onRemoved();
+	bed->onRemoved();
+	door.reset();
+	bed.reset();
+	g_game.cleanup();
+
+	CHECK(houseA->getDoors().empty());
+	CHECK(houseA->getBeds().empty());
+	CHECK(houseB->getDoors().empty());
+	CHECK(houseB->getBeds().empty());
+
+	// Call methods on House A and House B under ASan
+	houseA->setOwner(0, false);
+	houseB->setOwner(0, false);
+	CHECK(houseA->getDoorByNumber(1) == nullptr);
+	CHECK(houseB->getDoorByNumber(1) == nullptr);
+	CHECK(houseA->getBedCount() == 0);
+	CHECK(houseB->getBedCount() == 0);
+}
+
+TEST_CASE(container_on_orphan_house_tile_does_not_dereference_expired_house)
+{
+	ensureItemTypes();
+	const Position pos{150, 150, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(150, 150, 7);
+
+	std::shared_ptr<HouseTile> orphanTile;
+	{
+		auto house = std::make_shared<House>(903);
+		auto houseTile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(houseTile));
+		orphanTile = std::static_pointer_cast<HouseTile>(g_game.map.getTile(pos)->weak_from_this().lock());
+	}
+	// House is now destroyed; orphanTile->getHouse() is nullptr
+	CHECK(orphanTile != nullptr);
+	CHECK(orphanTile->getHouse() == nullptr);
+
+	ItemTypePropertyGuard guard100(100);
+	Item::items.getItemType(100).moveable = true;
+	Item::items.getItemType(100).pickupable = true;
+
+	auto ground = std::make_shared<Item>(100);
+	orphanTile->setGround(ground);
+
+	auto container = std::make_shared<Container>(ITEM_BAG, 10);
+	orphanTile->internalAddThing(container.get());
+
+	auto item = std::make_shared<Item>(100);
+	container->addItem(item);
+
+	auto player = makeTestPlayer(10, "OrphanHousePlayer");
+
+	// Test queryAdd and queryRemove with ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS enabled
+	bool prevOnlyInvited = ConfigManager::getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS);
+	ConfigManager::setBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, true);
+
+	auto addRet = container->queryAdd(0, *item, 1, 0, player.get());
+	CHECK(addRet == RETURNVALUE_NOERROR);
+
+	auto removeRet = container->queryRemove(*item, 1, 0, player.get());
+	CHECK(removeRet == RETURNVALUE_NOERROR);
+
+	ConfigManager::setBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, prevOnlyInvited);
+}
+
+TEST_CASE(house_tile_registry_is_unregistered_when_map_tile_is_removed)
+{
+	ensureItemTypes();
+	const Position pos{151, 151, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(151, 151, 7);
+
+	auto house = std::make_shared<House>(904);
+
+	for (int cycle = 0; cycle < 3; ++cycle) {
+		auto houseTile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
+		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(houseTile));
+
+		CHECK(house->getTileCount() == 1);
+		CHECK(house->getTiles().size() == 1);
+
+		g_game.map.removeTile(pos);
+
+		CHECK(house->getTileCount() == 0);
+		CHECK(house->getTiles().empty());
+	}
 }
 
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -753,11 +753,15 @@ TEST_CASE(house_get_door_by_position_finds_door_and_preserves_identity_and_lifet
 	ensureItemTypes();
 
 	const Position doorPos{105, 105, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(105, 105, 7);
+
 	auto house = std::make_shared<House>(502);
 	auto door = std::make_shared<Door>(0);
 	door->setDoorId(30);
 	Door* rawDoor = door.get();
 
+	CHECK(g_game.map.getTile(doorPos) == nullptr);
 	auto tile = std::make_unique<DynamicTile>(doorPos.x, doorPos.y, doorPos.z);
 	g_game.map.setTile(doorPos.x, doorPos.y, doorPos.z, std::move(tile));
 	Tile* rawTile = g_game.map.getTile(doorPos);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -77,6 +77,26 @@ TEST_CASE(house_transfer_item_trade_cancel_resets_document)
 	CHECK(replacement != transferItem);
 }
 
+TEST_CASE(houses_get_house_preserves_house_lifetime)
+{
+	std::shared_ptr<House> house;
+	House* rawHouse = nullptr;
+	{
+		Houses houses;
+		rawHouse = houses.addHouse(42);
+		house = houses.getHouse(42);
+
+		CHECK(house != nullptr);
+		CHECK(house.get() == rawHouse);
+		CHECK(houses.getHouse(42) == house);
+		CHECK(houses.getHouse(43) == nullptr);
+	}
+
+	CHECK(house != nullptr);
+	CHECK(house.get() == rawHouse);
+	CHECK(house->getId() == 42);
+}
+
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)
 {
 	auto container = std::make_shared<Container>(0, 2);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1,5 +1,6 @@
 #include "../otpch.h"
 
+#include "../bed.h"
 #include "../configmanager.h"
 #include "../house.h"
 #include "../item.h"
@@ -264,6 +265,60 @@ TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_destroyed)
 	}
 
 	CHECK(houseTile->getHouse() == nullptr);
+}
+
+TEST_CASE(bed_get_house_returns_valid_shared_ptr_and_preserves_identity)
+{
+	auto bed = std::make_shared<BedItem>(0);
+	CHECK(bed->getHouse() == nullptr);
+
+	auto house = std::make_shared<House>(700);
+	house->addBed(bed.get());
+
+	auto retrievedHouse = bed->getHouse();
+	CHECK(retrievedHouse != nullptr);
+	CHECK(retrievedHouse == house);
+	CHECK(retrievedHouse->getId() == 700);
+	CHECK(retrievedHouse.get() == house.get());
+}
+
+TEST_CASE(bed_get_house_returns_nullptr_when_house_is_destroyed_and_can_remove)
+{
+	auto bed = std::make_shared<BedItem>(0);
+	CHECK(bed->canRemove());
+
+	{
+		auto house = std::make_shared<House>(701);
+		house->addBed(bed.get());
+		CHECK(bed->getHouse() != nullptr);
+		CHECK(!bed->canRemove());
+	}
+
+	CHECK(bed->getHouse() == nullptr);
+	CHECK(bed->canRemove());
+}
+
+TEST_CASE(bed_get_house_preserves_lifetime_for_caller)
+{
+	auto bed = std::make_shared<BedItem>(0);
+	std::shared_ptr<House> callerHouseRef;
+
+	{
+		auto house = std::make_shared<House>(800);
+		house->addBed(bed.get());
+		callerHouseRef = bed->getHouse();
+		CHECK(callerHouseRef != nullptr);
+	}
+
+	// Original house out of scope, but callerHouseRef still keeps house alive
+	CHECK(callerHouseRef != nullptr);
+	CHECK(callerHouseRef->getId() == 800);
+	CHECK(bed->getHouse() != nullptr);
+
+	// When caller releases reference, house is destroyed
+	callerHouseRef.reset();
+	CHECK(bed->getHouse() == nullptr);
+	CHECK(bed->canRemove());
 }
 
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -333,6 +333,7 @@ TEST_CASE(bed_set_house_preserves_identity_and_handles_nullptr_and_expiration)
 
 	// Set house via shared_ptr
 	bed->setHouse(house);
+	CHECK(!bed->canRemove());
 	std::shared_ptr<House> retrievedHouse = bed->getHouse();
 	CHECK(retrievedHouse != nullptr);
 	CHECK(retrievedHouse == house);
@@ -348,6 +349,7 @@ TEST_CASE(bed_set_house_preserves_identity_and_handles_nullptr_and_expiration)
 	{
 		auto tempHouse = std::make_shared<House>(901);
 		bed->setHouse(tempHouse);
+		CHECK(!bed->canRemove());
 		CHECK(bed->getHouse() != nullptr);
 		CHECK(bed->getHouse()->getId() == 901);
 	}

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -80,21 +80,57 @@ TEST_CASE(house_transfer_item_trade_cancel_resets_document)
 TEST_CASE(houses_get_house_preserves_house_lifetime)
 {
 	std::shared_ptr<House> house;
-	House* rawHouse = nullptr;
+	std::shared_ptr<House> addedHouse;
 	{
 		Houses houses;
-		rawHouse = houses.addHouse(42);
+		addedHouse = houses.addHouse(42);
 		house = houses.getHouse(42);
 
 		CHECK(house != nullptr);
-		CHECK(house.get() == rawHouse);
+		CHECK(house == addedHouse);
 		CHECK(houses.getHouse(42) == house);
 		CHECK(houses.getHouse(43) == nullptr);
 	}
 
 	CHECK(house != nullptr);
-	CHECK(house.get() == rawHouse);
+	CHECK(house == addedHouse);
 	CHECK(house->getId() == 42);
+}
+
+TEST_CASE(houses_add_house_creates_and_returns_shared_ptr)
+{
+	Houses houses;
+	auto house100 = houses.addHouse(100);
+	CHECK(house100 != nullptr);
+	CHECK(house100->getId() == 100);
+
+	auto house100_again = houses.addHouse(100);
+	CHECK(house100_again != nullptr);
+	CHECK(house100 == house100_again);
+	CHECK(house100.get() == house100_again.get());
+
+	auto house200 = houses.addHouse(200);
+	CHECK(house200 != nullptr);
+	CHECK(house200->getId() == 200);
+	CHECK(house100 != house200);
+
+	CHECK(houses.getHouse(100) == house100);
+	CHECK(houses.getHouse(200) == house200);
+	CHECK(houses.getHouse(300) == nullptr);
+}
+
+TEST_CASE(houses_add_house_preserves_lifetime_beyond_houses_scope)
+{
+	std::shared_ptr<House> house;
+	{
+		Houses houses;
+		house = houses.addHouse(100);
+		CHECK(house != nullptr);
+		CHECK(house->getId() == 100);
+	}
+
+	CHECK(house != nullptr);
+	CHECK(house->getId() == 100);
 }
 
 TEST_CASE(container_get_item_by_index_preserves_item_lifetime)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1117,4 +1117,76 @@ TEST_CASE(house_door_set_drops_tile_destroyed_door)
 	CHECK(house->getDoorByNumber(88) == nullptr);
 }
 
+TEST_CASE(map_remove_tile_safely_removes_all_items_without_iterator_invalidation)
+{
+	ensureItemTypes();
+	const Position tilePos{122, 122, 7};
+	MapTileGuard tileGuard;
+	tileGuard.track(122, 122, 7);
+
+	auto house = std::make_shared<House>(708);
+	auto houseTile = std::make_unique<HouseTile>(tilePos.x, tilePos.y, tilePos.z, house);
+	g_game.map.setTile(tilePos.x, tilePos.y, tilePos.z, std::move(houseTile));
+
+	Tile* rawTile = g_game.map.getTile(tilePos);
+	CHECK(rawTile != nullptr);
+
+	auto ground = std::make_shared<Item>(100);
+	auto item1 = std::make_shared<Item>(2160);
+	auto item2 = std::make_shared<Item>(2160);
+	auto door = std::make_shared<Door>(0);
+	door->setDoorId(99);
+	auto bed = std::make_shared<BedItem>(694);
+
+	std::weak_ptr<Item> weakGround = ground;
+	std::weak_ptr<Item> weak1 = item1;
+	std::weak_ptr<Item> weak2 = item2;
+	std::weak_ptr<Door> weakDoor = door;
+	std::weak_ptr<BedItem> weakBed = bed;
+
+	rawTile->setGround(ground);
+	rawTile->internalAddThing(0, item1.get());
+	rawTile->internalAddThing(0, item2.get());
+	rawTile->internalAddThing(0, door.get());
+	rawTile->internalAddThing(0, bed.get());
+
+	house->addDoor(door.get());
+	house->addBed(bed.get());
+
+	CHECK(house->getDoors().size() == 1);
+	CHECK(house->getBeds().size() == 1);
+
+	// Release local strong pointers
+	ground.reset();
+	item1.reset();
+	item2.reset();
+	door.reset();
+	bed.reset();
+
+	CHECK(!weakGround.expired());
+	CHECK(!weak1.expired());
+	CHECK(!weak2.expired());
+	CHECK(!weakDoor.expired());
+	CHECK(!weakBed.expired());
+
+	// Remove tile from map: must remove all items safely via snapshot
+	g_game.map.removeTile(tilePos);
+	CHECK(g_game.map.getTile(tilePos) == nullptr);
+
+	// Flush deferred releases
+	g_game.cleanup();
+
+	// All items must be removed and destroyed (none skipped due to iterator invalidation)
+	CHECK(weakGround.expired());
+	CHECK(weak1.expired());
+	CHECK(weak2.expired());
+	CHECK(weakDoor.expired());
+	CHECK(weakBed.expired());
+
+	// House registries must be clean
+	CHECK(house->getDoors().empty());
+	CHECK(house->getBeds().empty());
+	CHECK(house->getTileCount() == 0);
+}
+
 TFS_TEST_MAIN()

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -21,6 +21,8 @@ class LuaFixture
 public:
 	LuaFixture()
 	{
+		prevWarnUnsafe = ConfigManager::getBoolean(ConfigManager::WARN_UNSAFE_SCRIPTS);
+		prevConvertUnsafe = ConfigManager::getBoolean(ConfigManager::CONVERT_UNSAFE_SCRIPTS);
 		ConfigManager::setBoolean(ConfigManager::WARN_UNSAFE_SCRIPTS, false);
 		ConfigManager::setBoolean(ConfigManager::CONVERT_UNSAFE_SCRIPTS, false);
 		CHECK(g_luaEnvironment.initState());
@@ -28,9 +30,16 @@ public:
 		CHECK(L != nullptr);
 	}
 
-	~LuaFixture() { g_luaEnvironment.closeState(); }
+	~LuaFixture()
+	{
+		g_luaEnvironment.closeState();
+		ConfigManager::setBoolean(ConfigManager::WARN_UNSAFE_SCRIPTS, prevWarnUnsafe);
+		ConfigManager::setBoolean(ConfigManager::CONVERT_UNSAFE_SCRIPTS, prevConvertUnsafe);
+	}
 
 	lua_State* L = nullptr;
+	bool prevWarnUnsafe{false};
+	bool prevConvertUnsafe{false};
 };
 
 } // namespace
@@ -483,6 +492,8 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 {
 	ensureItemTypes();
 
+	const auto origDir694 = Item::items.getItemType(694).bedPartnerDir;
+	const auto origDir695 = Item::items.getItemType(695).bedPartnerDir;
 	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
 	Item::items.getItemType(695).bedPartnerDir = DIRECTION_NORTH;
 
@@ -521,12 +532,16 @@ TEST_CASE(bed_get_next_bed_item_finds_partner_and_preserves_identity_and_lifetim
 	CHECK(bed1->getNextBedItem() == nullptr);
 	CHECK(partner != nullptr);
 	CHECK(partner->getID() == 695);
+
+	Item::items.getItemType(694).bedPartnerDir = origDir694;
+	Item::items.getItemType(695).bedPartnerDir = origDir695;
 }
 
 TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
 {
 	ensureItemTypes();
 
+	const auto origDir694 = Item::items.getItemType(694).bedPartnerDir;
 	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
 
 	auto bed = std::make_shared<BedItem>(694);
@@ -545,6 +560,8 @@ TEST_CASE(bed_get_next_bed_item_returns_nullptr_when_partner_absent)
 
 	// Target tile exists but has no bed -> returns nullptr
 	CHECK(bed->getNextBedItem() == nullptr);
+
+	Item::items.getItemType(694).bedPartnerDir = origDir694;
 }
 
 TEST_CASE(tile_get_bed_item_returns_nullptr_when_no_bed)

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -324,6 +324,25 @@ void ensureItemTypes()
 	CHECK(loaded);
 }
 
+std::shared_ptr<Item> makeTestGround()
+{
+	ensureItemTypes();
+	// Client IDs can change classification between OTB versions. Select an
+	// actual walkable ground instead of assuming item 100 is always ground.
+	static const uint16_t groundId = [] {
+		for (size_t id = 1; id < Item::items.size(); ++id) {
+			const auto& type = Item::items[id];
+			if (type.id != 0 && type.isGroundTile() && !type.blockSolid && !type.blockPathFind) {
+				return type.id;
+			}
+		}
+		return uint16_t{0};
+	}();
+	CHECK(groundId != 0);
+	CHECK(Item::items[groundId].isGroundTile());
+	return std::make_shared<Item>(groundId);
+}
+
 void ensureVocations()
 {
 	static const bool loaded = [] {
@@ -1292,7 +1311,7 @@ TEST_CASE(map_remove_tile_safely_removes_all_items_without_iterator_invalidation
 	Tile* rawTile = g_game.map.getTile(tilePos);
 	CHECK(rawTile != nullptr);
 
-	auto ground = std::make_shared<Item>(100);
+	auto ground = makeTestGround();
 	auto item1 = std::make_shared<Item>(2160);
 	auto item2 = std::make_shared<Item>(2160);
 	auto door = std::make_shared<Door>(0);
@@ -1498,7 +1517,7 @@ TEST_CASE(flag_nolimit_does_not_remove_special_nonremovable_containers)
 	tileGuard.track(pos.x, pos.y, pos.z);
 
 	auto tile = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
-	tile->internalAddThing(std::make_shared<Item>(100).get());
+	tile->internalAddThing(makeTestGround().get());
 	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
 	Tile* rawTile = g_game.map.getTile(pos);
 	CHECK(rawTile != nullptr);
@@ -1607,7 +1626,7 @@ TEST_CASE(orphan_house_tile_fails_closed_for_players_and_allows_map_cleanup)
 	Item::items.getItemType(100).moveable = true;
 	Item::items.getItemType(100).pickupable = true;
 
-	auto ground = std::make_shared<Item>(100);
+	auto ground = makeTestGround();
 	orphanTile->internalAddThing(ground.get());
 	CHECK(orphanTile->getGround() == ground.get());
 	CHECK(ground->getParent() == orphanTile);
@@ -1798,15 +1817,15 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 	tileGuard.track(partnerPos.x, partnerPos.y, partnerPos.z);
 
 	auto startTile = std::make_unique<DynamicTile>(startPos.x, startPos.y, startPos.z);
-	startTile->internalAddThing(std::make_shared<Item>(100).get());
+	startTile->internalAddThing(makeTestGround().get());
 	g_game.map.setTile(startPos.x, startPos.y, startPos.z, std::move(startTile));
 
 	auto house = std::make_shared<House>(912);
 	auto houseTile = std::make_unique<HouseTile>(bedPos.x, bedPos.y, bedPos.z, house);
-	houseTile->internalAddThing(std::make_shared<Item>(100).get());
+	houseTile->internalAddThing(makeTestGround().get());
 	g_game.map.setTile(bedPos.x, bedPos.y, bedPos.z, std::move(houseTile));
 	auto partnerTile = std::make_unique<HouseTile>(partnerPos.x, partnerPos.y, partnerPos.z, house);
-	partnerTile->internalAddThing(std::make_shared<Item>(100).get());
+	partnerTile->internalAddThing(makeTestGround().get());
 	g_game.map.setTile(partnerPos.x, partnerPos.y, partnerPos.z, std::move(partnerTile));
 	for (const auto& pos : {startPos, bedPos, partnerPos}) {
 		const auto* tile = g_game.map.getTile(pos);
@@ -1929,7 +1948,7 @@ void checkFailedOfflineBedRemoval(bool failSave, bool removeWholeTile, bool remo
 	for (const auto& pos : {bedPos, partnerPos}) {
 		tileGuard.track(pos.x, pos.y, pos.z);
 		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
-		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->internalAddThing(makeTestGround().get());
 		tile->setZoneIds({zoneId});
 		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
 	}
@@ -2115,13 +2134,13 @@ void checkAtomicBedTeardown(bool failSave, bool firstOnline)
 	for (const auto& tilePos : {pos, firstPartnerPos, secondPartnerPos}) {
 		tileGuard.track(tilePos.x, tilePos.y, tilePos.z);
 		auto tile = std::make_unique<HouseTile>(tilePos.x, tilePos.y, tilePos.z, house);
-		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->internalAddThing(makeTestGround().get());
 		tile->setZoneIds({zoneId});
 		g_game.map.setTile(tilePos.x, tilePos.y, tilePos.z, std::move(tile));
 	}
 	tileGuard.track(onlinePos.x, onlinePos.y, onlinePos.z);
 	auto onlineTile = std::make_unique<DynamicTile>(onlinePos.x, onlinePos.y, onlinePos.z);
-	onlineTile->internalAddThing(std::make_shared<Item>(100).get());
+	onlineTile->internalAddThing(makeTestGround().get());
 	g_game.map.setTile(onlinePos.x, onlinePos.y, onlinePos.z, std::move(onlineTile));
 	auto* source = g_game.map.getTile(pos);
 	auto firstBed = std::make_shared<OfflineTestBedItem>(694, states[0]);
@@ -2488,12 +2507,12 @@ TEST_CASE(house_access_list_kicks_survive_tile_and_creature_removal_callbacks)
 	for (const auto& pos : {firstPos, secondPos}) {
 		tileGuard.track(pos.x, pos.y, pos.z);
 		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
-		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->internalAddThing(makeTestGround().get());
 		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
 	}
 	tileGuard.track(exitPos.x, exitPos.y, exitPos.z);
 	auto exitTile = std::make_unique<DynamicTile>(exitPos.x, exitPos.y, exitPos.z);
-	exitTile->internalAddThing(std::make_shared<Item>(100).get());
+	exitTile->internalAddThing(makeTestGround().get());
 	g_game.map.setTile(exitPos.x, exitPos.y, exitPos.z, std::move(exitTile));
 
 	TilePlayersGuard players{{makeTestPlayer(930, "FirstGuest"), makeTestPlayer(931, "SecondGuest"),
@@ -2538,7 +2557,7 @@ TEST_CASE(removal_callbacks_can_remove_and_recreate_the_source_tile)
 		tileGuard.track(pos.x, pos.y, pos.z);
 		auto house = std::make_shared<House>(940);
 		auto tile = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
-		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->internalAddThing(makeTestGround().get());
 		auto originalItem = std::make_shared<Item>(2160);
 		tile->internalAddThing(originalItem.get());
 		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
@@ -2556,7 +2575,7 @@ TEST_CASE(removal_callbacks_can_remove_and_recreate_the_source_tile)
 				CHECK(g_game.map.getTile(pos) == nullptr);
 				CHECK(!oldTile.expired()); // The outer notification still uses this object.
 				auto replacement = std::make_unique<HouseTile>(pos.x, pos.y, pos.z, house);
-				replacement->internalAddThing(std::make_shared<Item>(100).get());
+				replacement->internalAddThing(makeTestGround().get());
 				replacement->internalAddThing(replacementItem.get());
 				g_game.map.setTile(pos.x, pos.y, pos.z, std::move(replacement));
 			}
@@ -2592,7 +2611,7 @@ TEST_CASE(map_removal_does_not_remove_items_moved_away_by_callbacks)
 	for (const auto& pos : {sourcePos, destinationPos}) {
 		tileGuard.track(pos.x, pos.y, pos.z);
 		auto tile = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
-		tile->internalAddThing(std::make_shared<Item>(100).get());
+		tile->internalAddThing(makeTestGround().get());
 		g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
 	}
 	Tile* source = g_game.map.getTile(sourcePos);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -245,7 +245,7 @@ TEST_CASE(door_can_use_and_access_list_behavior)
 TEST_CASE(housetile_get_house_returns_valid_shared_ptr_and_preserves_identity)
 {
 	auto house = std::make_shared<House>(500);
-	auto houseTile = std::make_unique<HouseTile>(100, 100, 7, house.get());
+	auto houseTile = std::make_unique<HouseTile>(100, 100, 7, house);
 	house->addTile(houseTile.get());
 
 	auto retrievedHouse = houseTile->getHouse();
@@ -255,12 +255,17 @@ TEST_CASE(housetile_get_house_returns_valid_shared_ptr_and_preserves_identity)
 	CHECK(retrievedHouse.get() == house.get());
 }
 
-TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_destroyed)
+TEST_CASE(housetile_get_house_returns_nullptr_when_house_is_null_or_destroyed)
 {
+	// Null/empty shared_ptr
+	auto nullHouseTile = std::make_unique<HouseTile>(102, 102, 7, nullptr);
+	CHECK(nullHouseTile->getHouse() == nullptr);
+
+	// Expiration after House dies
 	std::unique_ptr<HouseTile> houseTile;
 	{
 		auto house = std::make_shared<House>(600);
-		houseTile = std::make_unique<HouseTile>(101, 101, 7, house.get());
+		houseTile = std::make_unique<HouseTile>(101, 101, 7, house);
 		house->addTile(houseTile.get());
 		CHECK(houseTile->getHouse() != nullptr);
 		CHECK(houseTile->getHouse()->getId() == 600);

--- a/src/tests/test_item_lifetime.cpp
+++ b/src/tests/test_item_lifetime.cpp
@@ -1305,7 +1305,10 @@ TEST_CASE(map_remove_tile_safely_removes_all_items_without_iterator_invalidation
 	std::weak_ptr<Door> weakDoor = door;
 	std::weak_ptr<BedItem> weakBed = bed;
 
-	rawTile->setGround(ground);
+	// Use the insertion path: setGround() alone does not attach the parent.
+	rawTile->internalAddThing(ground.get());
+	CHECK(rawTile->getGround() == ground.get());
+	CHECK(ground->getParent() == rawTile);
 	rawTile->internalAddThing(0, item1.get());
 	rawTile->internalAddThing(0, item2.get());
 	rawTile->internalAddThing(0, door.get());
@@ -1331,7 +1334,7 @@ TEST_CASE(map_remove_tile_safely_removes_all_items_without_iterator_invalidation
 	CHECK(!weakBed.expired());
 
 	// Remove tile from map: must remove all items safely via snapshot
-	g_game.map.removeTile(tilePos);
+	CHECK(g_game.map.removeTile(tilePos));
 	CHECK(g_game.map.getTile(tilePos) == nullptr);
 
 	// Flush deferred releases
@@ -1495,10 +1498,12 @@ TEST_CASE(flag_nolimit_does_not_remove_special_nonremovable_containers)
 	tileGuard.track(pos.x, pos.y, pos.z);
 
 	auto tile = std::make_unique<DynamicTile>(pos.x, pos.y, pos.z);
-	tile->setGround(std::make_shared<Item>(100));
+	tile->internalAddThing(std::make_shared<Item>(100).get());
 	g_game.map.setTile(pos.x, pos.y, pos.z, std::move(tile));
 	Tile* rawTile = g_game.map.getTile(pos);
 	CHECK(rawTile != nullptr);
+	CHECK(rawTile->getGround() != nullptr);
+	CHECK(rawTile->getGround()->getParent() == rawTile);
 
 	std::vector<std::shared_ptr<Item>> specialItems{
 	    std::make_shared<Inbox>(ITEM_INBOX),
@@ -1520,7 +1525,8 @@ TEST_CASE(flag_nolimit_does_not_remove_special_nonremovable_containers)
 
 	// The dedicated Map cleanup path can still tear down the tile completely.
 	specialItems.clear();
-	g_game.map.removeTile(pos);
+	CHECK(g_game.map.removeTile(pos));
+	CHECK(g_game.map.getTile(pos) == nullptr);
 	g_game.cleanup();
 	for (const auto& weakItem : weakItems) {
 		CHECK(weakItem.expired());
@@ -1602,7 +1608,9 @@ TEST_CASE(orphan_house_tile_fails_closed_for_players_and_allows_map_cleanup)
 	Item::items.getItemType(100).pickupable = true;
 
 	auto ground = std::make_shared<Item>(100);
-	orphanTile->setGround(ground);
+	orphanTile->internalAddThing(ground.get());
+	CHECK(orphanTile->getGround() == ground.get());
+	CHECK(ground->getParent() == orphanTile);
 
 	auto container = std::make_shared<Container>(ITEM_BAG, 10);
 	orphanTile->internalAddThing(container.get());
@@ -1644,6 +1652,7 @@ TEST_CASE(orphan_house_tile_fails_closed_for_players_and_allows_map_cleanup)
 	CHECK(container->queryRemove(*nestedItem, 1, 0, nullptr) == RETURNVALUE_NOERROR);
 	ConfigManager::setBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, prevOnlyInvited);
 
+	std::weak_ptr<Item> weakGround = ground;
 	std::weak_ptr<Container> weakContainer = container;
 	std::weak_ptr<Item> weakNestedItem = nestedItem;
 	std::weak_ptr<Door> weakDoor = door;
@@ -1655,9 +1664,11 @@ TEST_CASE(orphan_house_tile_fails_closed_for_players_and_allows_map_cleanup)
 	door.reset();
 	bed.reset();
 
-	g_game.map.removeTile(pos);
+	CHECK(g_game.map.removeTile(pos));
+	CHECK(g_game.map.getTile(pos) == nullptr);
 	g_game.cleanup();
 	CHECK(weakTile.expired());
+	CHECK(weakGround.expired());
 	CHECK(weakContainer.expired());
 	CHECK(weakNestedItem.expired());
 	CHECK(weakDoor.expired());
@@ -1787,16 +1798,22 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 	tileGuard.track(partnerPos.x, partnerPos.y, partnerPos.z);
 
 	auto startTile = std::make_unique<DynamicTile>(startPos.x, startPos.y, startPos.z);
-	startTile->setGround(std::make_shared<Item>(100));
+	startTile->internalAddThing(std::make_shared<Item>(100).get());
 	g_game.map.setTile(startPos.x, startPos.y, startPos.z, std::move(startTile));
 
 	auto house = std::make_shared<House>(912);
 	auto houseTile = std::make_unique<HouseTile>(bedPos.x, bedPos.y, bedPos.z, house);
-	houseTile->setGround(std::make_shared<Item>(100));
+	houseTile->internalAddThing(std::make_shared<Item>(100).get());
 	g_game.map.setTile(bedPos.x, bedPos.y, bedPos.z, std::move(houseTile));
 	auto partnerTile = std::make_unique<HouseTile>(partnerPos.x, partnerPos.y, partnerPos.z, house);
-	partnerTile->setGround(std::make_shared<Item>(100));
+	partnerTile->internalAddThing(std::make_shared<Item>(100).get());
 	g_game.map.setTile(partnerPos.x, partnerPos.y, partnerPos.z, std::move(partnerTile));
+	for (const auto& pos : {startPos, bedPos, partnerPos}) {
+		const auto* tile = g_game.map.getTile(pos);
+		CHECK(tile != nullptr);
+		CHECK(tile->getGround() != nullptr);
+		CHECK(tile->getGround()->getParent() == tile);
+	}
 
 	ItemTypePropertyGuard bedTypeGuard(694);
 	Item::items.getItemType(694).bedPartnerDir = DIRECTION_SOUTH;
@@ -1856,7 +1873,8 @@ TEST_CASE(occupied_house_bed_removed_by_map_preserves_sleeper_regeneration)
 	CHECK(player->isRemoved());
 	CHECK(g_game.getPlayerByGUID(player->getGUID()) == nullptr);
 
-	g_game.map.removeTile(bedPos);
+	CHECK(g_game.map.removeTile(bedPos));
+	CHECK(g_game.map.getTile(bedPos) == nullptr);
 	g_game.cleanup();
 
 	CHECK(offlineState.loadCount == 1);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -288,14 +288,16 @@ std::shared_ptr<BedItem> Tile::getBedItem() const
 		return nullptr;
 	}
 
-	if (ground && ground->getBed()) {
-		return std::static_pointer_cast<BedItem>(ground);
+	if (ground) {
+		if (auto bed = ground->getBed()) {
+			return std::const_pointer_cast<BedItem>(bed);
+		}
 	}
 
 	if (const TileItemVector* items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-			if ((*it)->getBed()) {
-				return std::static_pointer_cast<BedItem>(*it);
+			if (auto bed = (*it)->getBed()) {
+				return std::const_pointer_cast<BedItem>(bed);
 			}
 		}
 	}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -5,6 +5,7 @@
 
 #include "tile.h"
 
+#include "bed.h"
 #include "combat.h"
 #include "configmanager.h"
 #include "container.h"
@@ -281,20 +282,20 @@ Mailbox* Tile::getMailbox() const
 	return nullptr;
 }
 
-BedItem* Tile::getBedItem() const
+std::shared_ptr<BedItem> Tile::getBedItem() const
 {
 	if (!hasFlag(TILESTATE_BED)) {
 		return nullptr;
 	}
 
 	if (ground && ground->getBed()) {
-		return ground->getBed();
+		return std::static_pointer_cast<BedItem>(ground);
 	}
 
 	if (const TileItemVector* items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getBed()) {
-				return (*it)->getBed();
+				return std::static_pointer_cast<BedItem>(*it);
 			}
 		}
 	}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1610,10 +1610,12 @@ void Tile::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t 
 		}
 
 		// calling movement scripts
-		if (creature) {
-			g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_IN);
-		} else if (item) {
-			g_moveEvents->onItemMove(item, this, true);
+		if (g_moveEvents) {
+			if (creature) {
+				g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_IN);
+			} else if (item) {
+				g_moveEvents->onItemMove(item, this, true);
+			}
 		}
 	}
 
@@ -1643,10 +1645,12 @@ void Tile::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32
 		player->postRemoveNotification(thing, newParent, index, LINK_NEAR);
 	}
 
-	if (Creature* creature = thing->getCreature()) {
-		g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_OUT);
-	} else if (Item* item = thing->getItem()) {
-		g_moveEvents->onItemMove(item, this, false);
+	if (g_moveEvents) {
+		if (Creature* creature = thing->getCreature()) {
+			g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_OUT);
+		} else if (Item* item = thing->getItem()) {
+			g_moveEvents->onItemMove(item, this, false);
+		}
 	}
 }
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -154,7 +154,7 @@ public:
 	Teleport* getTeleportItem() const;
 	TrashHolder* getTrashHolder() const;
 	Mailbox* getMailbox() const;
-	BedItem* getBedItem() const;
+	std::shared_ptr<BedItem> getBedItem() const;
 
 	Creature* getTopCreature() const;
 	const Creature* getBottomCreature() const;


### PR DESCRIPTION
## Goal

Incrementally migrate lifetime-sensitive raw-pointer API boundaries to smart pointers, preserving ownership while avoiding a broad architecture rewrite.

This PR follows a **one API at a time** strategy: keep existing ownership models where they are correct, return owning references when callers need lifetime guarantees, and use raw pointers only at legacy observer-only boundaries.

> The earlier `Condition` lifetime migration is tracked separately. This PR contains the item/house/bed ownership work that follows it.

## Smart pointer migrations

- `House::getTransferItem()` → `std::shared_ptr<HouseTransferItem>`
- `Container::getItemByIndex()` → `std::shared_ptr<Item>`
- `ContainerIterator::operator*()` → `std::shared_ptr<Item>`
- `Houses::getHouse()` → `std::shared_ptr<House>`
- `Houses::addHouse()` → `std::shared_ptr<House>`
- `Houses::getHouseByPlayerId()` → `std::shared_ptr<House>`
- `Door::getHouse()` → `std::shared_ptr<House>` via existing `weak_ptr::lock()`
- `HouseTile::getHouse()` → `std::shared_ptr<House>` via existing `weak_ptr::lock()`
- `BedItem::getHouse()` → `std::shared_ptr<House>` via existing `weak_ptr::lock()`
- `BedItem::getNextBedItem()` → `std::shared_ptr<BedItem>` using the existing control block

## Ownership rules preserved

- `Door`, `HouseTile`, and `BedItem` keep their existing `std::weak_ptr<House>` storage where applicable.
- No new strong House ownership cycles are introduced.
- No `std::shared_ptr<T>(rawPointer)` ownership is created for already-managed objects.
- `.get()` is used only when crossing an existing raw observer API boundary.
- No broad `Tile`, `Cylinder`, `Thing`, or `Item` smart-pointer rewrite is included.

## Caller/lifetime improvements

- Container iteration and indexed lookup keep Items alive during active processing.
- Quick-loot/autoloot and related item-processing paths retain shared references where lifetime matters.
- Lua container item userdata keeps shared ownership instead of exposing only a raw Item pointer.
- House, Door, HouseTile, and Bed callers keep a local `shared_ptr` instead of repeatedly doing `weak_ptr::lock().get()`.
- Bed partner access now preserves the partner Item lifetime through sleep/wake processing.

## Validation

Coverage includes lifetime/identity checks for:

- container indexed access;
- container iteration;
- Lua item userdata + garbage collection;
- House lookup/add/owner lookup;
- House transfer item identity/reset;
- Door → House weak ownership;
- HouseTile → House weak ownership;
- BedItem → House weak ownership;
- Bed partner lookup/lifetime.

Sanitizer/build workflows are used where available to check for UAF, double-free, leaks, invalid ownership, and regressions.

## Scope

This PR is intentionally focused on **smart pointer/lifetime hardening**. Remaining raw-pointer APIs will be audited and migrated separately, one function at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when interacting with tiles, beds, trades, or items without an associated house.
  * Lua tile house lookups now safely return `nil` when no house exists.
  * Improved handling of unavailable players, removed items, partner beds, and offline sleepers.
  * Tile removal now reports failures and safely handles occupied beds and protected items.

* **Reliability**
  * Improved lifetime handling for items, houses, doors, beds, and Lua objects.
  * Preserved item references during looting, trading, inventory, and house-transfer operations.

* **Tests**
  * Expanded coverage for ownership, expiration, cleanup, removal, iteration, and Lua bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

























<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates lifetime-sensitive item and house APIs to smart pointers and hardens destructive house/bed operations against partial state changes.
- Container iteration, indexed access, Lua userdata, and house lookups now retain shared ownership.
- Bed wake-up supports transactional multi-sleeper persistence before clearing sessions.
- Tile removal preflights occupied beds and preserves the tile and its items when sleeper persistence fails.
- House ownership transitions snapshot weakly held tiles, doors, and beds while handling failure explicitly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/bed.cpp | Implements failure-aware single-bed wake-up and transactional batch wake-up that persists offline regeneration before clearing sessions. |
| src/map.cpp | Preflights all occupied beds before tile mutation and checks removal and reentrancy outcomes throughout teardown. |
| src/game.cpp | Retains item and cylinder lifetimes during moves and removal while explicitly waking occupied beds before destruction. |
| src/house.cpp | Migrates house relationships to weak/shared ownership and makes ownership transitions abort when sleeper persistence fails. |
| src/save_manager.cpp | Provides transactional batch player persistence used to preserve all-or-nothing sleeper wake semantics. |
| src/tests/test_item_lifetime.cpp | Exercises smart-pointer identity and lifetime behavior together with successful and failed bed and tile teardown paths. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as Map::removeTile
    participant B as BedItem::wakeUpAll
    participant S as SaveManager
    participant G as Game::internalRemoveItem
    M->>B: Preflight occupied beds
    B->>S: Persist all offline sleepers atomically
    alt persistence fails
        S-->>B: false / transaction rolled back
        B-->>M: false
        M-->>M: Keep tile, items, and sleep sessions
    else persistence succeeds
        S-->>B: committed
        B->>B: Clear every sleep session
        B-->>M: true
        loop snapshot of tile items
            M->>G: Remove with IGNORECANREMOVE
            G->>G: Revalidate membership and occupied-bed state
        end
        M->>M: Unregister and release tile
    end
```
</details>

<sub>Reviews (13): Last reviewed commit: ["fix: harden item lifetime and house tear..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/0b4b424c06065b1332fc56c1c9281211b7f88ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55278026)</sub>

<!-- /greptile_comment -->