### PR TITLE
Prevent opening nested reward containers

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3579,6 +3579,16 @@ void Game::playerUseItem(uint32_t playerId, const Position& pos, uint8_t stackPo
 		return;
 	}
 
+	// The root reward containers remain accessible, but nested containers stay
+	// closed so they cannot be used to bypass the read-only reward behavior.
+	Container* container = item->getContainer();
+	const bool isRewardRoot = container && (container->getID() == ITEM_REWARD_CONTAINER ||
+	                                        container->getRewardChest() || container->isRewardCorpse());
+	if (container && !isRewardRoot && isInsideRewardContainer(item->getParent())) {
+		player->sendCancelMessage("Nao e possivel abrir containers que estejam dentro de uma recompensa.");
+		return;
+	}
+
 	if (player->isAstraClient() && isMonsterPodiumId(item->getID())) {
 		if (pos.x == 0xFFFF || !pos.isInRange(player->getPosition(), 1, 1, 0)) {
 			player->sendCancelMessage(RETURNVALUE_TOOFARAWAY);


### PR DESCRIPTION
## Summary
- keep the root Reward Container, Reward Chest, and reward corpse accessible
- prevent opening bags and backpacks nested anywhere inside a reward container
- avoid using nested containers to bypass the read-only reward behavior

## Validation
Manually verified on the server: the root reward opens normally, while a backpack stored inside it is refused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Players can now open eligible root-level reward containers.
  - Attempts to open containers nested within reward containers are blocked with an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->