### PR TITLE
Stabilize melee and distance weapon damage

### DIFF
--- a/src/tests/test_stable_weapon_damage.cpp
+++ b/src/tests/test_stable_weapon_damage.cpp
@@ -1,0 +1,31 @@
+#include "../otpch.h"
+
+#include "../weapons.h"
+
+#include "test_support.h"
+
+TEST_CASE(melee_damage_does_not_roll_near_zero)
+{
+	for (int32_t sample = 0; sample < 1'000; ++sample) {
+		const int32_t damage = Weapons::getStablePlayerDamage(0, 100);
+		CHECK(damage >= 43);
+		CHECK(damage <= 58);
+	}
+}
+
+TEST_CASE(distance_damage_stays_close_to_its_average)
+{
+	for (int32_t sample = 0; sample < 1'000; ++sample) {
+		const int32_t damage = Weapons::getStablePlayerDamage(40, 100);
+		CHECK(damage >= 60);
+		CHECK(damage <= 81);
+	}
+}
+
+TEST_CASE(stable_damage_preserves_fixed_values)
+{
+	CHECK(Weapons::getStablePlayerDamage(75, 75) == 75);
+	CHECK(Weapons::getStablePlayerDamage(0, 0) == 0);
+}
+
+TFS_TEST_MAIN()

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -20,6 +20,8 @@ extern Vocations g_vocations;
 
 namespace {
 
+constexpr double PLAYER_DAMAGE_VARIATION = 0.15;
+
 int32_t getPerfectShotDamageForRange(const Item* item, int32_t range)
 {
 	if (!item || range == 0 || item->getPerfectShotRange() != range) {
@@ -178,6 +180,14 @@ int32_t Weapons::getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t
 {
 	return static_cast<int32_t>(
 	    std::round((level / 5) + (((((attackSkill / 4.) + 1) * (attackValue / 3.)) * 1.03) / attackFactor)));
+}
+
+int32_t Weapons::getStablePlayerDamage(int32_t minDamage, int32_t maxDamage)
+{
+	const double average = (static_cast<double>(minDamage) + static_cast<double>(maxDamage)) / 2.0;
+	const double variation = std::abs(average) * PLAYER_DAMAGE_VARIATION;
+	return normal_random(static_cast<int32_t>(std::lround(average - variation)),
+	                     static_cast<int32_t>(std::lround(average + variation)));
 }
 
 void Weapon::configureWeapon(const ItemType& it) { id = it.id; }
@@ -725,7 +735,8 @@ int32_t WeaponMelee::getElementDamage(const Player* player, const Creature*, con
 	float attackFactor = player->getAttackFactor();
 
 	int32_t maxValue = Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor);
-	return -normal_random(0, static_cast<int32_t>(maxValue * player->getVocation()->meleeDamageMultiplier));
+	return -Weapons::getStablePlayerDamage(
+	    0, static_cast<int32_t>(maxValue * player->getVocation()->meleeDamageMultiplier));
 }
 
 int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, const Item* item,
@@ -742,7 +753,7 @@ int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, cons
 		return -maxValue;
 	}
 
-	return -normal_random(0, maxValue);
+	return -Weapons::getStablePlayerDamage(0, maxValue);
 }
 
 WeaponDistance::WeaponDistance(LuaScriptInterface* interface) : Weapon(interface)
@@ -951,7 +962,8 @@ int32_t WeaponDistance::getElementDamage(const Player* player, const Creature* t
 		}
 	}
 
-	return -normal_random(minValue, static_cast<int32_t>(maxValue * player->getVocation()->distDamageMultiplier));
+	return -Weapons::getStablePlayerDamage(
+	    minValue, static_cast<int32_t>(maxValue * player->getVocation()->distDamageMultiplier));
 }
 
 int32_t WeaponDistance::getWeaponDamage(const Player* player, const Creature* target, const Item* item,
@@ -986,7 +998,7 @@ int32_t WeaponDistance::getWeaponDamage(const Player* player, const Creature* ta
 	} else {
 		minValue = 0;
 	}
-	return -normal_random(minValue, maxValue);
+	return -Weapons::getStablePlayerDamage(minValue, maxValue);
 }
 
 bool WeaponDistance::getSkillType(const Player* player, const Item*, skills_t& skill, uint32_t& skillpoint) const

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -34,6 +34,7 @@ public:
 
 	static int32_t getMaxMeleeDamage(int32_t attackSkill, int32_t attackValue);
 	static int32_t getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t attackValue, float attackFactor);
+	static int32_t getStablePlayerDamage(int32_t minDamage, int32_t maxDamage);
 
 	bool registerLuaEvent(std::unique_ptr<Weapon> weapon);
 	void clear(bool fromLua) override final;


### PR DESCRIPTION
## Summary
- stabilize melee and distance weapon rolls around their calculated average
- limit variation to 15% of the average to prevent abnormally low physical hits
- apply the same behavior to the elemental component of melee and distance weapons
- keep fist attacks and wand damage unchanged

## Behavior
For a calculated range of 0-100, weapon damage now rolls between 43 and 58 instead of potentially approaching zero. Existing maximum-damage calculations, skill scaling, vocation multipliers, hit chance, armor and shielding remain unchanged.

## Regression coverage
- verifies melee rolls never approach zero
- verifies distance rolls remain within the stable range when a minimum damage is present
- verifies fixed damage ranges remain unchanged

## Files
- src/weapons.cpp
- src/weapons.h
- src/tests/test_stable_weapon_damage.cpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Gameplay Improvements**
  - Player weapon damage is now more consistent and predictable.
  - Melee and distance attacks continue to vary within their configured damage ranges while reducing extreme fluctuations.
  - Fixed-damage weapons preserve their configured damage values.

- **Bug Fixes**
  - Improved handling of very low and near-zero melee damage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->