### PR TITLE
fix(linux): prevent SIGPIPE crashes on broken socket writes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 #include "outputmessage.h"
 #include "tools.h"
 
+#include <cstdio>
+
 #ifdef _WIN32
 #include <io.h>
 #include <windows.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 #ifdef _WIN32
 #include <io.h>
 #include <windows.h>
+#else
+#include <signal.h>
 #endif
 
 namespace {
@@ -45,6 +47,17 @@ void waitForInteractiveConsoleOnStartupFailure()
 }
 #else
 void waitForInteractiveConsoleOnStartupFailure() {}
+
+bool ignoreSigPipe()
+{
+	struct sigaction action {};
+	action.sa_handler = SIG_IGN;
+	if (sigemptyset(&action.sa_mask) != 0 || sigaction(SIGPIPE, &action, nullptr) != 0) {
+		std::perror("Failed to ignore SIGPIPE");
+		return false;
+	}
+	return true;
+}
 #endif
 
 } // namespace
@@ -87,6 +100,12 @@ static bool argumentsHandler(const std::vector<std::string_view>& args)
 
 int main(int argc, const char** argv)
 {
+#ifndef _WIN32
+	if (!ignoreSigPipe()) {
+		return EXIT_FAILURE;
+	}
+#endif
+
 	std::vector<std::string_view> args(argv, argv + argc);
 	if (!argumentsHandler(args)) {
 		return 1;


### PR DESCRIPTION
## Summary

Prevents the server from being terminated by `SIGPIPE` on POSIX systems when a socket write targets a connection that has already been closed.

The crash was reproduced in the MySQL path, where a stale/broken database connection could reach:

```text
ProtocolLogin::onRecvFirstMessage()
→ IOBan::isIpBanned()
→ Database::storeQuery()
→ mysql_real_query()
→ mysql_send_query()
→ send()
→ EPIPE / SIGPIPE
```

A second backtrace also showed the same condition during connection cleanup:

```text
mysql_close()
→ send()
→ EPIPE / SIGPIPE
```

Without process-wide `SIGPIPE` protection, Linux may terminate the server before the existing database error/reconnect logic can handle the failed write.

## Changes

- Adds POSIX-only `SIGPIPE` handling in `src/main.cpp`.
- Installs `SIG_IGN` through `sigaction()`.
- Installs the handler at the beginning of `main()`, before server startup, MySQL initialization, network threads, and workers.
- Reports an error with `perror()` and aborts startup if the signal disposition cannot be installed.
- Leaves Windows behavior unchanged.
- Does not change MySQL reconnect logic or enable `MYSQL_OPT_RECONNECT`.

## Why this approach

Ignoring `SIGPIPE` allows socket writes to fail normally with `EPIPE` instead of terminating the entire process. This lets the existing database code receive the MySQL connection error, close/recreate the affected connection, and retry where appropriate.

The protection is process-wide so it also covers failures triggered inside client-library cleanup such as `mysql_close()`.

## Scope

This is intentionally a minimal fix:

- 1 file changed
- no database refactor
- no login-flow changes
- no additional mutexes
- no Windows changes

## Validation

- Static analysis: passed.
- Linux GCC build/tests: running.
- Clang build/tests: running.
- ThreadSanitizer: running.
- Docker build: running.
- vcpkg workflow reported a startup failure before any job was created, so it has not produced a code/build result for this commit yet.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability on non-Windows systems by handling broken network connections gracefully.
  * The application now reports configuration failures and exits cleanly when required system behavior cannot be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR installs a process-wide POSIX `SIGPIPE` ignore handler before server initialization so broken socket writes return errors instead of terminating the process.
- Adds an explicit `<cstdio>` include for the `std::perror` declaration.
- Configures `SIGPIPE` with `sigaction()` on non-Windows platforms.
- Aborts startup with an error message if signal configuration fails.
- Leaves Windows behavior unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/main.cpp | Adds early POSIX-only SIGPIPE handling and explicitly includes the standard header required by the previously reported `std::perror` portability issue. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: declare perror dependency directly"](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/c1faf17378647987a326711ad7c76bdead9d25d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58135171)</sub>

<!-- /greptile_comment -->