### PR TITLE
fix(npc): restore Crystal NPC loading on protocol 8.60

### DIFF
--- a/data/npc/lib/crystalcompat/npctype.lua
+++ b/data/npc/lib/crystalcompat/npctype.lua
@@ -1,4 +1,14 @@
 -- NpcType Wrapper
+-- CrystalServer uses these options for its NPC dialog-buttons packet, which
+-- this 8.60 fork does not send. Accept the optional UI metadata so imported
+-- scripts reach register(), where outfits, callbacks and shops are configured.
+-- Text keywords such as "trade" and "bye" remain handled by the NPC system.
+if not NpcType.addDialogOptions then
+	function NpcType:addDialogOptions(...)
+		return true
+	end
+end
+
 if not _G.OriginalNpcTypeRegister then
 	_G.OriginalNpcTypeRegister = NpcType.register
 end


### PR DESCRIPTION
Crystal NPC scripts call `npcType:addDialogOptions()` before `npcType:register()`. This API is absent in the 8.60 fork, so Dark Rodo, Onfroi (Day), Onfroi (Night), and Steven stop loading before their outfits and shops are configured.

Add a fallback in the Crystal compatibility layer that accepts this optional UI metadata without sending CrystalServer's unsupported dialog-options packet. Keep any existing native implementation intact. NPC registration, text keywords, and shops continue through the existing system; the TFS backend is unchanged.

Compared the behavior with [CrystalServer's NPC type bindings](https://github.com/zimbadev/crystalserver/blob/main/src/lua/functions/creatures/npc/npc_type_functions.cpp).

Validation:
- Reproduced the original `addDialogOptions` error in all four scripts before the change.
- Loaded the real NPC Lua libraries and scripts in an isolated Lua 5.4 harness with engine bindings stubbed. After the fix, all four registered their expected outfits and populated shops (64, 30, 30, and 64 entries).
- Checked preservation of an existing native implementation and of the original registration function on wrapper reload.
- `git diff --check` passed.

No server compilation or in-game validation was performed, as requested. This change does not implement CrystalServer's dialog-button protocol.

Closes #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with imported NPC scripts that use dialog options.
  * NPC configurations can now continue loading when dialog-button support is unavailable, preserving related outfits, callbacks, and shop setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores loading of four Crystal NPC scripts on protocol 8.60 by adding a guarded no-op compatibility implementation of `NpcType:addDialogOptions`.
- Preserves any native `addDialogOptions` implementation.
- Accepts unsupported dialog-button metadata without attempting to send a protocol packet.
- Allows NPC scripts to continue into their existing registration, outfit, callback, and shop setup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, compatibility, or security issue identified.

The fallback is installed only when the method is absent, existing native behavior remains intact, and affected scripts can proceed through the established NPC registration path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| data/npc/lib/crystalcompat/npctype.lua | Adds a narrowly scoped, guarded compatibility method whose return value is unused by the affected NPC scripts; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(npc): accept Crystal dialog options ..."](https://github.com/mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/41a4c76c88fc45ebaa8b52dac2da8c4363b0ddfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58665456)</sub>

<!-- /greptile_comment -->