### PR TITLE
Fix colorized loot price fallback

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -71,9 +71,19 @@ local function getLootItemValue(item)
 		return 0
 	end
 
-	local value = itemType.getDefaultPrice and itemType:getDefaultPrice() or itemType:getWorth()
-	local count = itemType:isStackable() and math.max(1, item:getCount()) or 1
-	return (tonumber(value) or 0) * count
+	local value = 0
+	if itemType.getDefaultPrice then
+		value = tonumber(itemType:getDefaultPrice()) or 0
+	end
+	if value <= 0 and itemType.getWorth then
+		value = tonumber(itemType:getWorth()) or 0
+	end
+
+	local count = 1
+	if itemType:isStackable() then
+		count = math.max(1, tonumber(item:getCount()) or 1)
+	end
+	return value * count
 end
 
 function Container:getContentDescription(colorizedLootValue)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -7981,8 +7981,9 @@ void Player::flushPendingLoot(const std::string& groupKey)
 			}
 			first = false;
 			if (colorized) {
-				const uint64_t itemValue =
-				    static_cast<uint64_t>(itemType.sellPrice > 0 ? itemType.sellPrice : itemType.buyPrice) * count;
+				const uint64_t unitValue = itemType.sellPrice > 0 ? itemType.sellPrice :
+				                           (itemType.buyPrice > 0 ? itemType.buyPrice : itemType.worth);
+				const uint64_t itemValue = unitValue * count;
 				text << "{" << itemId << ":" << itemValue << "|";
 			}
 			if (count > 1) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -691,7 +691,7 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 	if (isOTC) {
 		// Player loading can emit status packets before finishLogin(). Astra
 		// therefore needs its final wire-format features advertised up front.
-		sendFeatures(isAstraClient || isFonticakClient);
+		sendFeatures(isAstraClient);
 
 		NetworkMessage opcodeMessage;
 		opcodeMessage.addByte(0x32);


### PR DESCRIPTION
## Problem

When `enableColorizedLootValue = true`, the server includes the loot value in the AstraClient markup. For stackable items this value is the **total value of that specific stack** (`unit value × count`).

The old AstraClient path treated that transient stack total as if it were the canonical value for the `itemId`. Because stack counts change on almost every kill, the same item could receive a different cached value repeatedly. This caused the client to mark the loot-value cache dirty and schedule rarity/UI updates after each loot message.

The old rarity refresh then walked the UI tree and recalculated item rarity frames, while cache persistence could also serialize/write the loot cache shortly afterwards. During hunts this extra work happened around monster deaths and could produce the observed **~50–150 ms stutter**. With `enableColorizedLootValue = false`, the value markup was not sent, so this heavy client-side path was not triggered.

The main client-side performance fix is handled in AstraClient PR #147: https://github.com/Mateuzkl/AstraClient/pull/147

## Changes Proposed

* Fix colorized loot value fallback handling.
* Use item worth when default/sell/buy prices are unavailable or invalid.
* Keep the stack total as a display value while preserving correct unit-value semantics.
* Keep colorized loot behavior consistent across grouped and ungrouped loot paths.
* Keep Astra-specific item-state feature advertisement scoped to AstraClient.

## Result

With the matching AstraClient fix, `enableColorizedLootValue = true` keeps colorized loot enabled without turning each monster death into a global rarity/cache update. `enableColorizedLootValue = false` keeps the normal loot behavior unchanged.