### PR TITLE
feat(proto): enable Fonticak item values, colored loot, and blessings

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -72,7 +72,10 @@ local function getLootItemValue(item)
 	end
 
 	local value = 0
-	if itemType.getDefaultPrice then
+	if ItemPriceRegistry and ItemPriceRegistry.getDefaultValue then
+		value = tonumber(ItemPriceRegistry.getDefaultValue(item:getId())) or 0
+	end
+	if value <= 0 and itemType.getDefaultPrice then
 		value = tonumber(itemType:getDefaultPrice()) or 0
 	end
 	if value <= 0 and itemType.getWorth then

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -217,6 +217,20 @@ function Player.isUsingOtClient(self)
 		       (os >= CLIENTOS_OTCLIENTV8_LINUX and os <= CLIENTOS_OTCLIENTV8_WEB)
 end
 
+function Player.supportsColorizedLoot(self)
+	if not self then
+		return false
+	end
+	if self.isUsingAstraClient and self:isUsingAstraClient() then
+		return true
+	end
+	return self.isUsingFonticakClient and self:isUsingFonticakClient()
+end
+
+function Player.supportsCustomItemNetwork(self)
+	return self:supportsColorizedLoot()
+end
+
 function Player.sendExtendedOpcode(self, opcode, buffer)
 	if not self:isUsingOtClient() then return false end
 	buffer = buffer or ""

--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -6,7 +6,11 @@ NPC_SHOP_BUY_EXHAUST_MS = NPC_SHOP_BUY_EXHAUST_MS or 500
 NPC_SHOP_EXHAUST_MESSAGE = NPC_SHOP_EXHAUST_MESSAGE or "Please wait before buying again."
 
 function msgcontains(message, keyword)
-	local message, keyword = message:lower(), keyword:lower()
+	if message == nil or keyword == nil then
+		return false
+	end
+
+	message, keyword = message:lower(), keyword:lower()
 	if message == keyword then return true end
 
 	return message:find(keyword) and not message:find('(%w+)' .. keyword)
@@ -562,6 +566,31 @@ do
 	if not compat.originalNpcHandlerSay then
 		compat.originalNpcHandlerSay = NpcHandler.say
 
+		local function buildSayParseInfo(focusId)
+			local player = Player(focusId)
+			local playerName = player and player:getName() or ""
+			return {
+				[TAG_PLAYERNAME] = playerName,
+				["|TIME|"] = Game.getFormattedWorldTime(),
+			}
+		end
+
+		local function parseSayMessage(handler, message, parseInfo)
+			if type(message) == "table" then
+				local parsed = {}
+				for index = 1, #message do
+					parsed[index] = handler:parseMessage(message[index], parseInfo)
+				end
+				return parsed
+			end
+
+			if type(message) == "string" then
+				return handler:parseMessage(message, parseInfo)
+			end
+
+			return message
+		end
+
 		function NpcHandler:say(message, focus, publicize, shallDelay, delay)
 			local actualFocus = focus
 			local actualPublicize = publicize
@@ -573,6 +602,10 @@ do
 				else
 					actualFocus = getPlayerId(focus)
 				end
+			end
+
+			if actualFocus and actualFocus ~= 0 then
+				message = parseSayMessage(self, message, buildSayParseInfo(actualFocus))
 			end
 
 			return compat.originalNpcHandlerSay(self, message, actualFocus, actualPublicize, shallDelay, delay)
@@ -935,6 +968,30 @@ do
 		return openCompatShopWindow(self, player, itemsTable)
 	end
 
+	local function rememberPlayerMessage(handler, cid, message)
+		if not handler or not cid or message == nil then
+			return
+		end
+
+		handler.__lastPlayerMessage = handler.__lastPlayerMessage or {}
+		handler.__lastPlayerMessage[cid] = message
+	end
+
+	local function installLastMessageTracking(handler)
+		if not handler or not handler.keywordHandler or handler.__modernCompatMessageTrackingInstalled then
+			return
+		end
+
+		handler.__modernCompatMessageTrackingInstalled = true
+		local keywordHandler = handler.keywordHandler
+		local originalProcessMessage = keywordHandler.processMessage
+
+		function keywordHandler:processMessage(cid, message)
+			rememberPlayerMessage(handler, cid, message)
+			return originalProcessMessage(self, cid, message)
+		end
+	end
+
 	local function wrapHandlerCallback(handler, callbackId, wrapperFactory)
 		local callback = handler:getCallback(callbackId)
 		if not callback then
@@ -1087,10 +1144,12 @@ do
 
 		if handler then
 			handler.__modernCompatNpcName = npcName
+			installLastMessageTracking(handler)
 
 			wrapHandlerCallback(handler, CALLBACK_GREET, function(callback)
-				return function(cid)
-					return callModernCallback(callback, getCurrentNpc(handler), getCreatureObject(cid))
+				return function(cid, message)
+					message = message or (handler.__lastPlayerMessage and handler.__lastPlayerMessage[cid])
+					return callModernCallback(callback, getCurrentNpc(handler), getCreatureObject(cid), message)
 				end
 			end)
 

--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -620,7 +620,11 @@ do
 				return compat.originalNpcHandlerResetNpc(self)
 			end
 
-			return compat.originalNpcHandlerResetNpc(self, getPlayerId(target))
+			local playerId = getPlayerId(target)
+			if self.__lastPlayerMessage then
+				self.__lastPlayerMessage[playerId] = nil
+			end
+			return compat.originalNpcHandlerResetNpc(self, playerId)
 		end
 	end
 

--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -985,10 +985,18 @@ do
 		handler.__modernCompatMessageTrackingInstalled = true
 		local keywordHandler = handler.keywordHandler
 		local originalProcessMessage = keywordHandler.processMessage
+		local originalReleaseFocus = handler.releaseFocus
 
 		function keywordHandler:processMessage(cid, message)
 			rememberPlayerMessage(handler, cid, message)
 			return originalProcessMessage(self, cid, message)
+		end
+
+		function handler:releaseFocus(focus)
+			if self.__lastPlayerMessage then
+				self.__lastPlayerMessage[focus] = nil
+			end
+			return originalReleaseFocus(self, focus)
 		end
 	end
 

--- a/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
+++ b/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
@@ -8,16 +8,6 @@ local function formatHundredthsPercent(value)
 	return string.format("%.2f", (tonumber(value) or 0) / 100):gsub("0+$", ""):gsub("%.$", "")
 end
 
-local function supportsColorizedLoot(player)
-	if not player then
-		return false
-	end
-	if player.isUsingAstraClient and player:isUsingAstraClient() then
-		return true
-	end
-	return player.isUsingFonticakClient and player:isUsingFonticakClient()
-end
-
 local function addLootRecipient(recipients, player)
 	if player then
 		recipients[#recipients + 1] = player
@@ -50,7 +40,7 @@ local function sendUngroupedLootMessage(player, corpse, monsterName, preyLootTex
 
 	if useColorized then
 		for _, recipient in ipairs(recipients) do
-			if supportsColorizedLoot(recipient) then
+			if recipient.supportsColorizedLoot and recipient:supportsColorizedLoot() then
 				needColorized = true
 				break
 			end
@@ -63,7 +53,7 @@ local function sendUngroupedLootMessage(player, corpse, monsterName, preyLootTex
 	end
 
 	for _, recipient in ipairs(recipients) do
-		local wantsColorized = needColorized and supportsColorizedLoot(recipient)
+		local wantsColorized = needColorized and recipient.supportsColorizedLoot and recipient:supportsColorizedLoot()
 		if wantsColorized then
 			colorizedText = colorizedText or buildText(true)
 			sendLootMessage(recipient, colorizedText)

--- a/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
+++ b/data/scripts/eventcallbacks/monster/default_onDropLoot.lua
@@ -8,6 +8,16 @@ local function formatHundredthsPercent(value)
 	return string.format("%.2f", (tonumber(value) or 0) / 100):gsub("0+$", ""):gsub("%.$", "")
 end
 
+local function supportsColorizedLoot(player)
+	if not player then
+		return false
+	end
+	if player.isUsingAstraClient and player:isUsingAstraClient() then
+		return true
+	end
+	return player.isUsingFonticakClient and player:isUsingFonticakClient()
+end
+
 local function addLootRecipient(recipients, player)
 	if player then
 		recipients[#recipients + 1] = player
@@ -40,7 +50,7 @@ local function sendUngroupedLootMessage(player, corpse, monsterName, preyLootTex
 
 	if useColorized then
 		for _, recipient in ipairs(recipients) do
-			if recipient.isUsingAstraClient and recipient:isUsingAstraClient() then
+			if supportsColorizedLoot(recipient) then
 				needColorized = true
 				break
 			end
@@ -53,7 +63,7 @@ local function sendUngroupedLootMessage(player, corpse, monsterName, preyLootTex
 	end
 
 	for _, recipient in ipairs(recipients) do
-		local wantsColorized = needColorized and recipient.isUsingAstraClient and recipient:isUsingAstraClient()
+		local wantsColorized = needColorized and supportsColorizedLoot(recipient)
 		if wantsColorized then
 			colorizedText = colorizedText or buildText(true)
 			sendLootMessage(recipient, colorizedText)

--- a/data/scripts/network/item_values.lua
+++ b/data/scripts/network/item_values.lua
@@ -18,7 +18,10 @@ local MARKET_DETAIL_NAMES = {
 	[15] = "Weight",
 	[16] = "Imbuement Slots",
 	[17] = "Classification",
-	[18] = "Tier"
+	[18] = "Tier",
+	[19] = "Skill Boost",
+	[20] = "Protection",
+	[21] = "Augments"
 }
 
 local function supportsCustomNetwork(player)

--- a/data/scripts/network/item_values.lua
+++ b/data/scripts/network/item_values.lua
@@ -25,13 +25,7 @@ local MARKET_DETAIL_NAMES = {
 }
 
 local function supportsCustomNetwork(player)
-	if not player then
-		return false
-	end
-	if player.isUsingAstraClient and player:isUsingAstraClient() then
-		return true
-	end
-	return player.isUsingFonticakClient and player:isUsingFonticakClient()
+	return player and player.supportsCustomItemNetwork and player:supportsCustomItemNetwork()
 end
 
 local function colorizedLootEnabled()

--- a/data/scripts/network/item_values.lua
+++ b/data/scripts/network/item_values.lua
@@ -22,7 +22,13 @@ local MARKET_DETAIL_NAMES = {
 }
 
 local function supportsCustomNetwork(player)
-	return player and player.isUsingAstraClient and player:isUsingAstraClient()
+	if not player then
+		return false
+	end
+	if player.isUsingAstraClient and player:isUsingAstraClient() then
+		return true
+	end
+	return player.isUsingFonticakClient and player:isUsingFonticakClient()
 end
 
 local function colorizedLootEnabled()

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -44,6 +44,9 @@ local MARKET_DESC_WEIGHT = 15
 local MARKET_DESC_IMBUEMENTS = 16
 local MARKET_DESC_CLASSIFICATION = 17
 local MARKET_DESC_TIER = 18
+local MARKET_DESC_SKILL_BOOST = 19
+local MARKET_DESC_PROTECTION = 20
+local MARKET_DESC_AUGMENTS = 21
 
 local MARKET_REQUEST_MY_OFFERS = 0xFFFE
 local MARKET_REQUEST_MY_HISTORY = 0xFFFF
@@ -731,6 +734,17 @@ local function buildDepotItemMap(player)
 	return depotMap
 end
 
+local function getMarketItemClassification(itemId)
+	itemId = tonumber(itemId) or 0
+	if itemId <= 0 then
+		return 0
+	end
+
+	local xmlAttributes = marketItemXmlAttributes[itemId] or {}
+	local itemType = ItemType(itemId)
+	return tonumber(xmlAttributes.classification) or tonumber(itemType:getClassification()) or 0
+end
+
 -- Builds the list of catalog entries to send to a player when entering the market.
 -- Each entry represents a catalog item and the available amount the player has for a specific tier.
 -- @param depotMap Table mapping keys of the form "itemId:tier" to the available amount for that item/tier. If nil, treated as empty.
@@ -762,12 +776,14 @@ local function buildMarketEnterEntries(depotMap)
 	end
 
 	for _, entry in ipairs(marketItems) do
+		local classification = getMarketItemClassification(entry.id)
 		entries[#entries + 1] = {
 			id = entry.id,
 			category = entry.category,
 			name = entry.name,
 			amount = depotMap[getDepotItemKey(entry.id, 0)] or 0,
-			tier = 0
+			tier = 0,
+			classification = classification
 		}
 
 		local tierAmounts = tierAmountsByItem[entry.id]
@@ -780,7 +796,8 @@ local function buildMarketEnterEntries(depotMap)
 						category = entry.category,
 						name = entry.name,
 						amount = amount,
-						tier = tier
+						tier = tier,
+						classification = classification
 					}
 				end
 			end
@@ -1262,6 +1279,133 @@ local function buildAbilityDescription(itemType)
 	return table.concat(parts, ", ")
 end
 
+local function buildSkillBoostDescription(itemType)
+	local abilities = itemType:getAbilities()
+	if not abilities then
+		return nil
+	end
+
+	local parts = {}
+
+	if abilities.stats then
+		for statIndex, value in pairs(abilities.stats) do
+			value = tonumber(value) or 0
+			if value ~= 0 and getStatName then
+				local statId = (tonumber(statIndex) or 1) - 1
+				local statName = getStatName(statId)
+				if statName and statName ~= "unknown" then
+					parts[#parts + 1] = string.format("%s %+d", statName, value)
+				end
+			end
+		end
+	end
+
+	if abilities.skills then
+		for skillIndex, value in pairs(abilities.skills) do
+			value = tonumber(value) or 0
+			if value ~= 0 and getSkillName then
+				local skillId = (tonumber(skillIndex) or 1) - 1
+				local skillName = getSkillName(skillId)
+				if skillName and skillName ~= "unknown" then
+					parts[#parts + 1] = string.format("%s %+d", skillName, value)
+				end
+			end
+		end
+	end
+
+	if abilities.specialSkills then
+		for skillIndex, value in pairs(abilities.specialSkills) do
+			value = tonumber(value) or 0
+			if value ~= 0 and getSpecialSkillName then
+				local specialSkillId = (tonumber(skillIndex) or 1) - 1
+				local skillName = getSpecialSkillName(specialSkillId)
+				if skillName and skillName ~= "unknown" then
+					local formattedValue
+					if specialSkillId >= 6 then
+						formattedValue = string.format("%g", value / 100)
+					else
+						formattedValue = string.format("%+g", value / 100)
+					end
+					parts[#parts + 1] = string.format("%s %s%%", skillName, formattedValue)
+				end
+			end
+		end
+	end
+
+	if #parts == 0 then
+		return nil
+	end
+	return table.concat(parts, ", ")
+end
+
+local function addSkillBoostDescriptions(descriptions, itemType)
+	local text = buildSkillBoostDescription(itemType)
+	if text then
+		addDescription(descriptions, MARKET_DESC_SKILL_BOOST, text)
+	end
+end
+
+local function formatAugmentDescription(itemType)
+	local text = itemType:getAugmentDescription()
+	if not text or text == "" then
+		return nil
+	end
+
+	text = text:gsub("^%s+", "")
+	text = text:gsub("^Augments:%s*", "")
+	if text:sub(-1) == "." then
+		text = text:sub(1, -2)
+	end
+	if text == "" then
+		return nil
+	end
+	return text
+end
+
+local function addAugmentDescriptions(descriptions, itemType)
+	local text = formatAugmentDescription(itemType)
+	if text then
+		addDescription(descriptions, MARKET_DESC_AUGMENTS, text)
+	end
+end
+
+local function buildProtectionDescription(itemType)
+	local abilities = itemType:getAbilities()
+	if not abilities or not abilities.absorbPercent then
+		return nil
+	end
+
+	local absorbPercent = abilities.absorbPercent
+	local protectionPhysical = absorbPercent[1]
+	for elem = 2, #absorbPercent do
+		local val = absorbPercent[elem]
+		if protectionPhysical ~= val then
+			protectionPhysical = nil
+			break
+		end
+	end
+
+	if protectionPhysical and protectionPhysical ~= 0 then
+		return string.format("all %+d%%", protectionPhysical)
+	end
+
+	local protections = {}
+	for element, value in pairs(absorbPercent) do
+		value = tonumber(value) or 0
+		if value ~= 0 and getCombatName then
+			local elementName = getCombatName(2 ^ (element - 1))
+			if elementName then
+				protections[#protections + 1] = string.format("%s %+d%%", elementName, value)
+			end
+		end
+	end
+
+	if #protections == 0 then
+		return nil
+	end
+	return table.concat(protections, ", ")
+end
+
 local function buildMarketDescriptions(itemId)
 	local itemType = ItemType(itemId)
 	local descriptions = {}
@@ -1273,6 +1417,11 @@ local function buildMarketDescriptions(itemId)
 	local armor = tonumber(itemType:getArmor()) or 0
 	if armor > 0 then
 		addDescription(descriptions, MARKET_DESC_ARMOR, armor)
+	end
+
+	local protection = buildProtectionDescription(itemType)
+	if protection then
+		addDescription(descriptions, MARKET_DESC_PROTECTION, protection)
 	end
 
 	local attack = tonumber(itemType:getAttack()) or 0
@@ -1342,6 +1491,8 @@ local function buildMarketDescriptions(itemId)
 	end
 
 	addDescription(descriptions, MARKET_DESC_ABILITY, buildAbilityDescription(itemType))
+	addSkillBoostDescriptions(descriptions, itemType)
+	addAugmentDescriptions(descriptions, itemType)
 
 	local charges = tonumber(itemType:getCharges()) or 0
 	if charges > 0 then
@@ -1493,6 +1644,7 @@ local function sendMarketEnter(player, depotMap)
 			out:addString(entry.name)
 			out:addU16(math.min(entry.amount or 0, 0xFFFF))
 			out:addByte(entry.tier or 0)
+			out:addByte(entry.classification or 0)
 		end
 
 		out:sendToPlayer(player)
@@ -1604,15 +1756,16 @@ end
 
 local openHandler = PacketHandler(OPCODE_MARKET_OPEN)
 function openHandler.onReceive(player, msg)
+	expireOffers()
+
+	-- Cyclopedia/OTC can request the catalog without opening a market session.
 	if not hasCurrentMarketAccess(player) then
-		sendMarketMessage(player, "You need to be near a depot or market.")
-		sendMarketLeave(player)
+		sendMarketEnter(player, {})
 		return
 	end
 
 	setMarketDepotId(player, getPlayerLastDepotId(player))
 	setMarketOpen(player)
-	expireOffers()
 	sendMarketEnter(player)
 end
 openHandler:register()

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -432,7 +432,29 @@ local function readItemXmlAttributes(itemNode)
 	return attributes
 end
 
-local function addMarketItem(itemId, xmlName, xmlAttributes)
+local function readMoveeventAttribute(itemNode, key)
+	if not itemNode or not key then
+		return nil
+	end
+
+	for attributeNode in itemNode:children() do
+		if attributeNode:name() == "attribute" then
+			local nodeKey = attributeNode:attribute("key")
+			local nodeValue = attributeNode:attribute("value")
+			if nodeKey == "script" and nodeValue == "moveevent" then
+				for subNode in attributeNode:children() do
+					if subNode:name() == "attribute" and subNode:attribute("key") == key then
+						return subNode:attribute("value")
+					end
+				end
+			end
+		end
+	end
+
+	return nil
+end
+
+local function addMarketItem(itemId, xmlName, xmlAttributes, itemNode)
 	itemId = tonumber(itemId)
 	if not itemId or marketItemsById[itemId] or not isMarketableItem(itemId) then
 		return
@@ -444,10 +466,18 @@ local function addMarketItem(itemId, xmlName, xmlAttributes)
 		return
 	end
 
+	local moveeventVocation = readMoveeventAttribute(itemNode, "vocation")
+	local moveeventLevel = tonumber(readMoveeventAttribute(itemNode, "level")) or 0
+	local requiredLevel = math.max(tonumber(itemType:getMinReqLevel()) or 0, moveeventLevel)
+	local restrictVocation = 0
+
 	local entry = {
 		id = itemId,
 		name = name,
-		category = getItemCategory(itemType)
+		category = getItemCategory(itemType),
+		moveeventVocation = moveeventVocation,
+		requiredLevel = requiredLevel,
+		restrictVocation = restrictVocation,
 	}
 
 	marketItemsById[itemId] = entry
@@ -481,10 +511,10 @@ local function loadMarketCatalog()
 			local attributes = readItemXmlAttributes(itemNode)
 
 			if id then
-				addMarketItem(id, name, attributes)
+				addMarketItem(id, name, attributes, itemNode)
 			elseif fromId and toId and toId >= fromId then
 				for itemId = fromId, toId do
-					addMarketItem(itemId, name, attributes)
+					addMarketItem(itemId, name, attributes, itemNode)
 				end
 			end
 		end
@@ -745,6 +775,110 @@ local function getMarketItemClassification(itemId)
 	return tonumber(xmlAttributes.classification) or tonumber(itemType:getClassification()) or 0
 end
 
+-- Client cyclopedia/market filters use OTC vocation ids (1=sorc, 2=druid, 3=pally, 4=knight, 9=monk).
+local MARKET_VOCATION_NAME_TO_CLIENT_ID = {
+	["sorcerer"] = 1,
+	["master sorcerer"] = 1,
+	["druid"] = 2,
+	["elder druid"] = 2,
+	["paladin"] = 3,
+	["royal paladin"] = 3,
+	["knight"] = 4,
+	["elite knight"] = 4,
+	["monk"] = 9,
+	["exalted monk"] = 9,
+}
+
+local marketRestrictVocationCache = {}
+
+local function normalizeMarketVocationName(name)
+	name = name:gsub("^%s+", ""):gsub("%s+$", ""):lower()
+	if name:sub(-1) == "s" then
+		name = name:sub(1, -2)
+	end
+	return name
+end
+
+local function addVocationMaskFromName(mask, rawName)
+	local name = normalizeMarketVocationName(rawName:match("^([^;]+)") or rawName)
+	local clientVocId = MARKET_VOCATION_NAME_TO_CLIENT_ID[name]
+	if clientVocId and clientVocId > 0 then
+		return mask | (2 ^ (clientVocId - 1))
+	end
+	return mask
+end
+
+local function parseVocationMaskFromRawAttribute(vocationValue)
+	if not vocationValue or vocationValue == "" then
+		return 0
+	end
+
+	local mask = 0
+	for part in vocationValue:gmatch("[^,]+") do
+		mask = addVocationMaskFromName(mask, part)
+	end
+	return mask
+end
+
+local function parseVocationMaskFromDisplayString(vocationString)
+	if not vocationString or vocationString == "" then
+		return 0
+	end
+
+	local normalized = vocationString:lower():gsub("%s+and%s+", ",")
+	local mask = 0
+	for part in normalized:gmatch("[^,]+") do
+		mask = addVocationMaskFromName(mask, part)
+	end
+	return mask
+end
+
+local function getMarketRestrictVocation(itemId)
+	itemId = tonumber(itemId) or 0
+	if itemId <= 0 then
+		return 0
+	end
+
+	if marketRestrictVocationCache[itemId] ~= nil then
+		return marketRestrictVocationCache[itemId]
+	end
+
+	local entry = marketItemsById[itemId]
+	if entry and entry.restrictVocation and entry.restrictVocation > 0 then
+		marketRestrictVocationCache[itemId] = entry.restrictVocation
+		return entry.restrictVocation
+	end
+
+	local mask = 0
+	if entry and entry.moveeventVocation then
+		mask = parseVocationMaskFromRawAttribute(entry.moveeventVocation)
+	end
+
+	if mask == 0 then
+		mask = parseVocationMaskFromDisplayString(ItemType(itemId):getVocationString())
+	end
+
+	if entry then
+		entry.restrictVocation = mask
+	end
+	marketRestrictVocationCache[itemId] = mask
+	return mask
+end
+
+local function getMarketRequiredLevel(itemId)
+	itemId = tonumber(itemId) or 0
+	if itemId <= 0 then
+		return 0
+	end
+
+	local entry = marketItemsById[itemId]
+	if entry and entry.requiredLevel and entry.requiredLevel > 0 then
+		return entry.requiredLevel
+	end
+
+	return math.max(0, tonumber(ItemType(itemId):getMinReqLevel()) or 0)
+end
+
 -- Builds the list of catalog entries to send to a player when entering the market.
 -- Each entry represents a catalog item and the available amount the player has for a specific tier.
 -- @param depotMap Table mapping keys of the form "itemId:tier" to the available amount for that item/tier. If nil, treated as empty.
@@ -777,13 +911,17 @@ local function buildMarketEnterEntries(depotMap)
 
 	for _, entry in ipairs(marketItems) do
 		local classification = getMarketItemClassification(entry.id)
+		local requiredLevel = getMarketRequiredLevel(entry.id)
+		local restrictVocation = getMarketRestrictVocation(entry.id)
 		entries[#entries + 1] = {
 			id = entry.id,
 			category = entry.category,
 			name = entry.name,
 			amount = depotMap[getDepotItemKey(entry.id, 0)] or 0,
 			tier = 0,
-			classification = classification
+			classification = classification,
+			requiredLevel = requiredLevel,
+			restrictVocation = restrictVocation
 		}
 
 		local tierAmounts = tierAmountsByItem[entry.id]
@@ -797,7 +935,9 @@ local function buildMarketEnterEntries(depotMap)
 						name = entry.name,
 						amount = amount,
 						tier = tier,
-						classification = classification
+						classification = classification,
+						requiredLevel = requiredLevel,
+						restrictVocation = restrictVocation
 					}
 				end
 			end
@@ -1645,6 +1785,8 @@ local function sendMarketEnter(player, depotMap)
 			out:addU16(math.min(entry.amount or 0, 0xFFFF))
 			out:addByte(entry.tier or 0)
 			out:addByte(entry.classification or 0)
+			out:addU16(entry.requiredLevel or 0)
+			out:addU16(entry.restrictVocation or 0)
 		end
 
 		out:sendToPlayer(player)

--- a/data/scripts/network/market/market.lua
+++ b/data/scripts/network/market/market.lua
@@ -1453,6 +1453,18 @@ local function buildSkillBoostDescription(itemType)
 		end
 	end
 
+	if abilities.specialMagicLevel then
+		for element, value in pairs(abilities.specialMagicLevel) do
+			value = tonumber(value) or 0
+			if value ~= 0 and getCombatName then
+				local elementName = getCombatName(2 ^ (element - 1))
+				if elementName then
+					parts[#parts + 1] = string.format("%s magic level %+d", elementName, value)
+				end
+			end
+		end
+	end
+
 	if abilities.specialSkills then
 		for skillIndex, value in pairs(abilities.specialSkills) do
 			value = tonumber(value) or 0

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -157,7 +157,7 @@ Server condition:
 QuickLootFlags = shouldSendQuickLootFlags()
 ```
 
-`shouldSendQuickLootFlags()` is true only for AstraClient when quick loot is enabled in config.
+`shouldSendQuickLootFlags()` is true for AstraClient and FonticakClient when quick loot is enabled in config.
 
 ### GameThingUpgradeClassification
 

--- a/docs/client-configuration.pt-BR.md
+++ b/docs/client-configuration.pt-BR.md
@@ -157,7 +157,7 @@ Condição no server:
 QuickLootFlags = shouldSendQuickLootFlags()
 ```
 
-`shouldSendQuickLootFlags()` e verdadeiro para AstraClient e FonticakClient quando quick loot esta habilitado na config.
+`shouldSendQuickLootFlags()` é verdadeiro para AstraClient e FonticakClient quando quick loot está habilitado na configuração.
 
 ### GameThingUpgradeClassification
 

--- a/docs/client-configuration.pt-BR.md
+++ b/docs/client-configuration.pt-BR.md
@@ -157,7 +157,7 @@ Condição no server:
 QuickLootFlags = shouldSendQuickLootFlags()
 ```
 
-`shouldSendQuickLootFlags()` e verdadeiro apenas para AstraClient quando quick loot esta habilitado na config.
+`shouldSendQuickLootFlags()` e verdadeiro para AstraClient e FonticakClient quando quick loot esta habilitado na config.
 
 ### GameThingUpgradeClassification
 

--- a/src/luanetworkmessage.cpp
+++ b/src/luanetworkmessage.cpp
@@ -52,8 +52,9 @@ bool isOtcOrAstraLuaOpcode(uint8_t opcode)
 	}
 }
 
-bool isAstraOnlyLuaOpcode(uint8_t opcode)
+bool isExtendedClientLuaOpcode(uint8_t opcode)
 {
+	// Opcodes shared by AstraClient and FonticakClient custom item/blessing protocols.
 	switch (opcode) {
 		case 0x2C: // custom boss cooldown
 		case 0x3D: // weapon proficiency reshape offers
@@ -81,7 +82,7 @@ bool canSendLuaNetworkMessageToPlayer(const NetworkMessage& message, const Playe
 	}
 
 	const uint8_t opcode = message.getBuffer()[NetworkMessage::INITIAL_BUFFER_POSITION];
-	if (isAstraOnlyLuaOpcode(opcode)) {
+	if (isExtendedClientLuaOpcode(opcode)) {
 		return player.isAstraClient() || player.isFonticakClient();
 	}
 	if (isOtcOrAstraLuaOpcode(opcode)) {

--- a/src/luanetworkmessage.cpp
+++ b/src/luanetworkmessage.cpp
@@ -82,7 +82,7 @@ bool canSendLuaNetworkMessageToPlayer(const NetworkMessage& message, const Playe
 
 	const uint8_t opcode = message.getBuffer()[NetworkMessage::INITIAL_BUFFER_POSITION];
 	if (isAstraOnlyLuaOpcode(opcode)) {
-		return player.isAstraClient();
+		return player.isAstraClient() || player.isFonticakClient();
 	}
 	if (isOtcOrAstraLuaOpcode(opcode)) {
 		return player.isOTC() || player.isAstraClient();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -8016,7 +8016,9 @@ void Player::flushPendingLoot(const std::string& groupKey)
 	const std::string colorizedText = colorizedLootEnabled ? buildLootText(true) : plainText;
 	const auto sendLootText = [&](Player& recipient) {
 		recipient.sendChannelMessage(
-		    "", colorizedLootEnabled && recipient.isAstraClient() ? colorizedText : plainText, TALKTYPE_CHANNEL_O, 10);
+		    "", colorizedLootEnabled && (recipient.isAstraClient() || recipient.isFonticakClient()) ? colorizedText
+		                                                                                             : plainText,
+		    TALKTYPE_CHANNEL_O, 10);
 	};
 
 	const auto& party = getParty();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -8012,16 +8012,50 @@ void Player::flushPendingLoot(const std::string& groupKey)
 	};
 
 	const bool colorizedLootEnabled = ConfigManager::getBoolean(ConfigManager::COLORIZED_LOOT_VALUE);
-	const std::string plainText = buildLootText(false);
-	const std::string colorizedText = colorizedLootEnabled ? buildLootText(true) : plainText;
-	const auto sendLootText = [&](Player& recipient) {
-		recipient.sendChannelMessage(
-		    "", colorizedLootEnabled && (recipient.isAstraClient() || recipient.isFonticakClient()) ? colorizedText
-		                                                                                             : plainText,
-		    TALKTYPE_CHANNEL_O, 10);
+	std::string plainText;
+	std::string colorizedText;
+	bool needColorized = false;
+
+	const auto wantsColorizedLoot = [](const Player& recipient) {
+		return recipient.isAstraClient() || recipient.isFonticakClient();
 	};
 
 	const auto& party = getParty();
+	if (colorizedLootEnabled) {
+		if (party && party->isSharedExperienceEnabled()) {
+			const auto& leader = party->getLeader();
+			if (leader && wantsColorizedLoot(*leader)) {
+				needColorized = true;
+			}
+			if (!needColorized) {
+				for (auto& member : party->getMembers()) {
+					if (auto memberPtr = member.lock(); memberPtr && wantsColorizedLoot(*memberPtr)) {
+						needColorized = true;
+						break;
+					}
+				}
+			}
+		} else if (wantsColorizedLoot(*this)) {
+			needColorized = true;
+		}
+	}
+
+	const auto sendLootText = [&](Player& recipient) {
+		const bool useColorized = needColorized && wantsColorizedLoot(recipient);
+		if (useColorized) {
+			if (colorizedText.empty()) {
+				colorizedText = buildLootText(true);
+			}
+			recipient.sendChannelMessage("", colorizedText, TALKTYPE_CHANNEL_O, 10);
+			return;
+		}
+
+		if (plainText.empty()) {
+			plainText = buildLootText(false);
+		}
+		recipient.sendChannelMessage("", plainText, TALKTYPE_CHANNEL_O, 10);
+	};
+
 	if (party && party->isSharedExperienceEnabled()) {
 		const auto& leader = party->getLeader();
 		if (leader) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -621,7 +621,7 @@ void ProtocolGame::release()
 
 bool ProtocolGame::shouldSendQuickLootFlags() const
 {
-	return isAstraClient && getBoolean(ConfigManager::QUICK_LOOT_ENABLED);
+	return (isAstraClient || isFonticakClient) && getBoolean(ConfigManager::QUICK_LOOT_ENABLED);
 }
 
 bool ProtocolGame::shouldSendContainerPagination() const

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4915,41 +4915,55 @@ void ProtocolGame::sendItemInspection(std::shared_ptr<Item> item, uint16_t itemI
 	static const char* skillNames[] = {
 		"Fist", "Club", "Sword", "Axe", "Distance", "Shielding", "Fishing"
 	};
-	static const char* statNames[] = {
-		"", "", "", "Magic Level", ""
-	};
 	static const char* specialSkillNames[] = {
 		"Critical Hit Chance", "Critical Hit Amount",
 		"Life Leech Chance", "Life Leech Amount",
 		"Mana Leech Chance", "Mana Leech Amount"
 	};
 	if (itemType.abilities) {
-		std::string skillBonusParts;
+		const auto appendSignedBonus = [&descriptions](const std::string& key, int32_t value) {
+			if (value == 0) {
+				return;
+			}
+			const std::string formatted = value > 0 ? "+" + std::to_string(value) : std::to_string(value);
+			descriptions.emplace_back(key, formatted);
+		};
 
-		for (int i = STAT_FIRST; i <= STAT_LAST; ++i) {
-			if (itemType.abilities->stats[i] > 0 && statNames[i][0] != '\0') {
-				if (!skillBonusParts.empty()) skillBonusParts += ", ";
-				skillBonusParts += std::string(statNames[i]) + " +" + std::to_string(itemType.abilities->stats[i]);
+		const auto appendPercentBonus = [&descriptions](const std::string& key, int32_t value) {
+			if (value == 0) {
+				return;
 			}
+			const std::string formatted = value > 0 ? "+" + std::to_string(value) + "%" : std::to_string(value) + "%";
+			descriptions.emplace_back(key, formatted);
+		};
+
+		if (itemType.abilities->stats[STAT_MAGICPOINTS] != 0) {
+			appendSignedBonus("Magic Level", itemType.abilities->stats[STAT_MAGICPOINTS]);
 		}
+
+		for (int i = 0; i < COMBAT_COUNT; ++i) {
+			const int16_t value = itemType.abilities->specialMagicLevelSkill[i];
+			if (value == 0) {
+				continue;
+			}
+			const char* combatName = combatNames[i];
+			if (combatName == nullptr || combatName[0] == '\0') {
+				continue;
+			}
+			std::string label = combatName;
+			label[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(label[0])));
+			label += " Magic Level";
+			appendSignedBonus(label, value);
+		}
+
 		for (int i = SKILL_FIST; i <= SKILL_FISHING; ++i) {
-			if (itemType.abilities->skills[i] > 0) {
-				if (!skillBonusParts.empty()) skillBonusParts += ", ";
-				skillBonusParts += std::string(skillNames[i]) + " +" + std::to_string(itemType.abilities->skills[i]);
-			}
+			appendSignedBonus(skillNames[i], itemType.abilities->skills[i]);
 		}
-		if (itemType.abilities->speed > 0) {
-			if (!skillBonusParts.empty()) skillBonusParts += ", ";
-			skillBonusParts += "Speed +" + std::to_string(itemType.abilities->speed);
-		}
+
+		appendSignedBonus("Speed", itemType.abilities->speed);
+
 		for (int i = SPECIALSKILL_FIRST; i <= SPECIALSKILL_LAST; ++i) {
-			if (itemType.abilities->specialSkills[i] > 0) {
-				if (!skillBonusParts.empty()) skillBonusParts += ", ";
-				skillBonusParts += std::string(specialSkillNames[i]) + " +" + std::to_string(itemType.abilities->specialSkills[i]) + "%";
-			}
-		}
-		if (!skillBonusParts.empty()) {
-			descriptions.emplace_back("Skill Bonus", skillBonusParts);
+			appendPercentBonus(specialSkillNames[i], itemType.abilities->specialSkills[i]);
 		}
 	}
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -4953,6 +4953,26 @@ void ProtocolGame::sendItemInspection(std::shared_ptr<Item> item, uint16_t itemI
 		}
 	}
 
+	{
+		const std::string augmentDescription = itemType.parseAugmentDescription();
+		if (!augmentDescription.empty()) {
+			std::string augmentValue = augmentDescription;
+			if (!augmentValue.empty() && augmentValue.front() == '\n') {
+				augmentValue.erase(0, 1);
+			}
+			constexpr std::string_view augmentPrefix = "Augments: ";
+			if (augmentValue.rfind(augmentPrefix.data(), 0) == 0) {
+				augmentValue.erase(0, augmentPrefix.size());
+			}
+			if (!augmentValue.empty() && augmentValue.back() == '.') {
+				augmentValue.pop_back();
+			}
+			if (!augmentValue.empty()) {
+				descriptions.emplace_back("Augments", augmentValue);
+			}
+		}
+	}
+
 	const uint16_t totalSlots = item ? item->getImbuementSlots() : itemType.imbuementSlot;
 	if (totalSlots > 0) {
 		descriptions.emplace_back("Imbuement Slots", std::to_string(totalSlots));

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -522,7 +522,7 @@ ProtocolGame::~ProtocolGame()
 
 void ProtocolGame::sendBlessingWindow()
 {
-	if (!player || !isAstraClient) return;
+	if (!player || (!isAstraClient && !isFonticakClient)) return;
 
 	NetworkMessage msg;
 	msg.addByte(0x9B);
@@ -578,7 +578,7 @@ void ProtocolGame::sendBlessingWindow()
 
 void ProtocolGame::sendBlessStatus()
 {
-	if (!player || !isAstraClient) return;
+	if (!player || (!isAstraClient && !isFonticakClient)) return;
 
 	uint8_t totalCount = 0;
 	for (uint8_t i = 2; i <= 8; i++) {
@@ -1753,7 +1753,7 @@ void ProtocolGame::parsePacketOnDispatcher(NetworkMessage_ptr& packet)
 			break;
 
 		case 0xCF:
-			if (isAstraClient) {
+			if (isAstraClient || isFonticakClient) {
 				sendBlessingWindow();
 			}
 			break;
@@ -2945,7 +2945,7 @@ void ProtocolGame::sendKillTrackerUpdate(const std::shared_ptr<Container>& corps
 
 void ProtocolGame::sendItemValues()
 {
-	if (!isAstraClient) {
+	if (!isAstraClient && !isFonticakClient) {
 		return;
 	}
 
@@ -4262,7 +4262,7 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 		player->sendMonkData();
 	}
 
-	if (isAstraClient) {
+	if (isAstraClient || isFonticakClient) {
 		sendBlessStatus();
 	}
 

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -34,6 +34,7 @@ constexpr uint8_t ASTRA_LOGIN_CAST_LIST_MARKER = 0xA2;
 constexpr uint8_t ASTRA_LOGIN_CAST_LIST_VERSION = 1;
 constexpr size_t ASTRA_LOGIN_CAST_LIST_LIMIT = std::numeric_limits<uint8_t>::max();
 constexpr std::string_view ASTRA_LOGIN_CAST_LIST_REQUEST = "__astra_casts_v1__";
+constexpr std::string_view FONTICAK_LOGIN_BOOSTED_REQUEST = "__fonticak_boosted_v1__";
 
 struct LoginCastEntry {
 	std::string name;
@@ -516,12 +517,20 @@ void ProtocolLogin::getCharacterList(std::string_view accountName, std::string_v
 		}
 	}
 
-	if (isAstraClient) {
+	if (isAstraClient || isFonticakClient_) {
 		addAstraLoginBoostedInfo(output);
 	}
 
 	send(output);
 
+	disconnect();
+}
+
+void ProtocolLogin::getFonticakBoostedInfo()
+{
+	auto output = OutputMessagePool::getOutputMessage();
+	addAstraLoginBoostedInfo(output);
+	send(output);
 	disconnect();
 }
 
@@ -700,7 +709,7 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 
 	// Always detect AstraClient and FonticakClient, regardless of astraClientOnly setting.
 	// This allows sending the correct packet format (0x65 vs 0x64) to each client.
-	bool isFonticakClient_ = false;
+	isFonticakClient_ = false;
 	if (msg.getBufferPosition() + 2 <= msg.getLength()) {
 		uint16_t markerLength = msg.get<uint16_t>();
 		if (markerLength > 0 && markerLength <= 64 && msg.getBufferPosition() + markerLength <= msg.getLength()) {
@@ -731,6 +740,8 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 
 	const bool isAstraCastListRequest =
 	    accountName.empty() && isAstraClient_ && password == ASTRA_LOGIN_CAST_LIST_REQUEST;
+	const bool isFonticakBoostedRequest =
+	    accountName.empty() && isFonticakClient_ && password == FONTICAK_LOGIN_BOOSTED_REQUEST;
 	if (isAstraClient_ && !isAstraCastListRequest) {
 		LOG_DEBUG("[AstraClient] Login protocol client accepted");
 	}
@@ -752,10 +763,14 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	g_dispatcher.addTask([=, thisPtr = std::static_pointer_cast<ProtocolLogin>(shared_from_this()),
 	                      accountName = std::string{accountName},
 	                      password = std::string{password},
-	                      astraCastListRequest = isAstraCastListRequest]() {
+	                      astraCastListRequest = isAstraCastListRequest,
+	                      fonticakBoostedRequest = isFonticakBoostedRequest]() {
 		if (astraCastListRequest) {
 			LoginAttemptLimiter::getInstance().releaseReservation(clientIP, accountName);
 			thisPtr->getAstraCastList();
+		} else if (fonticakBoostedRequest) {
+			LoginAttemptLimiter::getInstance().releaseReservation(clientIP, accountName);
+			thisPtr->getFonticakBoostedInfo();
 		} else if (accountName.empty()) {
 			thisPtr->getCastList(password, clientIP);
 		} else {

--- a/src/protocollogin.h
+++ b/src/protocollogin.h
@@ -123,8 +123,10 @@ private:
 	                      uint32_t clientIP);
 	void getCastList(const std::string& password, uint32_t clientIP);
 	void getAstraCastList();
+	void getFonticakBoostedInfo();
 
 	bool isAstraClient_ = false;
+	bool isFonticakClient_ = false;
 };
 
 #endif


### PR DESCRIPTION
Send item values, colorized loot text, and blessing packets to OTC-Fonticak clients alongside Astra support.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper TFS Downgrades code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fonticak support for colorized loot, custom item values, Lua network messages, quick loot, blessing information, and boosted-creature login details.
  * Expanded item inspection with per-stat bonuses and augment details.
  * Added market classifications, descriptions, vocation restrictions, level requirements, and elemental protection details.
  * Added registry-based loot valuation with fallback pricing.
* **Bug Fixes**
  * Improved handling of missing player data and NPC messages, including placeholders and greeting context.
  * Market access now provides an empty catalog view instead of an error message when unavailable.
* **Documentation**
  * Updated quick-loot support documentation for Fonticak clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->