### PR TITLE
fix(pathfinding): preserve semantics after A* optimization

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -394,6 +394,7 @@ public:
 	Tile* getTile() override final { return tile.lock().get(); }
 	const Tile* getTile() const override final { return tile.lock().get(); }
 	std::shared_ptr<Tile> getTileShared() { return tile.lock(); }
+	std::shared_ptr<const Tile> getTileShared() const { return tile.lock(); }
 
 	const Position& getLastPosition() const { return lastPosition; }
 	void setLastPosition(Position newLastPos) { lastPosition = newLastPos; }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -808,11 +808,12 @@ struct PathSearchMetrics
 bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirList,
                           const FrozenPathingConditionCall& pathCondition, const FindPathParams& fpp) const
 {
+	const size_t initialDirListSize = dirList.size();
 	PerformanceScope performanceScope(PerformanceMetric::MapGetPathMatching);
 	PathSearchMetrics searchMetrics;
 	const auto finish = [&](bool success) {
 		g_performanceMetrics.recordPathRequest(success, searchMetrics.nodesVisited, searchMetrics.tilesRead,
-		                                       success ? dirList.size() : 0);
+		                                       success ? dirList.size() - initialDirListSize : 0);
 		return success;
 	};
 	const Position start_position = creature.getPosition();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -823,14 +823,16 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 	// here avoids exploring up to MAX_NODES tiles with queryAdd on every
 	// neighbor, which is the dominant pathfinder CPU cost when monsters chase
 	// distant/off-floor targets.
-	if (start_position.z != target_position.z) {
+	if (fpp.clearSight && start_position.z != target_position.z) {
 		return finish(false);
 	}
 	const int32_t startDx = start_position.getDistanceX(target_position);
 	const int32_t startDy = start_position.getDistanceY(target_position);
-	if (fpp.maxSearchDist != 0 && fpp.maxTargetDist >= 0) {
+	if (fpp.maxSearchDist > 0 && fpp.maxTargetDist >= 0) {
 		const int32_t startChebyshev = std::max(startDx, startDy);
-		if (startChebyshev > fpp.maxSearchDist + fpp.maxTargetDist) {
+		const int64_t maxReach = static_cast<int64_t>(fpp.maxSearchDist) +
+		                         static_cast<int64_t>(fpp.maxTargetDist);
+		if (static_cast<int64_t>(startChebyshev) > maxReach) {
 			return finish(false);
 		}
 	}
@@ -842,17 +844,11 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 	// to reset). Only valid when best_match == 0, i.e. the search would stop
 	// at the start node; otherwise the A* keeps looking for a better match.
 	if (pathCondition(start_position, start_position, fpp, best_match) && best_match == 0) {
-		dirList.clear();
 		return finish(true);
 	}
 	// The probe above may have touched best_match (non-zero = "acceptable but
 	// not ideal"); the search below must start from a clean state.
 	best_match = 0;
-
-	dirList.clear();
-	// Typical follow paths are short; pre-size to avoid push_back reallocs.
-	// clear() above keeps existing capacity, reserve only grows fresh vectors.
-	dirList.reserve(32);
 
 	Position end_position;
 	auto position = start_position;
@@ -884,7 +880,10 @@ bool Map::getPathMatching(const Creature& creature, std::vector<Direction>& dirL
 
 		return pathFloor ? pathFloor->getTile(tilePosition.x, tilePosition.y, tilePosition.z) : nullptr;
 	};
-	const Tile* creatureTile = creature.getTile();
+	// Pin the origin tile once for the complete search, then use its raw pointer
+	// in the hot loop without repeated weak_ptr locks or reference-count traffic.
+	const auto creatureTileRef = creature.getTileShared();
+	const Tile* const creatureTile = creatureTileRef.get();
 	const auto canWalkToForPath = [&](const Position& tilePosition) -> const Tile* {
 		const Tile* tile = getPathTile(tilePosition);
 		// Hoisted: Creature::getTile() locks a weak_ptr (atomic refcount) per
@@ -1307,13 +1306,11 @@ const AStarNode& AStarNodes::GetNode(uint16_t nodeIdx) const
 
 int_fast32_t AStarNodes::GetMapWalkCost(const AStarNode& node, const Position& neighborPos)
 {
-	// Orthogonal iff x or y matches (neighbors are always adjacent and never
-	// the node itself). Same result as the abs() comparison without abs().
-	if (node.x == neighborPos.x || node.y == neighborPos.y) {
-		return MAP_NORMALWALKCOST;
+	if (std::abs(node.x - neighborPos.x) == std::abs(node.y - neighborPos.y)) {
+		// diagonal movement extra cost
+		return MAP_DIAGONALWALKCOST;
 	}
-	// diagonal movement extra cost
-	return MAP_DIAGONALWALKCOST;
+	return MAP_NORMALWALKCOST;
 }
 
 int_fast32_t AStarNodes::GetTileWalkCost(const Creature& creature, const Tile* tile)

--- a/src/performance_metrics.cpp
+++ b/src/performance_metrics.cpp
@@ -261,6 +261,11 @@ uint64_t PerformanceMetrics::getMonsterIdleMetric(MonsterIdleMetric metric) cons
 	return monsterIdle[static_cast<size_t>(metric)].load(std::memory_order_relaxed);
 }
 
+uint64_t PerformanceMetrics::getPathSteps() const noexcept
+{
+	return path.pathLength.load(std::memory_order_relaxed);
+}
+
 void PerformanceMetrics::maybeReport()
 {
 	if (!isEnabled()) {

--- a/src/performance_metrics.h
+++ b/src/performance_metrics.h
@@ -171,6 +171,7 @@ public:
 
 	[[nodiscard]] uint64_t getMonsterIdleMetric(
 	    MonsterIdleMetric metric) const noexcept;
+	[[nodiscard]] uint64_t getPathSteps() const noexcept;
 
 	void maybeReport();
 

--- a/src/tests/test_pathfinding.cpp
+++ b/src/tests/test_pathfinding.cpp
@@ -2,6 +2,7 @@
 
 #include "../creature.h"
 #include "../map.h"
+#include "../performance_metrics.h"
 #include "../tile.h"
 #include "test_support.h"
 
@@ -36,6 +37,18 @@ public:
 
 private:
 	bool walkable;
+};
+
+class PathMetricsFixture
+{
+public:
+	PathMetricsFixture() : wasEnabled(g_performanceMetrics.isEnabled()) { g_performanceMetrics.setEnabled(true); }
+	~PathMetricsFixture() { g_performanceMetrics.setEnabled(wasEnabled); }
+
+	uint64_t getPathSteps() const { return g_performanceMetrics.getPathSteps(); }
+
+private:
+	bool wasEnabled;
 };
 
 using BlockedPositions = std::set<std::pair<uint16_t, uint16_t>>;
@@ -223,6 +236,32 @@ TEST_CASE(pathfinding_preserves_prefilled_direction_output_contract)
 	std::vector<Direction> inRangeDirections = prefix;
 	CHECK(findPath(map, Position{601, 601, 7}, Position{601, 601, 7}, exactPathParams(), inRangeDirections));
 	CHECK(inRangeDirections == prefix);
+}
+
+TEST_CASE(pathfinding_metrics_count_only_steps_appended_by_successful_search)
+{
+	PathMetricsFixture metrics;
+	const uint64_t initialPathSteps = metrics.getPathSteps();
+	Map map;
+	addGrid(map, 650, 654, 650, 652);
+	std::vector<Direction> directions = {DIRECTION_NORTH, DIRECTION_EAST};
+
+	CHECK(findPath(map, Position{651, 651, 7}, Position{653, 651, 7}, exactPathParams(false), directions));
+	CHECK(directions.size() == 4);
+	CHECK(metrics.getPathSteps() == initialPathSteps + 2);
+}
+
+TEST_CASE(pathfinding_metrics_count_zero_new_steps_when_already_in_range)
+{
+	PathMetricsFixture metrics;
+	const uint64_t initialPathSteps = metrics.getPathSteps();
+	Map map;
+	addGrid(map, 660, 660, 660, 660);
+	std::vector<Direction> directions = {DIRECTION_NORTH, DIRECTION_EAST};
+
+	CHECK(findPath(map, Position{660, 660, 7}, Position{660, 660, 7}, exactPathParams(), directions));
+	CHECK(directions.size() == 2);
+	CHECK(metrics.getPathSteps() == initialPathSteps);
 }
 
 TEST_CASE(pathfinding_keeps_origin_tile_alive_for_const_creature_search)

--- a/src/tests/test_pathfinding.cpp
+++ b/src/tests/test_pathfinding.cpp
@@ -5,6 +5,8 @@
 #include "../tile.h"
 #include "test_support.h"
 
+#include <limits>
+
 namespace {
 
 class PathCreature final : public Creature
@@ -56,6 +58,17 @@ FindPathParams exactPathParams(bool allowDiagonal = true)
 	params.maxSearchDist = 32;
 	params.minTargetDist = 0;
 	params.maxTargetDist = 0;
+	return params;
+}
+
+FindPathParams summonPathParams()
+{
+	FindPathParams params;
+	params.fullPathSearch = false;
+	params.clearSight = false;
+	params.maxSearchDist = 8;
+	params.minTargetDist = 1;
+	params.maxTargetDist = 2;
 	return params;
 }
 
@@ -135,6 +148,110 @@ TEST_CASE(pathfinding_same_start_and_target_returns_empty_path)
 	std::vector<Direction> directions;
 	CHECK(findPath(map, Position{300, 300, 7}, Position{300, 300, 7}, exactPathParams(), directions));
 	CHECK(directions.empty());
+}
+
+TEST_CASE(pathfinding_cross_floor_preserves_clear_sight_semantics)
+{
+	Map map;
+	addGrid(map, 400, 410, 400, 404);
+
+	auto params = exactPathParams(false);
+	std::vector<Direction> clearSightDirections = {DIRECTION_NORTH};
+	params.clearSight = true;
+	CHECK(!findPath(map, Position{401, 402, 7}, Position{405, 402, 8}, params, clearSightDirections));
+	CHECK(clearSightDirections == std::vector<Direction>{DIRECTION_NORTH});
+
+	std::vector<Direction> noClearSightDirections;
+	params.clearSight = false;
+	CHECK(findPath(map, Position{401, 402, 7}, Position{405, 402, 8}, params, noClearSightDirections));
+	CHECK(noClearSightDirections.size() == 4);
+
+	std::vector<Direction> summonDirections;
+	CHECK(findPath(map, Position{401, 402, 7}, Position{407, 402, 8}, summonPathParams(), summonDirections));
+	CHECK(!summonDirections.empty());
+}
+
+TEST_CASE(pathfinding_handles_search_distance_boundaries_without_overflow)
+{
+	Map map;
+	addGrid(map, 500, 508, 500, 504);
+
+	auto params = exactPathParams(false);
+	params.maxSearchDist = 0;
+	std::vector<Direction> unlimitedDirections;
+	CHECK(findPath(map, Position{501, 502, 7}, Position{505, 502, 7}, params, unlimitedDirections));
+
+	params.maxSearchDist = 1;
+	std::vector<Direction> limitedDirections;
+	CHECK(!findPath(map, Position{501, 502, 7}, Position{503, 502, 7}, params, limitedDirections));
+
+	params.maxSearchDist = -1;
+	std::vector<Direction> negativeDirections;
+	CHECK(!findPath(map, Position{501, 502, 7}, Position{502, 502, 7}, params, negativeDirections));
+
+	params.maxSearchDist = 0;
+	params.maxTargetDist = -1;
+	std::vector<Direction> invalidTargetDistanceDirections;
+	CHECK(!findPath(map, Position{501, 502, 7}, Position{502, 502, 7}, params,
+	                invalidTargetDistanceDirections));
+
+	params.maxSearchDist = std::numeric_limits<int32_t>::max();
+	params.minTargetDist = 1;
+	params.maxTargetDist = 1;
+	std::vector<Direction> overflowBoundaryDirections;
+	CHECK(findPath(map, Position{501, 502, 7}, Position{502, 502, 7}, params, overflowBoundaryDirections));
+	CHECK(overflowBoundaryDirections.empty());
+}
+
+TEST_CASE(pathfinding_preserves_prefilled_direction_output_contract)
+{
+	Map map;
+	addGrid(map, 600, 608, 600, 608, {{604, 600}, {604, 601}, {604, 602}, {604, 603}, {604, 604},
+	                                                {604, 605}, {604, 606}, {604, 607}, {604, 608}});
+	const std::vector<Direction> prefix = {DIRECTION_NORTH, DIRECTION_EAST};
+
+	std::vector<Direction> successDirections = prefix;
+	CHECK(findPath(map, Position{601, 601, 7}, Position{603, 601, 7}, exactPathParams(false), successDirections));
+	CHECK(successDirections.size() == prefix.size() + 2);
+	CHECK(std::equal(prefix.begin(), prefix.end(), successDirections.begin()));
+
+	std::vector<Direction> searchFailureDirections = prefix;
+	CHECK(!findPath(map, Position{601, 604, 7}, Position{607, 604, 7}, exactPathParams(false),
+	                searchFailureDirections));
+	CHECK(searchFailureDirections == prefix);
+
+	std::vector<Direction> inRangeDirections = prefix;
+	CHECK(findPath(map, Position{601, 601, 7}, Position{601, 601, 7}, exactPathParams(), inRangeDirections));
+	CHECK(inRangeDirections == prefix);
+}
+
+TEST_CASE(pathfinding_keeps_origin_tile_alive_for_const_creature_search)
+{
+	Map map;
+	addGrid(map, 700, 702, 700, 702);
+	auto creature = std::make_shared<PathCreature>();
+	Tile* startTile = map.getTile(Position{700, 700, 7});
+	startTile->internalAddThing(creature.get());
+
+	const Creature& constCreature = *creature;
+	const std::shared_ptr<const Tile> tileRef = constCreature.getTileShared();
+	CHECK(tileRef.get() == startTile);
+
+	std::vector<Direction> directions;
+	CHECK(map.getPathMatching(constCreature, directions, FrozenPathingConditionCall(Position{702, 700, 7}),
+	                          exactPathParams(false)));
+	startTile->removeThing(creature.get(), 0);
+	creature->setParent(nullptr);
+}
+
+TEST_CASE(pathfinding_map_walk_cost_keeps_generic_semantics)
+{
+	AStarNode node;
+	node.x = 800;
+	node.y = 800;
+	CHECK(AStarNodes::GetMapWalkCost(node, Position{802, 802, 7}) == MAP_DIAGONALWALKCOST);
+	CHECK(AStarNodes::GetMapWalkCost(node, Position{802, 801, 7}) == MAP_NORMALWALKCOST);
+	CHECK(AStarNodes::GetMapWalkCost(node, Position{800, 802, 7}) == MAP_NORMALWALKCOST);
 }
 
 TFS_TEST_MAIN()


### PR DESCRIPTION
## Background / why this PR exists

This is a follow-up hardening of [`58628dee`](https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/commit/58628dee6f66fd2ca0673c25ee38942ad2f3cdb9), originally authored by **@Johncorex**.

John's commit was an important pathfinding performance improvement: it reduced A* CPU cost by adding fast rejects for unreachable/already-satisfied searches, hoisting `weak_ptr`/`FindPathParams` work out of the neighbor loop, inlining movement/Manhattan costs, and adding empty/field-free tile fast paths. Those optimizations are intentionally preserved here.

While auditing the optimized pathfinder against its parent behavior, a few edge cases were found where the performance changes also changed semantics or weakened safety: unconditional cross-floor rejection affected `clearSight=false`/summon-style searches, the distance reject could overflow in `int32_t`, `dirList` gained inconsistent mutation behavior between fast and normal failures, the cached origin tile did not pin its lifetime, and `GetMapWalkCost` became adjacency-specific even though the hot loop no longer needed that helper.

This PR therefore **does not revert or replace John's optimization**. It keeps the CPU-oriented changes and applies a small compatibility/safety layer around them so the optimized implementation matches the historical pathfinding contract more closely.

## Summary

- preserve the historical cross-floor behavior by applying the fast reject only when `clearSight` is enabled
- count only directions appended by the current successful search in path_steps, including zero new steps for already-in-range results
- make the distance fast reject overflow-safe without changing the existing negative/unlimited distance behavior
- preserve caller-owned `dirList` contents on failures and append on normal success, matching the parent contract
- pin the creature origin tile once per search while keeping raw pointers and reference-count work out of the A* hot loop
- restore the generic semantics of `AStarNodes::GetMapWalkCost` while retaining the optimized inline cost in the hot loop
- add focused regressions for cross-Z, summon-like parameters, distance boundaries, overflow, prefilled output, tile lifetime, and generic walk cost

## What remains from `58628dee`

The main performance work from @Johncorex remains intact, including:

- fast rejects for valid unreachable cases
- already-in-range early success
- hoisted pathfinding invariants
- `thread_local` A* workspace
- heap/custom-hash A* structures already present in the pathfinder
- QTree/floor lookup reuse
- `constexpr` neighbor tables
- inline orthogonal/diagonal movement cost
- inline Manhattan heuristic
- empty-tile creature fast path
- `TILESTATE_MAGICFIELD` check before scanning field items

The lifetime fix adds only one owning tile reference per path search; the A* node/neighbor hot loop still uses raw non-owning pointers and does not introduce per-node `shared_ptr` refcount traffic.

## Validation

- `cmake --build build-release --target test_pathfinding -j2` — passed
- `ctest --test-dir build-release -R "^test_pathfinding$" --output-on-failure` — passed
- ASan + leak detection, targeted pathfinding test — passed
- complete Release CTest suite — **51/51 passed**
- normal `tfs` target — linked successfully
- `git diff --check` — passed

UBSan exercised all pathfinding cases without reporting a pathfinding issue, including the `INT32_MAX` boundary. At process shutdown, it detected an existing out-of-scope invalid-vptr issue in `LuaScriptInterface::closeState()` (`luascript.cpp:858`) through `Game -> Raids` global destruction. That lifecycle issue is not in any file changed by this PR and is documented here rather than mixed into the pathfinder hardening.

## Before/after benchmark

Method: Google Benchmark on WSL, pinned to CPU 0 with `taskset`, 3 repetitions, 0.3 s minimum time, CPU-time medians. Baseline is `58628dee`; after is this branch.

| Scenario (2,000 requests) | Before | After | Note |
|---|---:|---:|---|
| Short reachable | 1,729 us | 1,836 us | +6.2%; small fixed lifetime-pin cost plus host variance |
| Blocked | 101,672 us | 105,001 us | +3.3% |
| Distant fast reject | 11.2 us | 11.2 us | unchanged |
| Already in range | 21.5 us | 20.8 us | -3.3% |
| Cross-Z, `clearSight=true` | 9.71 us | 9.34 us | -3.8%; fast reject preserved |
| Cross-Z, `clearSight=false` | 9.20 us | 1,860 us | intentional: the baseline incorrectly rejected; the hardened code now performs the historical path search |

A repeated after run showed noticeable host/WSL load variance, so these measurements are reported as observed rather than used to claim a performance gain. The heap, custom hash, thread-local workspace, QTree/floor cache, constexpr neighbor tables, inline Manhattan/cost calculations, empty-tile fast path, and valid fast rejects remain intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pathfinding across floors, including clear-sight handling and search-distance limits.
  - Corrected path results when direction lists already contain entries.
  - Fixed diagonal movement cost calculations and handling of origin tiles during searches.
  - Improved pathfinding behavior for constant creature data.

- **New Features**
  - Added path-step metrics access for monitoring pathfinding activity.

- **Tests**
  - Expanded coverage for cross-floor searches, distance boundaries, output handling, metrics, and movement costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->